### PR TITLE
Add locked live control panel to /

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,4 @@
 *.test
 *.prof
 .env
-/AGENTS.md
 /.claude/settings.local.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,266 @@
+# ambience
+
+Shared-world ambient pixel-art effect system. Server coordinates state;
+every client (browser canvas, terminal sixel) runs its own sim replica
+that receives config + event broadcasts via SSE. Conceptually independent
+of fzt — the name only matches the domain (`ambience.romaine.life`).
+Read `D:/shell-config/setup/codex/AGENTS.md` for global Codex config.
+
+## Architecture
+
+```
+cmd/ambience (Go)     HTTP server. Runs the shared atmosphere goroutine
+  │                   at 10 Hz — decides when discrete events fire
+  │                   (downpour/calm/gust/splash) and broadcasts state
+  │                   commands. Does NOT stream pixel frames.
+  │                   Embeds web/ and serves it.
+  │
+  ├─► /                  Live broadcast monitor — canvas running the shared
+  │                      replica sim + status panel overlay (current scene,
+  │                      remaining, up next, entropy counter with togglable
+  │                      capture, rolling event log). Canonical consumer view.
+  ├─► /sim.js            JS port of sim/rain.go, `AmbienceSim` global
+  ├─► /client.js         Shared auto-init browser client (see "Consumer
+  │                      integration" below)
+  ├─► /ambience.js       Older helper (pre-client.js); still served
+  ├─► /dev               Dev page with per-session effect switching,
+  │                      presets, and live knobs (NOT connected to the
+  │                      shared broadcast)
+  ├─► /snapshot          JSON: current shared atmosphere state (incl. scene)
+  ├─► /events            SSE: atmosphere commands
+  │                      (snapshot/config/trigger/scene/metric)
+  ├─► /entropy           POST bytes — folded into the shared RNG
+  ├─► /effects/<effect>/schema  JSON schema for an effect's knobs
+  └─► /dev/{snapshot,events,config,trigger}  Per-session dev atmospheres
+
+sim/             Pure Go simulation logic. Rain is the live shared-world
+                 effect today; Fireflies and Waterfall also exist as
+                 isolated dev effects. No I/O; consumed by cmd/ambience
+                 (server-side) and by terminal/ (client-side sixel
+                 renderer).
+
+terminal/        Go package — SSE subscriber + local sim replica + sixel
+                 renderer. Consumed by fzt-automate via its
+                 PostFrameHook. See `docs/terminal-integration-status.md`
+                 for open issues (flicker, opacity, accumulation).
+
+tools/conpty-capture/  Python/pywinpty ConPTY capture tool — records full
+                       Windows terminal byte stream including sixel DCS
+                       blocks, writes asciinema-compatible .cast.
+                       Closes the diagnostic gap PowerSession leaves
+                       (PowerSession doesn't capture CONOUT$ writes).
+
+chart/ambience/  Helm chart used by ArgoCD for both environments.
+                 `values-prod.yaml` drives the live app at
+                 `ambience.romaine.life`; `values-dev.yaml` drives the
+                 flexible dev environment at `ambience.dev.romaine.life`.
+                 ArgoCD Applications live in
+                 `infra-bootstrap/k8s/apps/{ambience,ambience-dev}.yaml`.
+                 The dev app intentionally leaves autosync off so
+                 session-driven image swaps are not immediately
+                 reconciled away.
+                 CI is manual / session-driven:
+                 `.github/workflows/build-and-deploy.yml` has no automatic
+                 triggers and only builds + pushes
+                 `romainecr.azurecr.io/ambience:<sha>` when manually
+                 dispatched. The follow-up image-tag bump commit is done
+                 from the session by editing the appropriate Helm values
+                 file, then ArgoCD picks up that committed chart change
+                 and rolls out. Local k8s-first dev work uses
+                 `scripts/dev-deploy.ps1`, which patches live
+                 `edge`, `authority`, or `all` workload images for a
+                 fast inner loop without treating dev as a manual Helm
+                 release.
+```
+
+## Preferred iteration loop
+
+When the deployment/platform foundation is already stable, prefer using
+that stability to ship a scoped product slice instead of starting another
+infra refactor.
+
+For future Codex sessions, the default loop should be:
+
+1. Re-open the open GitHub issues and open PRs at the start of a fresh
+   session so the next slice is chosen from the real backlog, not memory.
+2. Pick one concrete, bounded feature. Bias toward effect work or
+   effect-adjacent enhancements when the existing registry, `/dev`
+   switcher, presets, and schema-driven controls already make that cheap.
+3. Build the slice end to end against the dev flow first. For browser
+   and server effect work together, patch the dev environment with
+   `powershell -ExecutionPolicy Bypass -File scripts/dev-deploy.ps1 -Component all`.
+   If the change is only static/browser-side or only authority-side, use
+   `edge` or `authority` respectively.
+4. Validate on `ambience.dev.romaine.life`, usually via
+   `/dev/<effect>` for new or changed dev effects, before treating the
+   slice as ready for promotion.
+5. Only after the dev environment looks right should the change move into
+   the manual production promotion flow: build/push the real image, bump
+   the Helm values file, commit that desired-state change, and let ArgoCD
+   reconcile it.
+
+This is the preferred default for future iterations unless the backlog
+item is explicitly infra-only or the current platform work is still
+blocking product progress.
+
+## Atmosphere model
+
+The server does NOT broadcast pixel frames. Instead, each atmosphere is a
+server-side sim running at 10 Hz whose job is to DECIDE when discrete
+events fire and when to rotate scenes. Clients run their own sims locally
+and apply five kinds of commands:
+
+- **`snapshot`** — initial state dump on connect. The outer envelope is
+  effect-generic:
+  `{type, tick, config, state, seed, gridW, gridH, currentScene,
+  nextScene, entropyBytes, sceneRemaining}`. `config` and `state` are
+  effect-owned blobs; `type` tells clients which constructor to use.
+- **`config`** — sim config changed; clients call `setConfig`. Broadcast on
+  entry to scene transitions (at ~1 Hz during drift) and on transition
+  completion (final target for exact sync).
+- **`trigger`** — an event fired (downpour/calm/gust/splash); clients apply.
+- **`scene`** — scene rotated. Carries `{name, durationTicks, startedAtTick,
+  nextName, transitionTicks}` so UI panels update + interpolated tick
+  interpolation works.
+- **`metric`** — entropy bytes + scene-remaining snapshot. Event-driven,
+  not periodic — fires on every `AddEntropy` call and on scene rotation.
+
+Clients do NOT roll for discrete events — only the server does. Clients
+advance timers and physics locally. Frame-level sync is not guaranteed
+(each client RNG drifts after initial snapshot), but event timing
+(downpour starts/ends, calm windows, scene changes) stays in sync.
+
+## Scene rotation
+
+Rain runs with generated scenes rather than a single fixed config.
+Scenes have a 1–4 h duration, two-slot lookahead (current + next, next
+pre-generated at rotation time using the atmosphere's RNG — entropy
+perturbs the RNG, so keystrokes bias future scenes with a one-scene
+delay). Scene names are auto-derived descriptors (`warm-fast-drizzle`,
+`cool-calm-downpour`) from hue/speed/spawn buckets.
+
+Transitions between scenes are a config DRIFT — `lerpConfig` over
+`min(60 s, sceneDur/2)` ticks with `easeInOutCubic` easing. Hue uses
+angular LERP so the 0/360° seam is crossed along the shortest arc.
+Server applies interpolated configs to its sim each tick and broadcasts
+every 10 ticks during drift (~1 Hz), so client replicas stay near-sync
+without overwhelming the SSE stream. See
+[#8](https://github.com/nelsong6/ambience/issues/8) for the larger
+cross-effect transition design; the current work is the within-effect
+half. Vocabulary (Scene vs Effect) is tracked in
+[#17](https://github.com/nelsong6/ambience/issues/17).
+
+For local testing, `AMBIENCE_SCENE_TICKS=60` env var shortens scene
+duration to 6 s so rotations fire visibly without a 90-minute wait.
+Production ignores the var (falls back to 1–4 h random).
+
+## Effect registry
+
+`sim.js` exports `AmbienceSim.effects = { rain, fireflies, waterfall }`.
+The shared
+`client.js` reads `snapshotData.Type` and looks up the constructor there
+— adding a new effect means registering one entry in `effects`, no
+client-side change, no per-consumer change. The 5-slot effect template
+(spawn / lever / event / event-mod / end) is in the ambience repo
+issues: [#1](https://github.com/nelsong6/ambience/issues/1).
+
+## Guiding principle
+
+One of ambience's guiding principles is to copy the *boundaries* that
+make simulation-heavy systems like Noita compelling, without trying to
+clone their exact engine.
+
+- Keep authoritative world truth compact and semantic. The server should
+  decide important events, phases, and state transitions; clients should
+  do the expensive local replay/render work.
+- Keep the transport generic at the envelope level and effect-owned on
+  the inside. Snapshot/config/trigger/schema are shared seams; each
+  effect owns its own inner state and tuning knobs.
+- Aggregate secondary systems instead of mirroring every particle.
+  Persistence, logs, metrics, entropy, and future audio should describe
+  meaningful simulation state, not become a raw firehose of per-pixel
+  updates.
+- Prefer stable control seams over effect-specific special cases. New
+  effects should plug into the registry, schema, snapshot/restore, and
+  trigger paths instead of requiring consumer-specific wiring.
+
+## Entropy flow
+
+Browsers capture `keydown` events and POST a byte per keystroke
+(`key.charCodeAt(0) ^ Date.now() & 0xff`) to `/entropy` every 2s
+(throttled, max 4KB per request). The server folds bytes into the
+shared atmosphere's seed and re-seeds the sim's RNG via
+`Rain.PerturbRNG(delta)`. Future random decisions drift — typing subtly
+steers the world. Cheap, lossy, intentional — this is aesthetic
+perturbation, not secure randomness.
+
+## Consumer integration
+
+The shared auto-init pattern. Drop this into any page:
+
+```html
+<canvas data-ambience></canvas>
+<script src="https://ambience.romaine.life/sim.js"></script>
+<script src="https://ambience.romaine.life/client.js"></script>
+```
+
+Then CSS (optional, for layered overlay):
+
+```css
+#ambience-canvas { position: fixed; inset: 0; z-index: 0; pointer-events: none; }
+body.ambience-on { --fzt-bg: transparent; }  /* or other opacity overrides */
+```
+
+`client.js` adds `body.ambience-on` on successful init — consumer CSS
+can conditionally adapt so the page still renders correctly if ambience
+JS fails to fetch. Configuration via `data-ambience-*` attrs on the
+canvas: `url`, `grid-w`, `grid-h`, `transparent`, `entropy`.
+
+Consumers:
+
+- **`/`** — live broadcast monitor. Full-screen canvas running the shared
+  replica sim (via inline EventSource + sim.js, not `client.js` — the page
+  consumes all five command kinds including `scene`/`metric` which
+  `client.js` doesn't know about). Status-panel overlay shows current scene
+  name, remaining time, up-next, tick, entropy counter with togglable
+  capture, and a rolling event log. Dev-ish tools here are a
+  fallback — `/dev` remains the real knob-tuning surface.
+- **`/dev`** — per-session dev-atmosphere knob-tuning page. NOT connected to
+  the shared broadcast; each session gets its own isolated atmosphere for
+  testing effects/configs without interfering with prod state. The page
+  supports effect switching via `/dev/<effect>` and effect-defined presets.
+- **fzt-showcase** — `<canvas data-ambience>` behind the WASM DOS terminal.
+- **my-homepage** — `<canvas data-ambience>` behind the fzt bookmark terminal.
+- **fzt-automate** (terminal) — imports `github.com/nelsong6/ambience/terminal`,
+  paints sixel via `tui.PostFrameHook`. Currently has known rendering
+  issues tracked in #11–#15; on pause.
+
+## Decisions settled
+
+- Name: `ambience` (matches `ambience.romaine.life`)
+- Language: Go server + sim + terminal client; JS for browser consumers
+- First effect: Rain ([#2](https://github.com/nelsong6/ambience/issues/2))
+- Shared state is global across all consumers/profiles
+- K8s-native deploy — first app on the per-app deployment pattern
+  (see `infra-bootstrap/k8s/apps/ambience.yaml`)
+- Effects plug in via `AmbienceSim.effects` registry; server broadcasts
+  `snapshotData.Type` so clients know which constructor to pick. Adding
+  Sand/Fire/Tetris requires zero client changes.
+- Repo migration from `nelsong6/` → `romaine-life/` tracked by
+  [#10](https://github.com/nelsong6/ambience/issues/10) (May 2026)
+
+## Status
+
+Rain MVP live at `ambience.romaine.life` with scene rotation + smooth
+drift transitions + live monitor panel at `/`. The dev environment at
+`ambience.dev.romaine.life` is also live, Argo-owned, and intentionally
+manual-sync so sessions can hot-swap images without immediate
+reconciliation. Rain lifecycle intro/outro controls exist in `/dev` for
+tuning and preview, and the dev page now supports effect switching plus
+Waterfall presets. Consumers: fzt-showcase + my-homepage integrated via
+shared client (unaffected by scene/metric commands — client.js ignores
+unknown kinds). Entropy intake wired, visible on the `/` panel. Shared
+atmosphere state now persists across authority restarts via the mounted PVC
+and persisted snapshot file. Terminal integration tabled, see
+`docs/terminal-integration-status.md`. Future effects ready to plug in via
+the registry.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,7 @@ cmd/ambience (Go)     HTTP server. Runs the shared atmosphere goroutine
   │                      remaining, up next, entropy counter with togglable
   │                      capture, rolling event log). Canonical consumer view.
   ├─► /sim.js            JS port of sim/rain.go, `AmbienceSim` global
+  ├─► /controls.js       Shared schema-driven control panel helper
   ├─► /client.js         Shared auto-init browser client (see "Consumer
   │                      integration" below)
   ├─► /ambience.js       Older helper (pre-client.js); still served
@@ -31,13 +32,14 @@ cmd/ambience (Go)     HTTP server. Runs the shared atmosphere goroutine
   │                      (snapshot/config/trigger/scene/metric)
   ├─► /entropy           POST bytes — folded into the shared RNG
   ├─► /effects/<effect>/schema  JSON schema for an effect's knobs
-  └─► /dev/{snapshot,events,config,trigger}  Per-session dev atmospheres
+  └─► /dev/{snapshot,events,config,randomize,trigger}
+                         Per-session dev atmospheres
 
 sim/             Pure Go simulation logic. Rain is the live shared-world
-                 effect today; Fireflies and Waterfall also exist as
-                 isolated dev effects. No I/O; consumed by cmd/ambience
-                 (server-side) and by terminal/ (client-side sixel
-                 renderer).
+                 effect today; Fireflies, Waterfall, and Dust also exist
+                 as isolated dev effects. No I/O; consumed by
+                 cmd/ambience (server-side) and by terminal/
+                 (client-side sixel renderer).
 
 terminal/        Go package — SSE subscriber + local sim replica + sixel
                  renderer. Consumed by fzt-automate via its
@@ -70,7 +72,14 @@ chart/ambience/  Helm chart used by ArgoCD for both environments.
                  `scripts/dev-deploy.ps1`, which patches live
                  `edge`, `authority`, or `all` workload images for a
                  fast inner loop without treating dev as a manual Helm
-                 release.
+                 release. The script prefers local Docker when it is
+                 available, but can fall back to `az acr build` and
+                 verifies the image tag exists before patching, so local
+                 Docker is optional for the dev path. For static browser
+                 work, `scripts/dev-loop.ps1` syncs `cmd/ambience/web`
+                 straight into the dev edge pod's override directory so
+                 testing stays on `ambience.dev.romaine.life` instead of
+                 falling back to localhost.
 ```
 
 ## Preferred iteration loop
@@ -86,15 +95,21 @@ For future Codex sessions, the default loop should be:
 2. Pick one concrete, bounded feature. Bias toward effect work or
    effect-adjacent enhancements when the existing registry, `/dev`
    switcher, presets, and schema-driven controls already make that cheap.
-3. Build the slice end to end against the dev flow first. For browser
-   and server effect work together, patch the dev environment with
-   `powershell -ExecutionPolicy Bypass -File scripts/dev-deploy.ps1 -Component all`.
-   If the change is only static/browser-side or only authority-side, use
-   `edge` or `authority` respectively.
-4. Validate on `ambience.dev.romaine.life`, usually via
+3. Treat `ambience.dev.romaine.life` as the default test target. Do not
+   spin up or rely on a local runtime unless the user explicitly asks for
+   a localhost repro.
+4. For browser-only static work in `cmd/ambience/web`, use
+   `powershell -ExecutionPolicy Bypass -File scripts/dev-loop.ps1`
+   so the edge pod serves override files directly.
+5. For Go or image-backed changes, patch the dev environment with
+   `powershell -ExecutionPolicy Bypass -File scripts/dev-deploy.ps1 -Component all`
+   when both browser and authority change together. If the change is only
+   static/browser-side or only authority-side, use `edge` or `authority`
+   respectively.
+6. Validate on `ambience.dev.romaine.life`, usually via
    `/dev/<effect>` for new or changed dev effects, before treating the
    slice as ready for promotion.
-5. Only after the dev environment looks right should the change move into
+7. Only after the dev environment looks right should the change move into
    the manual production promotion flow: build/push the real image, bump
    the Helm values file, commit that desired-state change, and let ArgoCD
    reconcile it.
@@ -156,7 +171,7 @@ Production ignores the var (falls back to 1–4 h random).
 
 ## Effect registry
 
-`sim.js` exports `AmbienceSim.effects = { rain, fireflies, waterfall }`.
+`sim.js` exports `AmbienceSim.effects = { rain, fireflies, waterfall, dust }`.
 The shared
 `client.js` reads `snapshotData.Type` and looks up the constructor there
 — adding a new effect means registering one entry in `effects`, no
@@ -228,7 +243,9 @@ Consumers:
 - **`/dev`** — per-session dev-atmosphere knob-tuning page. NOT connected to
   the shared broadcast; each session gets its own isolated atmosphere for
   testing effects/configs without interfering with prod state. The page
-  supports effect switching via `/dev/<effect>` and effect-defined presets.
+  supports effect switching via `/dev/<effect>`, effect-defined presets,
+  randomized per-session starting configs, and a `randomize` button for
+  another quick stat roll on the active effect.
 - **fzt-showcase** — `<canvas data-ambience>` behind the WASM DOS terminal.
 - **my-homepage** — `<canvas data-ambience>` behind the fzt bookmark terminal.
 - **fzt-automate** (terminal) — imports `github.com/nelsong6/ambience/terminal`,
@@ -255,12 +272,16 @@ Rain MVP live at `ambience.romaine.life` with scene rotation + smooth
 drift transitions + live monitor panel at `/`. The dev environment at
 `ambience.dev.romaine.life` is also live, Argo-owned, and intentionally
 manual-sync so sessions can hot-swap images without immediate
-reconciliation. Rain lifecycle intro/outro controls exist in `/dev` for
-tuning and preview, and the dev page now supports effect switching plus
-Waterfall presets. Consumers: fzt-showcase + my-homepage integrated via
-shared client (unaffected by scene/metric commands — client.js ignores
-unknown kinds). Entropy intake wired, visible on the `/` panel. Shared
-atmosphere state now persists across authority restarts via the mounted PVC
-and persisted snapshot file. Terminal integration tabled, see
+reconciliation. `/dev` now supports effect switching across Rain,
+Fireflies, Waterfall, and Dust, including randomized per-session starting
+stats, a `randomize` button, and a bottom-anchored event log that behaves
+like a live tail instead of pinning the newest entry off-screen. The web
+surface is tightened around clean routes: use `/` and `/dev/<effect>`,
+not `.html` paths, and unknown static routes now 404. Consumers:
+fzt-showcase + my-homepage integrated via shared client (unaffected by
+scene/metric commands — client.js ignores unknown kinds). Entropy intake
+wired, visible on the `/` panel. Shared atmosphere state now persists
+across authority restarts via the mounted PVC and persisted snapshot
+file. Terminal integration tabled, see
 `docs/terminal-integration-status.md`. Future effects ready to plug in via
 the registry.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,3 @@
-# syntax=docker/dockerfile:1.7
-
 # Multi-stage build for a minimal ambience image.
 # Build layers are arranged to keep dependency and compiler caches hot across
 # normal source edits, while the final runtime image stays distroless.
@@ -7,13 +5,10 @@ FROM golang:1.26-alpine AS build
 WORKDIR /src
 
 COPY go.mod go.sum ./
-RUN --mount=type=cache,target=/go/pkg/mod \
-	go mod download
+RUN go mod download
 
 COPY . .
-RUN --mount=type=cache,target=/go/pkg/mod \
-	--mount=type=cache,target=/root/.cache/go-build \
-	CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /out/ambience ./cmd/ambience
+RUN CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /out/ambience ./cmd/ambience
 
 FROM gcr.io/distroless/static-debian12:nonroot
 COPY --from=build /out/ambience /ambience

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ Shared-world ambient pixel-art effects. A 10 Hz server decides when
 discrete events fire (downpour, calm, gust, splash) and broadcasts those
 as commands via SSE; every consumer (browser canvas, terminal sixel)
 runs its own sim replica and applies the commands in sync. Rain is the
-only effect in the shared live world today; Fireflies and Waterfall are
-available in isolated dev sessions.
+only effect in the shared live world today; Fireflies, Waterfall, and
+Dust are available in isolated dev sessions.
 
 Canonical live view: <https://ambience.romaine.life>.
 
@@ -18,7 +18,8 @@ go run ./cmd/ambience
 
 `/` renders the current effect full-screen. `/dev` opens a per-session
 effect-tuning page with an effect switcher, presets when the active
-effect defines them, and live adjustable knobs.
+effect defines them, randomized starting stats, a `randomize` button,
+and live adjustable knobs.
 
 ## Consumer integration
 
@@ -48,8 +49,9 @@ cmd/ambience/    HTTP server + atmosphere goroutine. Decides event
                  timing (downpour/calm/gust/splash) and broadcasts
                  state commands. Does NOT stream pixel frames.
   web/           Embedded static: index.html (demo), sim.js (JS port
-                 of the sim), client.js (auto-init shim for consumers),
-                 dev.html (knob-tuning page).
+                 of the sim), controls.js (shared control helper),
+                 client.js (auto-init shim for consumers), dev.html
+                 (knob-tuning page).
 
 sim/             Pure Go simulation logic. No I/O. Consumed by the
                  server and by the terminal client.
@@ -72,7 +74,15 @@ chart/ambience/  Helm chart used by ArgoCD for both prod and dev.
 scripts/dev-deploy.ps1
                  Local k8s-first dev helper that builds, pushes, and
                  patches just `edge`, just `authority`, or `all` in the
-                 live dev namespace.
+                 live dev namespace. Prefers local Docker when available,
+                 but can fall back to `az acr build` so a local Docker
+                 daemon is not required for the dev loop.
+scripts/dev-loop.ps1
+                 Fast static-web dev helper for the dev environment.
+                 Syncs `cmd/ambience/web` straight into the live edge
+                 pod's override directory so `/dev` changes can be
+                 tested on `ambience.dev.romaine.life` without a local
+                 runtime or a full image rebuild.
 ```
 
 ## Atmosphere model
@@ -147,12 +157,20 @@ All broadcast endpoints set permissive CORS for cross-origin consumers.
 
 - `GET  /` — demo page
 - `GET  /dev`, `/dev/<effect>` — dev page with effect switcher, presets,
-  and per-effect knobs
-- `GET  /sim.js`, `/client.js` — consumer scripts
+  randomized per-session configs, and per-effect knobs
+- `GET  /sim.js`, `/controls.js`, `/client.js` — consumer scripts
 - `GET  /snapshot` — current atmosphere state (JSON)
 - `GET  /events` — atmosphere command stream (SSE)
+- `POST /config?effect=&...` — mutate the shared atmosphere config
+- `POST /trigger/:event` — fire a discrete event on the shared atmosphere
 - `POST /entropy` — raw bytes folded into the RNG (max 4KB/req)
+- `POST /dev/randomize?session=&effect=` — roll a new config for the
+  active dev session
 - `GET  /effects/:effect/schema` — knob schema for the dev UI
+
+The user-facing static routes are intentionally exact: use `/` and
+`/dev/<effect>`, not `.html` URLs. `/index.html` and unknown static paths
+return 404.
 
 ## Roles
 
@@ -188,12 +206,30 @@ leaves automated sync off. That keeps Argo as the owner of the base dev
 environment without immediately reverting fast live image swaps during a
 session.
 
-For local dev against `ambience.dev.romaine.life`, use
-`powershell -ExecutionPolicy Bypass -File scripts/dev-deploy.ps1 -Component edge`
-or swap `edge` for `authority` / `all`. The script builds and pushes a
-temporary image tag, then patches the live `ambience-edge` and/or
-`ambience-authority` image fields with `kubectl set image`. That keeps the
-inner loop fast while still treating dev as an Argo-owned environment.
+Unless a task explicitly calls for localhost, the default test target
+should be `https://ambience.dev.romaine.life`, not a local runtime.
+
+Use the dev helpers like this:
+
+1. Static browser-only work in `cmd/ambience/web/`:
+   run `powershell -ExecutionPolicy Bypass -File scripts/dev-loop.ps1`
+   to sync the web files into the live dev edge pod. Leave it running
+   while editing for a hot-ish loop, or add `-Once` for a single sync.
+2. Go/runtime changes that need a new binary or image:
+   run `powershell -ExecutionPolicy Bypass -File scripts/dev-deploy.ps1 -Component edge`
+   or swap `edge` for `authority` / `all`. The script builds and pushes a
+   temporary image tag, then patches the live `ambience-edge` and/or
+   `ambience-authority` image fields with `kubectl set image`.
+3. If local Docker is unavailable, `scripts/dev-deploy.ps1` automatically
+   falls back to `az acr build` and verifies the tag exists in ACR before
+   patching, so the session can stay k8s-first without relying on a local
+   Docker daemon.
+
+The web sync path is backed by `AMBIENCE_WEB_OVERRIDE_DIR` on the dev
+edge deployment: the main container reads static files from the shared
+override directory first, then falls back to embedded assets from the
+image. That keeps static `/dev` iteration fast without changing the
+authority workload.
 
 The recommended feature-iteration loop is:
 
@@ -202,12 +238,15 @@ The recommended feature-iteration loop is:
 2. Choose one bounded feature, preferably effect work or an
    effect-adjacent enhancement when the registry and `/dev` tooling
    already support it cleanly.
-3. Build and validate it on `ambience.dev.romaine.life` first.
-4. Use `scripts/dev-deploy.ps1 -Component all` for changes that touch both
+3. Validate it on `ambience.dev.romaine.life` first, not localhost, unless
+   the task explicitly needs a local-only repro.
+4. Use `scripts/dev-loop.ps1` for browser-only static work in
+   `cmd/ambience/web/`.
+5. Use `scripts/dev-deploy.ps1 -Component all` for changes that touch both
    browser assets and authority/runtime code, which is the common case for
    new effects. Use `edge` or `authority` only when the change is truly
    one-sided.
-5. Verify the result on `/dev/<effect>` or the relevant dev route before
+6. Verify the result on `/dev/<effect>` or the relevant dev route before
    promoting it.
 
 When a dev image should become declared state again, update
@@ -221,15 +260,17 @@ changes feed the desired state, with prod autosyncing and dev syncing on
 demand.
 
 The shipped Kubernetes manifests now split the app into one internal
-`authority` Deployment and a public two-replica `edge` Deployment. The
-authority snapshots the shared atmosphere every 30s to
+`authority` StatefulSet and a public `edge` Deployment. The authority
+snapshots the shared atmosphere every 30s to
 `AMBIENCE_PERSIST_PATH`; the manifests mount a PVC at `/data` and persist
 to `/data/shared-atmosphere.json`, so authority restarts resume the live
 world instead of resetting it.
 
 ## Status
 
-Rain effect live. Consumers: ambience's own demo, fzt-showcase (DOS
+Rain effect live. Dev sessions now support Rain, Fireflies, Waterfall,
+and Dust with randomized starting stats plus a `randomize` button on
+`/dev/<effect>`. Consumers: ambience's own demo, fzt-showcase (DOS
 terminal), my-homepage (bookmark terminal). Entropy flow wired.
 
 Terminal integration via fzt-automate is tabled pending platform

--- a/README.md
+++ b/README.md
@@ -195,6 +195,21 @@ temporary image tag, then patches the live `ambience-edge` and/or
 `ambience-authority` image fields with `kubectl set image`. That keeps the
 inner loop fast while still treating dev as an Argo-owned environment.
 
+The recommended feature-iteration loop is:
+
+1. Start a fresh session by re-checking the open issues and open PRs so
+   the next slice comes from the current backlog.
+2. Choose one bounded feature, preferably effect work or an
+   effect-adjacent enhancement when the registry and `/dev` tooling
+   already support it cleanly.
+3. Build and validate it on `ambience.dev.romaine.life` first.
+4. Use `scripts/dev-deploy.ps1 -Component all` for changes that touch both
+   browser assets and authority/runtime code, which is the common case for
+   new effects. Use `edge` or `authority` only when the change is truly
+   one-sided.
+5. Verify the result on `/dev/<effect>` or the relevant dev route before
+   promoting it.
+
 When a dev image should become declared state again, update
 `chart/ambience/values-dev.yaml` to that image tag, commit the bump, and
 manually sync the `ambience-dev` Argo app.

--- a/chart/ambience/templates/edge-deployment.yaml
+++ b/chart/ambience/templates/edge-deployment.yaml
@@ -34,6 +34,10 @@ spec:
               value: {{ .Values.edge.authorityURL | quote }}
             - name: AMBIENCE_SHUTDOWN_DRAIN
               value: {{ .Values.edge.shutdownDrain | quote }}
+            {{- if .Values.edge.webOverride.enabled }}
+            - name: AMBIENCE_WEB_OVERRIDE_DIR
+              value: {{ .Values.edge.webOverride.mountPath | quote }}
+            {{- end }}
           ports:
             - containerPort: 8080
               name: http
@@ -47,4 +51,29 @@ spec:
               port: http
           resources:
             {{- toYaml .Values.edge.resources | nindent 12 }}
+          {{- if .Values.edge.webOverride.enabled }}
+          volumeMounts:
+            - name: web-override
+              mountPath: {{ .Values.edge.webOverride.mountPath | quote }}
+              readOnly: true
+          {{- end }}
+        {{- if .Values.edge.webOverride.enabled }}
+        - name: {{ .Values.edge.webOverride.containerName }}
+          image: {{ .Values.edge.webOverride.sidecarImage | quote }}
+          imagePullPolicy: {{ .Values.edge.webOverride.sidecarImagePullPolicy }}
+          command:
+            - sh
+            - -c
+            - |
+              mkdir -p {{ .Values.edge.webOverride.mountPath | quote }}
+              while true; do sleep 3600; done
+          volumeMounts:
+            - name: web-override
+              mountPath: {{ .Values.edge.webOverride.mountPath | quote }}
+        {{- end }}
+      {{- if .Values.edge.webOverride.enabled }}
+      volumes:
+        - name: web-override
+          emptyDir: {}
+      {{- end }}
 {{- end }}

--- a/chart/ambience/values-dev.yaml
+++ b/chart/ambience/values-dev.yaml
@@ -9,6 +9,8 @@ edge:
   replicas: 1
   terminationGracePeriodSeconds: 3
   shutdownDrain: 1s
+  webOverride:
+    enabled: true
 
 pdb:
   enabled: false

--- a/chart/ambience/values.yaml
+++ b/chart/ambience/values.yaml
@@ -35,6 +35,12 @@ edge:
   terminationGracePeriodSeconds: 20
   authorityURL: http://ambience-authority-client
   shutdownDrain: 12s
+  webOverride:
+    enabled: false
+    mountPath: /var/run/ambience-web-override
+    containerName: web-sync
+    sidecarImage: alpine:3.20
+    sidecarImagePullPolicy: IfNotPresent
   resources:
     requests:
       cpu: 10m

--- a/cmd/ambience/atmosphere.go
+++ b/cmd/ambience/atmosphere.go
@@ -440,12 +440,22 @@ func (a *atmosphere) setConfigRaw(data json.RawMessage) error {
 	if err := a.effect.ApplyConfig(data); err != nil {
 		return err
 	}
+	effectType := a.effect.Type()
 	var cfg sim.Config
-	if err := json.Unmarshal(data, &cfg); err == nil {
-		a.mu.Lock()
-		a.cfg = cfg
-		a.mu.Unlock()
+	hasRainConfig := effectType == "rain" && json.Unmarshal(data, &cfg) == nil
+	if hasRainConfig {
+		cfg = cfg.withDefaults()
 	}
+	a.mu.Lock()
+	// A manual live edit should take over immediately instead of getting
+	// overwritten by the previous scene transition on the next tick.
+	a.transitionDur = 0
+	a.transitionStart = 0
+	if hasRainConfig {
+		a.cfg = cfg
+		a.current.Config = cfg
+	}
+	a.mu.Unlock()
 	a.broadcast(Command{
 		Kind: "config",
 		Tick: a.effect.CurrentTick(),

--- a/cmd/ambience/atmosphere.go
+++ b/cmd/ambience/atmosphere.go
@@ -444,7 +444,7 @@ func (a *atmosphere) setConfigRaw(data json.RawMessage) error {
 	var cfg sim.Config
 	hasRainConfig := effectType == "rain" && json.Unmarshal(data, &cfg) == nil
 	if hasRainConfig {
-		cfg = cfg.withDefaults()
+		cfg = sim.NormalizeConfig(cfg)
 	}
 	a.mu.Lock()
 	// A manual live edit should take over immediately instead of getting

--- a/cmd/ambience/dev_random.go
+++ b/cmd/ambience/dev_random.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"encoding/json"
+	"math"
+	"math/rand"
+
+	"github.com/nelsong6/ambience/sim"
+)
+
+const devRandomSeedMixer int64 = 0x5deece66d
+
+func randomizedDevConfig(schema sim.EffectSchema, seed int64) (json.RawMessage, error) {
+	rng := rand.New(rand.NewSource(seed ^ devRandomSeedMixer))
+	cfg := make(map[string]any, len(schema.Knobs))
+	for _, knob := range schema.Knobs {
+		value := randomizedKnobValue(rng, knob)
+		switch knob.Type {
+		case sim.KnobInt:
+			cfg[knob.Key] = int(math.Round(value))
+		default:
+			cfg[knob.Key] = value
+		}
+	}
+	return json.Marshal(cfg)
+}
+
+func randomizedKnobValue(rng *rand.Rand, knob sim.Knob) float64 {
+	min := knob.Min
+	max := knob.Max
+	if max < min {
+		min, max = max, min
+	}
+	if max == min {
+		return min
+	}
+
+	step := knob.Step
+	switch knob.Type {
+	case sim.KnobInt:
+		if step < 1 {
+			step = 1
+		}
+	default:
+		if step <= 0 {
+			step = 0.01
+		}
+	}
+
+	fraction := randomizedKnobFraction(rng, knob, min, max)
+	value := min + (max-min)*fraction
+	value = quantizeKnobValue(value, min, max, step, knob.Type)
+	return avoidImplicitDefaultCollision(value, min, max, step, knob)
+}
+
+func randomizedKnobFraction(rng *rand.Rand, knob sim.Knob, min, max float64) float64 {
+	sample := fullRangeKnobFraction(rng, knob)
+	if knob.Default < min || knob.Default > max || max <= min {
+		return clampUnit(sample)
+	}
+
+	biasChance, biasSpan := knobBiasProfile(knob)
+	if rng.Float64() >= biasChance {
+		return clampUnit(sample)
+	}
+
+	defaultNorm := (knob.Default - min) / (max - min)
+	low := math.Max(0, defaultNorm-biasSpan*0.5)
+	high := math.Min(1, defaultNorm+biasSpan*0.5)
+	if high <= low {
+		return clampUnit(defaultNorm)
+	}
+	return low + rng.Float64()*(high-low)
+}
+
+func fullRangeKnobFraction(rng *rand.Rand, knob sim.Knob) float64 {
+	switch knob.Slot {
+	case sim.SlotEvent:
+		return math.Pow(rng.Float64(), 2.4)
+	case sim.SlotSpawn, sim.SlotEnd:
+		return 0.05 + 0.9*rng.Float64()
+	default:
+		return rng.Float64()
+	}
+}
+
+func knobBiasProfile(knob sim.Knob) (chance, span float64) {
+	switch knob.Slot {
+	case sim.SlotEvent:
+		return 0.55, 0.12
+	case sim.SlotSpawn, sim.SlotEnd:
+		return 0.45, 0.4
+	case sim.SlotEventMod:
+		return 0.35, 0.5
+	default:
+		return 0.35, 0.45
+	}
+}
+
+func quantizeKnobValue(value, min, max, step float64, knobType sim.KnobType) float64 {
+	if step > 0 {
+		value = min + math.Round((value-min)/step)*step
+	}
+	if value < min {
+		value = min
+	}
+	if value > max {
+		value = max
+	}
+	if knobType == sim.KnobInt {
+		return math.Round(value)
+	}
+	return math.Round(value*1e6) / 1e6
+}
+
+func avoidImplicitDefaultCollision(value, min, max, step float64, knob sim.Knob) float64 {
+	if knob.Default == 0 || value != 0 || max <= 0 || step <= 0 {
+		return value
+	}
+
+	replacement := step
+	if min < 0 && max > 0 && knob.Default < 0 {
+		replacement = -step
+	}
+	if replacement < min {
+		replacement = min
+	}
+	if replacement > max {
+		replacement = max
+	}
+	return quantizeKnobValue(replacement, min, max, step, knob.Type)
+}
+
+func clampUnit(v float64) float64 {
+	if v < 0 {
+		return 0
+	}
+	if v > 1 {
+		return 1
+	}
+	return v
+}

--- a/cmd/ambience/dev_random_test.go
+++ b/cmd/ambience/dev_random_test.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"encoding/json"
+	"math"
+	"testing"
+
+	"github.com/nelsong6/ambience/sim"
+)
+
+func TestRandomizedDevConfigStaysWithinSchemaBounds(t *testing.T) {
+	schemas := []sim.EffectSchema{
+		sim.RainSchema(),
+		sim.DustSchema(),
+		sim.FirefliesSchema(),
+		sim.WaterfallSchema(),
+	}
+
+	for i, schema := range schemas {
+		data, err := randomizedDevConfig(schema, int64(12345+i))
+		if err != nil {
+			t.Fatalf("%s randomizedDevConfig: %v", schema.Name, err)
+		}
+
+		var values map[string]float64
+		if err := json.Unmarshal(data, &values); err != nil {
+			t.Fatalf("%s unmarshal randomized config: %v", schema.Name, err)
+		}
+
+		for _, knob := range schema.Knobs {
+			got, ok := values[knob.Key]
+			if !ok {
+				t.Fatalf("%s missing randomized value for %q", schema.Name, knob.Key)
+			}
+			if got < knob.Min-1e-9 || got > knob.Max+1e-9 {
+				t.Fatalf("%s %s = %v outside [%v, %v]", schema.Name, knob.Key, got, knob.Min, knob.Max)
+			}
+			if !valueAlignedToStep(knob, got) {
+				t.Fatalf("%s %s = %v is not aligned to step %v from min %v", schema.Name, knob.Key, got, knob.Step, knob.Min)
+			}
+		}
+	}
+}
+
+func TestRandomizedDevConfigChangesAtLeastOneKnob(t *testing.T) {
+	schemas := []sim.EffectSchema{
+		sim.RainSchema(),
+		sim.DustSchema(),
+		sim.FirefliesSchema(),
+		sim.WaterfallSchema(),
+	}
+
+	for i, schema := range schemas {
+		data, err := randomizedDevConfig(schema, int64(98765+i))
+		if err != nil {
+			t.Fatalf("%s randomizedDevConfig: %v", schema.Name, err)
+		}
+
+		var values map[string]float64
+		if err := json.Unmarshal(data, &values); err != nil {
+			t.Fatalf("%s unmarshal randomized config: %v", schema.Name, err)
+		}
+
+		changed := false
+		for _, knob := range schema.Knobs {
+			if math.Abs(values[knob.Key]-knob.Default) > 1e-9 {
+				changed = true
+				break
+			}
+		}
+		if !changed {
+			t.Fatalf("%s randomized config unexpectedly matched every default", schema.Name)
+		}
+	}
+}
+
+func valueAlignedToStep(knob sim.Knob, value float64) bool {
+	if knob.Step <= 0 {
+		if knob.Type == sim.KnobInt {
+			return math.Abs(value-math.Round(value)) <= 1e-9
+		}
+		return true
+	}
+	steps := math.Round((value - knob.Min) / knob.Step)
+	expected := knob.Min + steps*knob.Step
+	if math.Abs(value-expected) > 1e-6 {
+		return false
+	}
+	if knob.Type == sim.KnobInt {
+		return math.Abs(value-math.Round(value)) <= 1e-9
+	}
+	return true
+}

--- a/cmd/ambience/dev_sessions.go
+++ b/cmd/ambience/dev_sessions.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"reflect"
 	"strconv"
 	"strings"
 	"sync"
@@ -100,12 +101,31 @@ func newDevSession(effectType string) (*devSession, error) {
 	if err != nil {
 		return nil, err
 	}
+	cfg, err := randomizedDevConfig(effect.Schema(), seed)
+	if err != nil {
+		return nil, err
+	}
+	if err := effect.ApplyConfig(cfg); err != nil {
+		return nil, err
+	}
 	return &devSession{
 		seed:      seed,
 		effect:    effect,
 		listeners: make(map[chan Command]struct{}),
 		lastSeen:  time.Now(),
 	}, nil
+}
+
+func configsEqualJSON(left, right json.RawMessage) bool {
+	var a any
+	if err := json.Unmarshal(left, &a); err != nil {
+		return false
+	}
+	var b any
+	if err := json.Unmarshal(right, &b); err != nil {
+		return false
+	}
+	return reflect.DeepEqual(a, b)
 }
 
 func devSessionKey(effectType, sessionID string) string {
@@ -249,6 +269,10 @@ func (s *devSession) setConfigQuery(values url.Values) error {
 	if err != nil {
 		return err
 	}
+	return s.applyConfig(data)
+}
+
+func (s *devSession) applyConfig(data json.RawMessage) error {
 	if err := s.effect.ApplyConfig(data); err != nil {
 		return err
 	}
@@ -258,6 +282,26 @@ func (s *devSession) setConfigQuery(values url.Values) error {
 		Data: cloneRaw(data),
 	})
 	return nil
+}
+
+func (s *devSession) randomizeConfig(seed int64) (json.RawMessage, error) {
+	current, err := s.effect.Snapshot()
+	if err != nil {
+		return nil, err
+	}
+	for attempt := range 6 {
+		cfg, err := randomizedDevConfig(s.effect.Schema(), seed+int64(attempt)*7919)
+		if err != nil {
+			return nil, err
+		}
+		if attempt == 5 || !configsEqualJSON(cfg, current.Config) {
+			if err := s.applyConfig(cfg); err != nil {
+				return nil, err
+			}
+			return cfg, nil
+		}
+	}
+	return nil, fmt.Errorf("randomize config: exhausted attempts")
 }
 
 func (s *devSession) triggerEvent(event string) bool {
@@ -355,6 +399,25 @@ func serveDevSessionConfig(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)
+}
+
+func serveDevSessionRandomize(w http.ResponseWriter, req *http.Request) {
+	if req.Method != http.MethodPost {
+		http.Error(w, "POST required", http.StatusMethodNotAllowed)
+		return
+	}
+	s, _, _, err := devSessionFromRequest(req)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	cfg, err := s.randomizeConfig(time.Now().UnixNano())
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = w.Write(cfg)
 }
 
 func serveDevSessionTrigger(w http.ResponseWriter, req *http.Request) {

--- a/cmd/ambience/dev_sessions_test.go
+++ b/cmd/ambience/dev_sessions_test.go
@@ -1,6 +1,9 @@
 package main
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
 
 func TestDevPageEffectFromPath(t *testing.T) {
 	cases := []struct {
@@ -10,6 +13,7 @@ func TestDevPageEffectFromPath(t *testing.T) {
 	}{
 		{path: "/dev", want: "rain", wantOK: true},
 		{path: "/dev/", want: "rain", wantOK: true},
+		{path: "/dev/dust", want: "dust", wantOK: true},
 		{path: "/dev/fireflies", want: "fireflies", wantOK: true},
 		{path: "/dev/waterfall", want: "waterfall", wantOK: true},
 		{path: "/dev/unknown", wantOK: false},
@@ -33,6 +37,7 @@ func TestEffectFromSchemaPath(t *testing.T) {
 		wantOK bool
 	}{
 		{path: "/effects/rain/schema", want: "rain", wantOK: true},
+		{path: "/effects/dust/schema", want: "dust", wantOK: true},
 		{path: "/effects/fireflies/schema", want: "fireflies", wantOK: true},
 		{path: "/effects/waterfall/schema", want: "waterfall", wantOK: true},
 		{path: "/effects/unknown/schema", wantOK: false},
@@ -60,6 +65,17 @@ func TestNewDevSessionFirefliesSnapshotType(t *testing.T) {
 	}
 }
 
+func TestNewDevSessionDustSnapshotType(t *testing.T) {
+	session, err := newDevSession("dust")
+	if err != nil {
+		t.Fatalf("newDevSession: %v", err)
+	}
+	snap := session.snapshot()
+	if snap.Type != "dust" {
+		t.Fatalf("snapshot type = %q, want dust", snap.Type)
+	}
+}
+
 func TestNewDevSessionWaterfallSnapshotType(t *testing.T) {
 	session, err := newDevSession("waterfall")
 	if err != nil {
@@ -68,5 +84,23 @@ func TestNewDevSessionWaterfallSnapshotType(t *testing.T) {
 	snap := session.snapshot()
 	if snap.Type != "waterfall" {
 		t.Fatalf("snapshot type = %q, want waterfall", snap.Type)
+	}
+}
+
+func TestDevSessionRandomizeConfigChangesSnapshotConfig(t *testing.T) {
+	session, err := newDevSession("dust")
+	if err != nil {
+		t.Fatalf("newDevSession: %v", err)
+	}
+
+	before := session.snapshot()
+	time.Sleep(time.Nanosecond)
+	if _, err := session.randomizeConfig(99); err != nil {
+		t.Fatalf("randomizeConfig: %v", err)
+	}
+	after := session.snapshot()
+
+	if configsEqualJSON(before.Config, after.Config) {
+		t.Fatal("expected randomized config to differ from previous session config")
 	}
 }

--- a/cmd/ambience/effects.go
+++ b/cmd/ambience/effects.go
@@ -56,6 +56,11 @@ var effectRegistry = map[string]effectDefinition{
 		Schema:     sim.RainSchema,
 		NewRuntime: newRainRuntime,
 	},
+	"dust": {
+		Type:       "dust",
+		Schema:     sim.DustSchema,
+		NewRuntime: newDustRuntime,
+	},
 	"fireflies": {
 		Type:       "fireflies",
 		Schema:     sim.FirefliesSchema,
@@ -136,6 +141,10 @@ type rainRuntime struct {
 	sim *sim.Rain
 }
 
+type dustRuntime struct {
+	sim *sim.Dust
+}
+
 type firefliesRuntime struct {
 	sim *sim.Fireflies
 }
@@ -152,6 +161,16 @@ func newRainRuntime(w, h int, seed int64, cfg json.RawMessage) (effectRuntime, e
 		}
 	}
 	return &rainRuntime{sim: sim.NewRain(w, h, seed, parsed)}, nil
+}
+
+func newDustRuntime(w, h int, seed int64, cfg json.RawMessage) (effectRuntime, error) {
+	var parsed sim.DustConfig
+	if len(cfg) > 0 {
+		if err := json.Unmarshal(cfg, &parsed); err != nil {
+			return nil, fmt.Errorf("decode dust config: %w", err)
+		}
+	}
+	return &dustRuntime{sim: sim.NewDust(w, h, seed, parsed)}, nil
 }
 
 func newFirefliesRuntime(w, h int, seed int64, cfg json.RawMessage) (effectRuntime, error) {
@@ -274,6 +293,107 @@ func (r *rainRuntime) ApplyConfig(data json.RawMessage) error {
 }
 
 func (r *rainRuntime) AddEntropy(delta int64) { r.sim.PerturbRNG(delta) }
+
+func (d *dustRuntime) Type() string { return "dust" }
+
+func (d *dustRuntime) Schema() sim.EffectSchema { return sim.DustSchema() }
+
+func (d *dustRuntime) Snapshot() (effectEnvelope, error) {
+	configData, err := json.Marshal(d.sim.EffectiveConfig())
+	if err != nil {
+		return effectEnvelope{}, err
+	}
+	snap := d.sim.Snapshot()
+	stateData, err := json.Marshal(snap)
+	if err != nil {
+		return effectEnvelope{}, err
+	}
+	return effectEnvelope{
+		Tick:   snap.Tick,
+		Config: configData,
+		State:  stateData,
+		GridW:  d.sim.W,
+		GridH:  d.sim.H,
+	}, nil
+}
+
+func (d *dustRuntime) Restore(s effectEnvelope) error {
+	if len(s.Config) > 0 {
+		if err := d.ApplyConfig(s.Config); err != nil {
+			return err
+		}
+	}
+	if len(s.State) == 0 {
+		return nil
+	}
+	var state sim.DustSnapshot
+	if err := json.Unmarshal(s.State, &state); err != nil {
+		return fmt.Errorf("decode dust snapshot: %w", err)
+	}
+	if s.GridW > 0 && s.GridH > 0 && (d.sim.W != s.GridW || d.sim.H != s.GridH) {
+		d.sim.Resize(s.GridW, s.GridH)
+	}
+	d.sim.RestoreSnapshot(state)
+	return nil
+}
+
+func (d *dustRuntime) Persisted() (persistedEffectState, error) {
+	configData, err := json.Marshal(d.sim.EffectiveConfig())
+	if err != nil {
+		return persistedEffectState{}, err
+	}
+	stateData, err := json.Marshal(d.sim.SnapshotPersistedState())
+	if err != nil {
+		return persistedEffectState{}, err
+	}
+	return persistedEffectState{
+		Config: configData,
+		State:  stateData,
+		GridW:  d.sim.W,
+		GridH:  d.sim.H,
+	}, nil
+}
+
+func (d *dustRuntime) RestorePersisted(s persistedEffectState) error {
+	if len(s.Config) > 0 {
+		if err := d.ApplyConfig(s.Config); err != nil {
+			return err
+		}
+	}
+	if len(s.State) == 0 {
+		return nil
+	}
+	var state sim.DustPersistedState
+	if err := json.Unmarshal(s.State, &state); err != nil {
+		return fmt.Errorf("decode dust persisted state: %w", err)
+	}
+	if s.GridW > 0 && s.GridH > 0 && (d.sim.W != s.GridW || d.sim.H != s.GridH) {
+		d.sim.Resize(s.GridW, s.GridH)
+	}
+	d.sim.RestorePersistedState(state)
+	return nil
+}
+
+func (d *dustRuntime) Trigger(name string) bool { return d.sim.TriggerEvent(name) }
+
+func (d *dustRuntime) Step() { d.sim.Step() }
+
+func (d *dustRuntime) CurrentTick() int { return d.sim.CurrentTick() }
+
+func (d *dustRuntime) DrainLog() []sim.LogEntry { return d.sim.DrainLog() }
+
+func (d *dustRuntime) ApplyConfig(data json.RawMessage) error {
+	var cfg sim.DustConfig
+	if len(data) > 0 {
+		if err := json.Unmarshal(data, &cfg); err != nil {
+			return fmt.Errorf("decode dust config: %w", err)
+		}
+	}
+	d.sim.SetConfig(cfg)
+	return nil
+}
+
+func (d *dustRuntime) AddEntropy(delta int64) { d.sim.PerturbRNG(delta) }
 
 func (f *firefliesRuntime) Type() string { return "fireflies" }
 

--- a/cmd/ambience/live_controls.go
+++ b/cmd/ambience/live_controls.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/nelsong6/ambience/sim"
+)
+
+func sharedEffectSchema(req *http.Request) (string, sim.EffectSchema, error) {
+	if shared == nil {
+		return "", sim.EffectSchema{}, fmt.Errorf("shared atmosphere unavailable")
+	}
+	snap := shared.snapshot()
+	effectType := strings.TrimSpace(strings.ToLower(snap.Type))
+	if effectType == "" {
+		return "", sim.EffectSchema{}, fmt.Errorf("shared atmosphere unavailable")
+	}
+	if requested := strings.TrimSpace(strings.ToLower(req.URL.Query().Get("effect"))); requested != "" && requested != effectType {
+		return "", sim.EffectSchema{}, fmt.Errorf("shared atmosphere is %s, not %s", effectType, requested)
+	}
+	schema, ok := schemaForEffect(effectType)
+	if !ok {
+		return "", sim.EffectSchema{}, fmt.Errorf("unknown shared effect %q", effectType)
+	}
+	return effectType, schema, nil
+}
+
+func serveSharedConfig(w http.ResponseWriter, req *http.Request) {
+	if req.Method != http.MethodPost {
+		http.Error(w, "POST required", http.StatusMethodNotAllowed)
+		return
+	}
+	_, schema, err := sharedEffectSchema(req)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	data, err := parseEffectConfig(req.URL.Query(), schema)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if err := shared.setConfigRaw(data); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func serveSharedTrigger(w http.ResponseWriter, req *http.Request) {
+	if req.Method != http.MethodPost {
+		http.Error(w, "POST required", http.StatusMethodNotAllowed)
+		return
+	}
+	event := strings.Trim(strings.TrimPrefix(req.URL.Path, "/trigger/"), "/")
+	if event == "" || strings.Contains(event, "/") {
+		http.Error(w, "usage: /trigger/<event>?effect=<name>", http.StatusBadRequest)
+		return
+	}
+	if _, _, err := sharedEffectSchema(req); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if !shared.triggerEvent(event) {
+		http.Error(w, "unknown event: "+event, http.StatusBadRequest)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/cmd/ambience/main.go
+++ b/cmd/ambience/main.go
@@ -17,6 +17,7 @@
 //	GET  /dev/snapshot?session=&effect=
 //	GET  /dev/events?session=&effect=
 //	POST /dev/config?session=&effect=
+//	POST /dev/randomize?session=&effect=
 //	POST /dev/trigger/:session/:event?effect=
 //	                            — fire a discrete event on the dev atmosphere
 //	GET  /effects/<effect>/schema — JSON schema for the dev knob panel
@@ -59,10 +60,11 @@ const (
 )
 
 type appConfig struct {
-	role          appRole
-	addr          string
-	authorityURL  string
-	shutdownDrain time.Duration
+	role           appRole
+	addr           string
+	authorityURL   string
+	shutdownDrain  time.Duration
+	webOverrideDir string
 }
 
 type lifecycleState struct {
@@ -83,6 +85,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
+	static := newStaticAssets(web, cfg.webOverrideDir)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	lifecycle := &lifecycleState{}
@@ -95,7 +98,7 @@ func main() {
 		if err := bootAuthority(ctx); err != nil {
 			log.Fatal(err)
 		}
-		registerStaticRoutes(mux, web)
+		registerStaticRoutes(mux, static)
 		registerSchemaRoute(mux)
 		registerAuthorityRoutes(mux)
 		registerDevRoutes(mux)
@@ -105,7 +108,7 @@ func main() {
 			log.Fatal(err)
 		}
 		baseReady = proxy.ready
-		registerStaticRoutes(mux, web)
+		registerStaticRoutes(mux, static)
 		registerSchemaRoute(mux)
 		registerEdgeRoutes(mux, proxy)
 	default:
@@ -185,6 +188,7 @@ func loadAppConfigFromEnv() (appConfig, error) {
 		}
 		cfg.shutdownDrain = d
 	}
+	cfg.webOverrideDir = strings.TrimSpace(os.Getenv("AMBIENCE_WEB_OVERRIDE_DIR"))
 	return cfg, nil
 }
 
@@ -207,10 +211,14 @@ func registerCommonRoutes(mux *http.ServeMux, ready func() bool) {
 	mux.HandleFunc("/readyz", serveReadyz(ready))
 }
 
-func registerStaticRoutes(mux *http.ServeMux, web fs.FS) {
-	mux.HandleFunc("/dev", serveDevPage(web))
-	mux.HandleFunc("/dev/", serveDevPage(web))
-	mux.Handle("/", http.FileServer(http.FS(web)))
+func registerStaticRoutes(mux *http.ServeMux, static staticAssets) {
+	mux.HandleFunc("/dev", serveDevPage(static))
+	mux.HandleFunc("/dev/", serveDevPage(static))
+	mux.HandleFunc("/sim.js", serveStaticFile(static, "sim.js"))
+	mux.HandleFunc("/controls.js", serveStaticFile(static, "controls.js"))
+	mux.HandleFunc("/client.js", serveStaticFile(static, "client.js"))
+	mux.HandleFunc("/ambience.js", serveStaticFile(static, "ambience.js"))
+	mux.HandleFunc("/", serveExactStaticFile(static, "/", "index.html"))
 }
 
 func registerSchemaRoute(mux *http.ServeMux) {
@@ -236,6 +244,7 @@ func registerDevRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/dev/snapshot", serveDevSessionSnapshot)
 	mux.HandleFunc("/dev/events", serveDevSessionEvents)
 	mux.HandleFunc("/dev/config", serveDevSessionConfig)
+	mux.HandleFunc("/dev/randomize", serveDevSessionRandomize)
 	mux.HandleFunc("/dev/trigger/", serveDevSessionTrigger)
 }
 
@@ -269,13 +278,13 @@ func cors(h http.HandlerFunc) http.HandlerFunc {
 	}
 }
 
-func serveDevPage(web fs.FS) http.HandlerFunc {
+func serveDevPage(static staticAssets) http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
 		if _, ok := devPageEffectFromPath(req.URL.Path); !ok {
 			http.NotFound(w, req)
 			return
 		}
-		data, err := fs.ReadFile(web, "dev.html")
+		data, err := static.readFile("dev.html")
 		if err != nil {
 			http.Error(w, "dev page not found", http.StatusNotFound)
 			return

--- a/cmd/ambience/main.go
+++ b/cmd/ambience/main.go
@@ -7,8 +7,11 @@
 //	GET  /                      — canonical demo page (browser runs a JS sim)
 //	GET  /ambience.js           — shared renderer / SSE helpers
 //	GET  /sim.js                — JS port of sim/rain.go (runs in browser)
+//	GET  /controls.js           — shared schema-driven control panel helper
 //	GET  /snapshot              — shared atmosphere init payload (JSON)
 //	GET  /events                — shared atmosphere SSE command stream
+//	POST /config?effect=&...    — mutate the shared atmosphere config
+//	POST /trigger/:event        — fire a discrete event on the shared atmosphere
 //	GET  /dev                   — dev page with knob controls (defaults to rain)
 //	GET  /dev/<effect>          — effect-specific dev page (e.g. /dev/fireflies)
 //	GET  /dev/snapshot?session=&effect=
@@ -219,6 +222,10 @@ func registerAuthorityRoutes(mux *http.ServeMux) {
 	// my-homepage, etc.) can consume the stream.
 	mux.HandleFunc("/snapshot", cors(serveSharedSnapshot))
 	mux.HandleFunc("/events", cors(serveSharedEvents))
+	// Shared live controls stay same-origin only. They intentionally do not
+	// opt into permissive CORS because they mutate the shared atmosphere.
+	mux.HandleFunc("/config", serveSharedConfig)
+	mux.HandleFunc("/trigger/", serveSharedTrigger)
 	// Entropy intake — clients POST keystroke-derived bytes here; bytes
 	// get folded into the shared atmosphere's RNG.
 	mux.HandleFunc("/entropy", cors(serveEntropy))

--- a/cmd/ambience/proxy.go
+++ b/cmd/ambience/proxy.go
@@ -64,6 +64,8 @@ func registerEdgeRoutes(mux *http.ServeMux, proxy *authorityProxy) {
 	mux.HandleFunc("/snapshot", cors(proxy.serveSnapshot))
 	mux.HandleFunc("/events", cors(proxy.serveEvents))
 	mux.HandleFunc("/entropy", cors(proxy.serveEntropy))
+	mux.HandleFunc("/config", proxy.serveHTTP)
+	mux.HandleFunc("/trigger/", proxy.serveHTTP)
 	mux.HandleFunc("/dev/snapshot", proxy.serveHTTP)
 	mux.HandleFunc("/dev/events", proxy.serveHTTP)
 	mux.HandleFunc("/dev/config", proxy.serveHTTP)

--- a/cmd/ambience/proxy.go
+++ b/cmd/ambience/proxy.go
@@ -69,6 +69,7 @@ func registerEdgeRoutes(mux *http.ServeMux, proxy *authorityProxy) {
 	mux.HandleFunc("/dev/snapshot", proxy.serveHTTP)
 	mux.HandleFunc("/dev/events", proxy.serveHTTP)
 	mux.HandleFunc("/dev/config", proxy.serveHTTP)
+	mux.HandleFunc("/dev/randomize", proxy.serveHTTP)
 	mux.HandleFunc("/dev/trigger/", proxy.serveHTTP)
 }
 

--- a/cmd/ambience/static.go
+++ b/cmd/ambience/static.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"io/fs"
+	"mime"
+	"net/http"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+var defaultStaticMTime = time.Unix(0, 0)
+
+type staticAssets struct {
+	embedded    fs.FS
+	overrideDir string
+}
+
+func newStaticAssets(embedded fs.FS, overrideDir string) staticAssets {
+	return staticAssets{
+		embedded:    embedded,
+		overrideDir: overrideDir,
+	}
+}
+
+func (s staticAssets) readFile(name string) ([]byte, error) {
+	if s.overrideDir != "" {
+		path := filepath.Join(s.overrideDir, filepath.FromSlash(name))
+		data, err := os.ReadFile(path)
+		if err == nil {
+			return data, nil
+		}
+		if !errors.Is(err, os.ErrNotExist) {
+			return nil, err
+		}
+	}
+	return fs.ReadFile(s.embedded, name)
+}
+
+func serveStaticFile(static staticAssets, name string) http.HandlerFunc {
+	return func(w http.ResponseWriter, req *http.Request) {
+		data, err := static.readFile(name)
+		if err != nil {
+			http.NotFound(w, req)
+			return
+		}
+		if ctype := mime.TypeByExtension(filepath.Ext(name)); ctype != "" {
+			w.Header().Set("Content-Type", ctype)
+		}
+		http.ServeContent(w, req, name, defaultStaticMTime, bytes.NewReader(data))
+	}
+}
+
+func serveExactStaticFile(static staticAssets, routePath, name string) http.HandlerFunc {
+	handler := serveStaticFile(static, name)
+	return func(w http.ResponseWriter, req *http.Request) {
+		if req.URL.Path != routePath {
+			http.NotFound(w, req)
+			return
+		}
+		handler(w, req)
+	}
+}

--- a/cmd/ambience/static_test.go
+++ b/cmd/ambience/static_test.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"io/fs"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"testing/fstest"
+)
+
+func TestStaticAssetsReadFileFallsBackToEmbedded(t *testing.T) {
+	static := newStaticAssets(fstest.MapFS{
+		"dev.html": &fstest.MapFile{Data: []byte("embedded-dev")},
+	}, "")
+
+	got, err := static.readFile("dev.html")
+	if err != nil {
+		t.Fatalf("readFile returned error: %v", err)
+	}
+	if string(got) != "embedded-dev" {
+		t.Fatalf("readFile = %q, want embedded content", string(got))
+	}
+}
+
+func TestStaticAssetsReadFileUsesOverride(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "dev.html"), []byte("override-dev"), 0o644); err != nil {
+		t.Fatalf("write override file: %v", err)
+	}
+
+	static := newStaticAssets(fstest.MapFS{
+		"dev.html": &fstest.MapFile{Data: []byte("embedded-dev")},
+	}, dir)
+
+	got, err := static.readFile("dev.html")
+	if err != nil {
+		t.Fatalf("readFile returned error: %v", err)
+	}
+	if string(got) != "override-dev" {
+		t.Fatalf("readFile = %q, want override content", string(got))
+	}
+}
+
+func TestServeDevPageUsesOverride(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "dev.html"), []byte("override-dev"), 0o644); err != nil {
+		t.Fatalf("write override file: %v", err)
+	}
+
+	static := newStaticAssets(fstest.MapFS{
+		"dev.html": &fstest.MapFile{Data: []byte("embedded-dev")},
+	}, dir)
+
+	req := httptest.NewRequest(http.MethodGet, "/dev/dust", nil)
+	rec := httptest.NewRecorder()
+	serveDevPage(static).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	if body := rec.Body.String(); body != "override-dev" {
+		t.Fatalf("body = %q, want override content", body)
+	}
+}
+
+func TestServeExactStaticFileServesOnlyConfiguredRoute(t *testing.T) {
+	static := newStaticAssets(fstest.MapFS{
+		"index.html": &fstest.MapFile{Data: []byte("home")},
+	}, "")
+
+	handler := serveExactStaticFile(static, "/", "index.html")
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("root status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	if body := rec.Body.String(); body != "home" {
+		t.Fatalf("root body = %q, want %q", body, "home")
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/index.html", nil)
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("/index.html status = %d, want %d", rec.Code, http.StatusNotFound)
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/not-a-page", nil)
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("unknown path status = %d, want %d", rec.Code, http.StatusNotFound)
+	}
+}
+
+func TestLoadAppConfigFromEnvWebOverrideDir(t *testing.T) {
+	t.Setenv("AMBIENCE_WEB_OVERRIDE_DIR", "C:\\override")
+
+	cfg, err := loadAppConfigFromEnv()
+	if err != nil {
+		t.Fatalf("loadAppConfigFromEnv returned error: %v", err)
+	}
+	if cfg.webOverrideDir != "C:\\override" {
+		t.Fatalf("webOverrideDir = %q, want %q", cfg.webOverrideDir, "C:\\override")
+	}
+}
+
+var _ fs.FS = fstest.MapFS{}

--- a/cmd/ambience/web/controls.js
+++ b/cmd/ambience/web/controls.js
@@ -1,0 +1,359 @@
+(function (global) {
+	'use strict';
+
+	const SLOT_LABELS = {
+		'spawn': 'spawn config',
+		'lever': 'continuous levers',
+		'event': 'discrete events',
+		'event-mod': 'event modifiers',
+		'end': 'end conditions',
+	};
+	const SLOT_ORDER = ['spawn', 'lever', 'event', 'event-mod', 'end'];
+	const CUSTOM_PRESET = '__custom__';
+	const CHEV = '\u25be';
+
+	function effectLabel(name) {
+		return String(name || '').replace(/-/g, ' ');
+	}
+
+	function effectPresets(name) {
+		const presets = global.AmbienceSim && global.AmbienceSim.presets && global.AmbienceSim.presets[name];
+		return Array.isArray(presets) ? presets : [];
+	}
+
+	function presetValue(preset) {
+		return preset.key || preset.name;
+	}
+
+	function presetConfig(preset) {
+		return (preset && (preset.config || preset.values)) || {};
+	}
+
+	function findPreset(effect, value) {
+		return effectPresets(effect).find((preset) => presetValue(preset) === value) || null;
+	}
+
+	function knobMatches(knob, left, right) {
+		if (!knob) return false;
+		const a = Number(left);
+		const b = Number(right);
+		if (!Number.isFinite(a) || !Number.isFinite(b)) return false;
+		if (knob.type === 'int') return Math.round(a) === Math.round(b);
+		const step = Number(knob.step) || 0.001;
+		return Math.abs(a - b) <= Math.max(1e-9, step / 2);
+	}
+
+	function formatValue(knob, value) {
+		const v = Number(value);
+		if (!Number.isFinite(v)) return '';
+		if (knob.type === 'int') return String(Math.round(v));
+		const step = Number(knob.step) || 0;
+		const decimals = step < 0.1 ? 2 : (step < 1 ? 1 : 0);
+		return v.toFixed(decimals) + ((knob.key === 'hue' || knob.key === 'hue_sp') ? '\u00b0' : '');
+	}
+
+	function create(options) {
+		const state = {
+			effect: options.effect || 'rain',
+			locked: !!options.locked,
+			schema: null,
+			knobs: [],
+		};
+
+		const root = options.root;
+		const effectSelect = options.effectSelect || null;
+		const presetSelect = options.presetSelect || null;
+		const toggleAll = options.toggleAll || null;
+		const storagePrefix = options.storagePrefix || 'ambience.controls.section.';
+		const canSwitchEffect = !!options.canSwitchEffect;
+
+		function currentValues() {
+			const values = {};
+			for (const knob of state.knobs) {
+				const input = document.getElementById(knob.key);
+				if (input) values[knob.key] = +input.value;
+			}
+			return values;
+		}
+
+		function updateReadouts() {
+			for (const knob of state.knobs) {
+				const input = document.getElementById(knob.key);
+				const readout = document.getElementById(knob.key + '_v');
+				if (input && readout) readout.textContent = formatValue(knob, input.value);
+			}
+		}
+
+		function resolvedPresetConfig(schema, preset) {
+			const resolved = {};
+			for (const knob of (schema && schema.knobs) || []) resolved[knob.key] = knob.default;
+			return Object.assign(resolved, presetConfig(preset));
+		}
+
+		function matchingPresetValue() {
+			if (!state.schema || !state.knobs.length) return CUSTOM_PRESET;
+			const values = currentValues();
+			for (const preset of effectPresets(state.effect)) {
+				const resolved = resolvedPresetConfig(state.schema, preset);
+				let matches = true;
+				for (const knob of state.knobs) {
+					if (!knobMatches(knob, values[knob.key], resolved[knob.key])) {
+						matches = false;
+						break;
+					}
+				}
+				if (matches) return presetValue(preset);
+			}
+			return CUSTOM_PRESET;
+		}
+
+		function syncEffectSwitcher() {
+			if (!effectSelect) return;
+			const optionsList = (typeof options.effectOptions === 'function')
+				? options.effectOptions(state.effect)
+				: [state.effect];
+			effectSelect.innerHTML = '';
+			for (const name of optionsList) {
+				const opt = document.createElement('option');
+				opt.value = name;
+				opt.textContent = effectLabel(name);
+				opt.selected = name === state.effect;
+				effectSelect.appendChild(opt);
+			}
+			if (!optionsList.includes(state.effect)) {
+				const opt = document.createElement('option');
+				opt.value = state.effect;
+				opt.textContent = effectLabel(state.effect);
+				opt.selected = true;
+				effectSelect.appendChild(opt);
+			}
+			effectSelect.disabled = !canSwitchEffect;
+		}
+
+		function syncPresetSwitcher(selectedValue) {
+			if (!presetSelect) return;
+			const presets = effectPresets(state.effect);
+			presetSelect.innerHTML = '';
+			const custom = document.createElement('option');
+			custom.value = CUSTOM_PRESET;
+			custom.textContent = 'custom';
+			presetSelect.appendChild(custom);
+			for (const preset of presets) {
+				const opt = document.createElement('option');
+				opt.value = presetValue(preset);
+				opt.textContent = preset.label || preset.name || opt.value;
+				presetSelect.appendChild(opt);
+			}
+			const desired = selectedValue || matchingPresetValue();
+			presetSelect.value = findPreset(state.effect, desired) ? desired : CUSTOM_PRESET;
+			presetSelect.disabled = state.locked || !state.schema || presets.length === 0;
+			presetSelect.title = presets.length ? 'apply effect preset' : 'no presets for this effect yet';
+		}
+
+		function setInteractiveDisabled(disabled) {
+			for (const input of root.querySelectorAll('input[type="range"]')) input.disabled = disabled;
+			for (const button of root.querySelectorAll('button.fire')) button.disabled = disabled;
+			syncEffectSwitcher();
+			syncPresetSwitcher();
+		}
+
+		function applyValues(values) {
+			for (const knob of state.knobs) {
+				const input = document.getElementById(knob.key);
+				if (!input) continue;
+				const next = values && values[knob.key] != null ? values[knob.key] : knob.default;
+				input.value = next;
+			}
+			updateReadouts();
+			syncPresetSwitcher();
+		}
+
+		function buildRow(knob) {
+			const row = document.createElement('div');
+			row.className = 'control-row';
+
+			const label = document.createElement('label');
+			label.htmlFor = knob.key;
+			label.textContent = knob.label;
+
+			const input = document.createElement('input');
+			input.type = 'range';
+			input.id = knob.key;
+			input.min = knob.min;
+			input.max = knob.max;
+			input.step = knob.step;
+			input.value = knob.default;
+
+			const value = document.createElement('span');
+			value.className = 'val';
+			value.id = knob.key + '_v';
+
+			row.append(label, input, value);
+
+			if (knob.trigger) {
+				const fire = document.createElement('button');
+				fire.type = 'button';
+				fire.className = 'fire';
+				fire.textContent = 'fire';
+				fire.title = 'trigger this event now';
+				fire.addEventListener('click', () => {
+					if (state.locked || typeof options.onTrigger !== 'function') return;
+					options.onTrigger(knob.trigger);
+				});
+				row.appendChild(fire);
+			}
+
+			if (knob.description) {
+				const help = document.createElement('span');
+				help.className = 'help';
+				help.textContent = '?';
+				help.title = knob.description;
+				row.appendChild(help);
+			}
+
+			input.addEventListener('input', () => {
+				updateReadouts();
+				if (presetSelect && !presetSelect.disabled) presetSelect.value = CUSTOM_PRESET;
+				if (state.locked || typeof options.onConfigChange !== 'function') return;
+				options.onConfigChange(currentValues(), knob);
+			});
+
+			return row;
+		}
+
+		function buildSection(id, titleText, count, defaultOpen, bodyBuilder) {
+			const section = document.createElement('div');
+			section.className = 'section';
+			section.dataset.id = id;
+
+			const storedClosed = localStorage.getItem(storagePrefix + id) === 'closed';
+			const initiallyClosed = storedClosed || (!defaultOpen && localStorage.getItem(storagePrefix + id) === null);
+			if (initiallyClosed) section.classList.add('closed');
+
+			const head = document.createElement('div');
+			head.className = 'section-head';
+			head.innerHTML = '<span class="chev">' + CHEV + '</span><span class="name">' + titleText + '</span>' +
+				(count != null ? '<span class="count">' + count + '</span>' : '');
+			head.addEventListener('click', () => {
+				section.classList.toggle('closed');
+				localStorage.setItem(storagePrefix + id, section.classList.contains('closed') ? 'closed' : 'open');
+			});
+			section.appendChild(head);
+
+			const body = document.createElement('div');
+			body.className = 'section-body';
+			bodyBuilder(body);
+			section.appendChild(body);
+			return section;
+		}
+
+		function render(schema) {
+			state.schema = schema;
+			state.knobs = Array.isArray(schema && schema.knobs) ? schema.knobs.slice() : [];
+			root.innerHTML = '';
+
+			const bySlot = {};
+			for (const knob of state.knobs) {
+				if (!bySlot[knob.slot]) bySlot[knob.slot] = {};
+				const group = knob.group || '';
+				if (!bySlot[knob.slot][group]) bySlot[knob.slot][group] = [];
+				bySlot[knob.slot][group].push(knob);
+			}
+
+			for (const slot of SLOT_ORDER) {
+				const slotKnobs = bySlot[slot] ? Object.values(bySlot[slot]).flat() : [];
+				const section = buildSection(
+					'slot.' + slot,
+					SLOT_LABELS[slot] || slot,
+					slotKnobs.length > 0 ? slotKnobs.length : 'none',
+					slot === 'spawn',
+					(body) => {
+						if (!bySlot[slot]) {
+							const empty = document.createElement('div');
+							empty.className = 'empty-slot';
+							empty.textContent = 'none yet';
+							body.appendChild(empty);
+							return;
+						}
+						const groups = bySlot[slot];
+						const groupNames = Object.keys(groups);
+						const showSubheaders = !(groupNames.length === 1 && groupNames[0] === '');
+						for (const group of groupNames) {
+							if (showSubheaders && group) {
+								const heading = document.createElement('h3');
+								heading.textContent = group;
+								body.appendChild(heading);
+							}
+							for (const knob of groups[group]) body.appendChild(buildRow(knob));
+						}
+					}
+				);
+				root.appendChild(section);
+			}
+
+			updateReadouts();
+			syncEffectSwitcher();
+			syncPresetSwitcher();
+			setInteractiveDisabled(state.locked);
+		}
+
+		if (effectSelect) {
+			effectSelect.addEventListener('change', () => {
+				const next = effectSelect.value;
+				if (!canSwitchEffect || !next || next === state.effect || typeof options.onEffectChange !== 'function') return;
+				options.onEffectChange(next);
+			});
+		}
+
+		if (presetSelect) {
+			presetSelect.addEventListener('change', () => {
+				if (state.locked || presetSelect.value === CUSTOM_PRESET || !state.schema) return;
+				const preset = findPreset(state.effect, presetSelect.value);
+				if (!preset) return;
+				applyValues(resolvedPresetConfig(state.schema, preset));
+				if (typeof options.onConfigChange === 'function') options.onConfigChange(currentValues(), null);
+			});
+		}
+
+		if (toggleAll) {
+			toggleAll.addEventListener('click', () => {
+				const sections = root.querySelectorAll('.section');
+				const anyOpen = Array.from(sections).some((section) => !section.classList.contains('closed'));
+				for (const section of sections) {
+					section.classList.toggle('closed', anyOpen);
+					localStorage.setItem(storagePrefix + section.dataset.id, anyOpen ? 'closed' : 'open');
+				}
+			});
+		}
+
+		syncEffectSwitcher();
+		syncPresetSwitcher();
+
+		return {
+			currentValues,
+			getKnobs() {
+				return state.knobs.slice();
+			},
+			getSchema() {
+				return state.schema;
+			},
+			isLocked() {
+				return state.locked;
+			},
+			render,
+			setEffect(effect) {
+				state.effect = effect;
+				syncEffectSwitcher();
+				syncPresetSwitcher();
+			},
+			setLocked(locked) {
+				state.locked = !!locked;
+				setInteractiveDisabled(state.locked);
+			},
+			setValues: applyValues,
+			updateReadouts,
+		};
+	}
+
+	global.AmbienceControls = { create };
+})(window);

--- a/cmd/ambience/web/dev.html
+++ b/cmd/ambience/web/dev.html
@@ -100,9 +100,9 @@
 	.fire:active { background: #555; }
 
 	#logEntries {
-		font-size: 9px; max-height: 180px; overflow-y: auto;
+		font-size: 9px; height: 180px; overflow-y: auto;
 		background: #060606; border: 1px solid #1a1a1a; padding: 4px 6px;
-		opacity: 0.9;
+		opacity: 0.9; display: flex; flex-direction: column; justify-content: flex-end;
 	}
 	#logEntries .entry { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; line-height: 1.4; }
 	#logEntries .entry .t { opacity: 0.5; margin-right: 4px; }
@@ -132,6 +132,7 @@
 		<div class="switcher-row">
 			<label for="presetSelect">preset</label>
 			<select id="presetSelect" title="apply effect preset"></select>
+			<button class="iconbtn" id="randomizeBtn" title="randomize current effect config">randomize</button>
 		</div>
 	</div>
 	<div class="body" id="body"></div>
@@ -163,6 +164,7 @@
 	const title = document.getElementById('title');
 	const effectSelect = document.getElementById('effectSelect');
 	const presetSelect = document.getElementById('presetSelect');
+	const randomizeBtn = document.getElementById('randomizeBtn');
 	const CUSTOM_PRESET = '__custom__';
 	let knobs = [];
 	let currentSchema = null;
@@ -303,6 +305,12 @@
 		updateReadouts();
 	}
 
+	function applyServerConfig(values) {
+		if (!values || !knobs.length) return;
+		applyValues(values);
+		syncPresetSwitcher();
+	}
+
 	function applyPresetSelection(value) {
 		const preset = findPreset(effect, value);
 		if (!preset || !currentSchema) return;
@@ -366,6 +374,22 @@
 			await fetch('/dev/trigger/' + encodeURIComponent(SESSION_ID) + '/' + encodeURIComponent(eventName) +
 				'?effect=' + encodeURIComponent(effect), { method: 'POST' });
 		} catch (e) { console.error('trigger', e); }
+	}
+
+	async function randomizeCurrentEffect() {
+		randomizeBtn.disabled = true;
+		try {
+			const resp = await fetch('/dev/randomize?session=' + encodeURIComponent(SESSION_ID) +
+				'&effect=' + encodeURIComponent(effect), { method: 'POST' });
+			if (!resp.ok) throw new Error('randomize failed: ' + resp.status);
+			const cfg = await resp.json();
+			sim.setConfig(cfg);
+			applyServerConfig(cfg);
+		} catch (e) {
+			console.error('randomize', e);
+		} finally {
+			randomizeBtn.disabled = false;
+		}
 	}
 
 	function buildRow(knob) {
@@ -486,12 +510,13 @@
 	function appendLog(entry) {
 		const box = document.getElementById('logEntries');
 		if (!box) return;
+		const shouldStick = box.scrollHeight-box.clientHeight-box.scrollTop <= 12;
 		const row = document.createElement('div');
 		row.className = 'entry ' + entry.type;
 		row.innerHTML = '<span class="t">t=' + entry.tick + '</span><span class="k">' + entry.type + '</span><span class="d">' + (entry.desc || '') + '</span>';
 		box.appendChild(row);
 		while (box.children.length > 200) box.removeChild(box.firstChild);
-		box.scrollTop = box.scrollHeight;
+		if (shouldStick) box.scrollTop = box.scrollHeight;
 	}
 
 	// Panel collapse (global) + per-section collapse.
@@ -515,6 +540,7 @@
 		if (presetSelect.value === CUSTOM_PRESET) return;
 		applyPresetSelection(presetSelect.value);
 	});
+	randomizeBtn.addEventListener('click', randomizeCurrentEffect);
 	document.getElementById('toggleAll').addEventListener('click', () => {
 		const sections = document.querySelectorAll('.section');
 		const anyOpen = [...sections].some(s => !s.classList.contains('closed'));
@@ -551,21 +577,14 @@
 					sim.restoreSnapshot(snap);
 					ready = true;
 					// Initialize sliders to the server's current config.
-					if (snap.config && knobs.length) {
-						for (const k of knobs) {
-							if (snap.config[k.key] != null) {
-								document.getElementById(k.key).value = snap.config[k.key];
-							}
-						}
-						updateReadouts();
-						syncPresetSwitcher();
-					}
+					applyServerConfig(snap.config);
 				} catch (err) { console.error('bad snapshot', err); }
 				break;
 			case 'config':
 				try {
 					const cfg = typeof cmd.data === 'string' ? JSON.parse(cmd.data) : cmd.data;
 					sim.setConfig(cfg);
+					applyServerConfig(cfg);
 				} catch (err) { console.error('bad config', err); }
 				break;
 			case 'trigger':

--- a/cmd/ambience/web/index.html
+++ b/cmd/ambience/web/index.html
@@ -2,79 +2,466 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
-<title>ambience — live</title>
+<title>ambience - live</title>
 <style>
-  html, body { margin:0; padding:0; height:100%; background:#0a0a0a; color:#eee; font-family: Consolas, "SF Mono", Menlo, monospace; overflow:hidden; }
-  #c { position:fixed; inset:0; z-index:0; image-rendering:pixelated; width:100vw; height:100vh; display:block; }
-  #panel {
-    position:fixed; top:12px; right:12px; z-index:1;
-    background:rgba(10,10,10,0.75); backdrop-filter:blur(6px);
-    border:1px solid #333; border-radius:4px;
-    padding:10px 14px;
-    min-width:280px; max-width:320px;
-    font-size:12px; line-height:1.55;
-    box-shadow: 0 4px 18px rgba(0,0,0,0.4);
+  html, body {
+    margin: 0;
+    padding: 0;
+    height: 100%;
+    background: #0a0a0a;
+    color: #eee;
+    font-family: Consolas, "SF Mono", Menlo, monospace;
+    overflow: hidden;
   }
-  h2 { margin:0 0 6px; font-size:13px; font-weight:normal; color:#9cf; letter-spacing:0.05em; text-transform:uppercase; }
-  .row { display:flex; justify-content:space-between; padding:1px 0; }
-  .row .k { color:#888; }
-  .row .v { color:#eee; font-variant-numeric: tabular-nums; }
-  .section { margin-top:8px; padding-top:8px; border-top:1px solid #222; }
-  .toggle { display:flex; align-items:center; gap:8px; }
-  .toggle label { color:#aaa; cursor:pointer; flex:1; }
-  .toggle input[type="checkbox"] { accent-color:#9cf; }
-  .toggle .v { color:#9cf; font-variant-numeric: tabular-nums; }
-  #events { max-height:200px; overflow-y:auto; font-size:11px; }
-  #events::-webkit-scrollbar { width:4px; }
-  #events::-webkit-scrollbar-thumb { background:#333; }
-  .event { color:#999; padding:1px 0; font-variant-numeric: tabular-nums; }
-  .event .time { color:#555; margin-right:6px; }
-  .event.trigger { color:#fc9; }
-  .event.scene { color:#9fc; }
-  .event.entropy { color:#c9f; }
-  #devlink { margin-top:6px; font-size:10px; text-align:right; }
-  #devlink a { color:#666; text-decoration:none; }
-  #devlink a:hover { color:#9cf; }
-  .flash { animation: flash 350ms ease-out; }
-  @keyframes flash { from { background:rgba(70,90,80,0.6); } to { background:rgba(10,10,10,0.75); } }
-  .entropy-pulse { animation: pulse 200ms ease-out; }
-  @keyframes pulse { from { color:#c9f; transform:scale(1.08); } to { color:#9cf; transform:scale(1); } }
+  #c {
+    position: fixed;
+    inset: 0;
+    z-index: 0;
+    image-rendering: pixelated;
+    width: 100vw;
+    height: 100vh;
+    display: block;
+  }
+  #panel {
+    position: fixed;
+    top: 12px;
+    right: 12px;
+    z-index: 1;
+    width: 360px;
+    max-width: min(360px, calc(100vw - 24px));
+    max-height: calc(100vh - 24px);
+    overflow-y: auto;
+    background: rgba(10, 10, 10, 0.82);
+    backdrop-filter: blur(8px);
+    border: 1px solid #333;
+    border-radius: 4px;
+    box-shadow: 0 4px 18px rgba(0, 0, 0, 0.4);
+  }
+  #panel.collapsed {
+    width: auto;
+  }
+  #panel.collapsed .panel-body {
+    display: none;
+  }
+  #panel h2 {
+    margin: 0;
+    padding: 10px 14px 8px;
+    font-size: 12px;
+    font-weight: normal;
+    color: #9cf;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+  }
+  .panel-body {
+    padding: 0 14px 10px;
+  }
+  .btnbar {
+    display: flex;
+    gap: 4px;
+  }
+  .iconbtn {
+    background: none;
+    border: 1px solid #333;
+    color: #e0e0e0;
+    font-family: inherit;
+    font-size: 10px;
+    padding: 0 6px;
+    cursor: pointer;
+    border-radius: 2px;
+    line-height: 1.5;
+  }
+  .iconbtn:hover {
+    background: #1a1a1a;
+    border-color: #555;
+  }
+  .row {
+    display: flex;
+    justify-content: space-between;
+    gap: 10px;
+    padding: 2px 0;
+    font-size: 12px;
+    line-height: 1.5;
+  }
+  .row .k {
+    color: #888;
+    text-transform: lowercase;
+  }
+  .row .v {
+    color: #eee;
+    font-variant-numeric: tabular-nums;
+    text-align: right;
+  }
+  .section-lite {
+    margin-top: 8px;
+    padding-top: 8px;
+    border-top: 1px solid #222;
+  }
+  .toggle {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .toggle label {
+    color: #aaa;
+    cursor: pointer;
+    flex: 1;
+    font-size: 11px;
+  }
+  .toggle input[type="checkbox"] {
+    accent-color: #9cf;
+  }
+  .switcher {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+  .switcher-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .switcher label {
+    width: 52px;
+    opacity: 0.55;
+    font-size: 9px;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+  }
+  .switcher select {
+    flex: 1;
+    background: #111;
+    border: 1px solid #333;
+    color: #e0e0e0;
+    font-family: inherit;
+    font-size: 10px;
+    padding: 4px 6px;
+    border-radius: 3px;
+  }
+  .switcher select:disabled {
+    opacity: 0.8;
+    cursor: default;
+  }
+  .lock-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+  }
+  .lock-copy {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+  }
+  .lock-copy .eyebrow {
+    opacity: 0.55;
+    font-size: 9px;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+  }
+  .lock-copy .lock-state {
+    font-size: 12px;
+    color: #bbb;
+  }
+  .lock-copy .lock-state.unlocked {
+    color: #f7c06a;
+  }
+  .lock-button {
+    min-width: 78px;
+    background: #171717;
+    border: 1px solid #555;
+    color: #eee;
+    font-family: inherit;
+    font-size: 10px;
+    padding: 5px 8px;
+    cursor: pointer;
+    border-radius: 3px;
+    text-transform: uppercase;
+    letter-spacing: 0.8px;
+  }
+  .lock-button:hover {
+    background: #212121;
+    border-color: #777;
+  }
+  .lock-button.unlocked {
+    background: #33210c;
+    border-color: #a56d20;
+    color: #ffdca7;
+  }
+  .hint {
+    margin-top: 6px;
+    font-size: 10px;
+    line-height: 1.45;
+    color: #8b8b8b;
+  }
+  #controlBody {
+    margin-top: 8px;
+  }
+  .section {
+    margin-top: 6px;
+  }
+  .section-head {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 3px 0;
+    cursor: pointer;
+    user-select: none;
+    border-bottom: 1px solid #2a2a2a;
+    font-size: 10px;
+    opacity: 0.78;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+  }
+  .section-head:hover {
+    opacity: 1;
+  }
+  .section-head .chev {
+    display: inline-block;
+    width: 10px;
+    transition: transform 0.15s;
+    opacity: 0.6;
+    font-size: 9px;
+  }
+  .section.closed .section-head .chev {
+    transform: rotate(-90deg);
+  }
+  .section-head .name {
+    flex: 1;
+  }
+  .section-head .count {
+    opacity: 0.4;
+    font-size: 9px;
+  }
+  .section-body {
+    padding: 4px 0 6px;
+  }
+  .section.closed .section-body {
+    display: none;
+  }
+  #controlBody h3 {
+    font-size: 9px;
+    margin: 6px 0 2px;
+    opacity: 0.4;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    font-weight: normal;
+  }
+  .empty-slot {
+    opacity: 0.3;
+    font-size: 10px;
+    padding: 4px 0;
+    font-style: italic;
+  }
+  .control-row {
+    display: flex;
+    align-items: center;
+    margin: 3px 0;
+    gap: 6px;
+  }
+  .control-row label {
+    opacity: 0.75;
+    min-width: 76px;
+    font-size: 10px;
+  }
+  .control-row input[type="range"] {
+    flex: 1;
+    min-width: 50px;
+  }
+  .control-row .val {
+    opacity: 0.6;
+    min-width: 42px;
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+    font-size: 10px;
+  }
+  .help {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 13px;
+    height: 13px;
+    min-width: 13px;
+    border: 1px solid #555;
+    border-radius: 50%;
+    font-size: 8px;
+    line-height: 1;
+    color: #888;
+    cursor: help;
+    user-select: none;
+  }
+  .help:hover {
+    border-color: #aaa;
+    color: #e0e0e0;
+    background: #1a1a1a;
+  }
+  .fire {
+    background: #2a2a2a;
+    border: 1px solid #555;
+    color: #e0e0e0;
+    font-family: inherit;
+    font-size: 9px;
+    padding: 1px 5px;
+    cursor: pointer;
+    border-radius: 2px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    flex-shrink: 0;
+  }
+  .fire:hover {
+    background: #3a3a3a;
+    border-color: #888;
+  }
+  .fire:disabled,
+  .control-row input:disabled,
+  .switcher select:disabled {
+    cursor: default;
+  }
+  .subhead {
+    font-size: 10px;
+    opacity: 0.72;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    margin-bottom: 6px;
+  }
+  #events {
+    max-height: 180px;
+    overflow-y: auto;
+    font-size: 11px;
+    background: #060606;
+    border: 1px solid #1a1a1a;
+    padding: 6px;
+  }
+  #events::-webkit-scrollbar {
+    width: 4px;
+  }
+  #events::-webkit-scrollbar-thumb {
+    background: #333;
+  }
+  .event {
+    color: #999;
+    padding: 1px 0;
+    font-variant-numeric: tabular-nums;
+    line-height: 1.45;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .event .time {
+    color: #555;
+    margin-right: 6px;
+  }
+  .event.trigger {
+    color: #fc9;
+  }
+  .event.scene {
+    color: #9fc;
+  }
+  .event.entropy {
+    color: #c9f;
+  }
+  .event.system {
+    color: #f7b86c;
+  }
+  #devlink {
+    margin-top: 8px;
+    font-size: 10px;
+    text-align: right;
+  }
+  #devlink a {
+    color: #666;
+    text-decoration: none;
+  }
+  #devlink a:hover {
+    color: #9cf;
+  }
+  .flash {
+    animation: flash 350ms ease-out;
+  }
+  @keyframes flash {
+    from { background: rgba(70, 90, 80, 0.6); }
+    to { background: rgba(10, 10, 10, 0.82); }
+  }
+  .entropy-pulse {
+    animation: pulse 200ms ease-out;
+  }
+  @keyframes pulse {
+    from { color: #c9f; transform: scale(1.08); }
+    to { color: #9cf; transform: scale(1); }
+  }
 </style>
 </head>
 <body>
 <canvas id="c"></canvas>
 
 <div id="panel">
-  <h2>ambience · live broadcast</h2>
-  <div class="row"><span class="k">scene</span><span class="v" id="sceneName">—</span></div>
-  <div class="row"><span class="k">remaining</span><span class="v" id="sceneRemaining">—</span></div>
-  <div class="row"><span class="k">up next</span><span class="v" id="nextName">—</span></div>
-  <div class="row"><span class="k">tick</span><span class="v" id="tick">0</span></div>
+  <h2>
+    <span>ambience live broadcast</span>
+    <span class="btnbar">
+      <button class="iconbtn" id="toggleAll" title="collapse or expand all control sections">[]</button>
+      <button class="iconbtn" id="togglePanel" title="collapse or expand panel (h)">-</button>
+    </span>
+  </h2>
+  <div class="panel-body" id="panelBody">
+    <div class="row"><span class="k">scene</span><span class="v" id="sceneName">-</span></div>
+    <div class="row"><span class="k">remaining</span><span class="v" id="sceneRemaining">-</span></div>
+    <div class="row"><span class="k">up next</span><span class="v" id="nextName">-</span></div>
+    <div class="row"><span class="k">tick</span><span class="v" id="tick">0</span></div>
 
-  <div class="section toggle">
-    <input type="checkbox" id="entropyToggle" checked>
-    <label for="entropyToggle">entropy capture</label>
-    <span class="v" id="entropyCount">0 B</span>
+    <div class="section-lite toggle">
+      <input type="checkbox" id="entropyToggle" checked>
+      <label for="entropyToggle">entropy capture</label>
+      <span class="v" id="entropyCount">0 B</span>
+    </div>
+
+    <div class="section-lite">
+      <div class="lock-row">
+        <div class="lock-copy">
+          <span class="eyebrow">live controls</span>
+          <span class="lock-state locked" id="lockState">view only</span>
+        </div>
+        <button class="lock-button" id="lockButton" type="button">unlock</button>
+      </div>
+      <div class="hint" id="lockHelp">Controls mirror the shared atmosphere, but slider moves and fire buttons stay inert until you unlock them.</div>
+    </div>
+
+    <div class="section-lite switcher">
+      <div class="switcher-row">
+        <label for="effectSelect">effect</label>
+        <select id="effectSelect" title="shared live effect"></select>
+      </div>
+      <div class="switcher-row">
+        <label for="presetSelect">preset</label>
+        <select id="presetSelect" title="apply effect preset"></select>
+      </div>
+    </div>
+
+    <div id="controlBody"></div>
+
+    <div class="section-lite">
+      <div class="subhead">event log</div>
+      <div id="events"></div>
+    </div>
+
+    <div id="devlink"><a href="/dev">/dev -&gt;</a></div>
   </div>
-
-  <div class="section">
-    <div id="events"></div>
-  </div>
-
-  <div id="devlink"><a href="/dev">/dev →</a></div>
 </div>
 
 <script src="/sim.js"></script>
+<script src="/controls.js"></script>
 <script>
 (() => {
   'use strict';
 
-  // Grid dims match the server's cmd/ambience/main.go gridW/gridH. Snapshots
-  // re-adopt server dims so this is more of an initial hint than a constraint.
-  const GRID_W = 160, GRID_H = 80;
+  const GRID_W = 160;
+  const GRID_H = 80;
 
   const canvas = document.getElementById('c');
   const ctx = canvas.getContext('2d');
+
   function resize() {
     const dpr = window.devicePixelRatio || 1;
     canvas.width = Math.floor(window.innerWidth * dpr);
@@ -83,11 +470,23 @@
   resize();
   window.addEventListener('resize', resize);
 
-  let effectType = 'rain';
-  let effect = new AmbienceSim.effects[effectType](GRID_W, GRID_H, {});
+  function newEffectInstance(name) {
+    const ctor = AmbienceSim.effects[name];
+    if (!ctor) throw new Error('unknown effect: ' + name);
+    return new ctor(GRID_W, GRID_H, {});
+  }
 
-  // Panel DOM refs.
+  let effectType = 'rain';
+  let effect = newEffectInstance(effectType);
+  let latestConfig = null;
+  let ready = false;
+  let schemaLoadToken = 0;
+
   const el = {
+    panel: document.getElementById('panel'),
+    panelBody: document.getElementById('panelBody'),
+    togglePanel: document.getElementById('togglePanel'),
+    toggleAll: document.getElementById('toggleAll'),
     sceneName: document.getElementById('sceneName'),
     sceneRemaining: document.getElementById('sceneRemaining'),
     nextName: document.getElementById('nextName'),
@@ -95,10 +494,57 @@
     entropyToggle: document.getElementById('entropyToggle'),
     entropyCount: document.getElementById('entropyCount'),
     events: document.getElementById('events'),
-    panel: document.getElementById('panel'),
+    lockButton: document.getElementById('lockButton'),
+    lockState: document.getElementById('lockState'),
+    lockHelp: document.getElementById('lockHelp'),
+    effectSelect: document.getElementById('effectSelect'),
+    presetSelect: document.getElementById('presetSelect'),
+    controlBody: document.getElementById('controlBody'),
   };
 
-  // ── Formatting helpers ─────────────────────────────────────
+  const controls = AmbienceControls.create({
+    root: el.controlBody,
+    effect: effectType,
+    effectOptions: (current) => [current],
+    effectSelect: el.effectSelect,
+    presetSelect: el.presetSelect,
+    toggleAll: el.toggleAll,
+    storagePrefix: 'ambience.live.section.',
+    locked: true,
+    canSwitchEffect: false,
+    onConfigChange: () => scheduleSharedConfigPush(),
+    onTrigger: (eventName) => triggerSharedEvent(eventName),
+  });
+
+  function setControlsLocked(locked) {
+    controls.setLocked(locked);
+    el.lockButton.textContent = locked ? 'unlock' : 'lock';
+    el.lockButton.classList.toggle('unlocked', !locked);
+    el.lockState.textContent = locked ? 'view only' : 'live mutations armed';
+    el.lockState.classList.toggle('locked', locked);
+    el.lockState.classList.toggle('unlocked', !locked);
+    el.lockHelp.textContent = locked
+      ? 'Controls mirror the shared atmosphere, but slider moves and fire buttons stay inert until you unlock them.'
+      : 'Slider moves, presets, and fire buttons now hit the shared atmosphere immediately. This is the deliberate havoc switch.';
+  }
+  setControlsLocked(true);
+
+  el.lockButton.addEventListener('click', () => {
+    setControlsLocked(!controls.isLocked());
+  });
+
+  function setPanelCollapsed(on) {
+    el.panel.classList.toggle('collapsed', on);
+    el.togglePanel.textContent = on ? '+' : '-';
+  }
+  el.togglePanel.addEventListener('click', () => {
+    setPanelCollapsed(!el.panel.classList.contains('collapsed'));
+  });
+  window.addEventListener('keydown', (event) => {
+    if (event.target && (event.target.tagName === 'INPUT' || event.target.tagName === 'BUTTON' || event.target.tagName === 'SELECT')) return;
+    if (event.key === 'h') setPanelCollapsed(!el.panel.classList.contains('collapsed'));
+  });
+
   function fmtDuration(ticks) {
     const secs = Math.max(0, Math.round(ticks / 10));
     const h = Math.floor(secs / 3600);
@@ -108,17 +554,32 @@
     if (m > 0) return m + 'm ' + String(s).padStart(2, '0') + 's';
     return s + 's';
   }
+
   function fmtBytes(n) {
     if (n < 1024) return n + ' B';
     if (n < 1024 * 1024) return (n / 1024).toFixed(1) + ' KB';
     return (n / 1024 / 1024).toFixed(2) + ' MB';
   }
+
   function nowTimestamp() {
     const d = new Date();
     return d.toTimeString().slice(0, 8);
   }
 
-  // ── Scene state (client-side interpolation of remaining time) ─
+  function log(text, kind) {
+    const div = document.createElement('div');
+    div.className = 'event' + (kind ? ' ' + kind : '');
+    const time = document.createElement('span');
+    time.className = 'time';
+    time.textContent = nowTimestamp();
+    const body = document.createElement('span');
+    body.textContent = text;
+    div.append(time, body);
+    el.events.appendChild(div);
+    while (el.events.children.length > 60) el.events.removeChild(el.events.firstChild);
+    el.events.scrollTop = el.events.scrollHeight;
+  }
+
   let serverTick = 0;
   let lastBeatAt = Date.now();
   let sceneStartTick = 0;
@@ -128,134 +589,178 @@
     if (sceneDurationTicks <= 0) return;
     const elapsedSecs = (Date.now() - lastBeatAt) / 1000;
     const tickNow = serverTick + Math.round(elapsedSecs * 10);
-    const rem = Math.max(0, sceneStartTick + sceneDurationTicks - tickNow);
-    el.sceneRemaining.textContent = fmtDuration(rem);
+    const remaining = Math.max(0, sceneStartTick + sceneDurationTicks - tickNow);
+    el.sceneRemaining.textContent = fmtDuration(remaining);
     el.tick.textContent = tickNow.toLocaleString();
   }
   setInterval(updateRemainingDisplay, 1000);
 
-  // ── Event log ────────────────────────────────────────────
-  function log(text, kind) {
-    const div = document.createElement('div');
-    div.className = 'event' + (kind ? ' ' + kind : '');
-    div.innerHTML = '<span class="time">' + nowTimestamp() + '</span>' + text;
-    el.events.appendChild(div);
-    // Cap at 40 lines; scroll to bottom.
-    while (el.events.children.length > 40) el.events.removeChild(el.events.firstChild);
-    el.events.scrollTop = el.events.scrollHeight;
+  async function loadSchema(effectName) {
+    const token = ++schemaLoadToken;
+    try {
+      const resp = await fetch('/effects/' + encodeURIComponent(effectName) + '/schema');
+      const schema = await resp.json();
+      if (token !== schemaLoadToken) return;
+      controls.setEffect(effectName);
+      controls.render(schema);
+      if (latestConfig) controls.setValues(latestConfig);
+    } catch (err) {
+      console.error('schema', err);
+      log('schema unavailable for ' + effectName, 'system');
+    }
   }
 
-  // ── SSE subscription ─────────────────────────────────────
-  // All five command kinds handled here (snapshot/config/trigger/scene/metric).
-  // We deliberately do NOT use AmbienceSim.subscribe — that helper only knows
-  // the first three kinds and we want scene/metric plumbed into the panel.
-  function applySnapshot(snap) {
-    const newType = (snap && snap.type) || 'rain';
-    if (newType !== effectType) {
-      const ctor = AmbienceSim.effects[newType];
-      if (!ctor) {
-        console.warn('live monitor: unknown effect type', newType);
-        return;
-      }
-      effectType = newType;
-      effect = new ctor(GRID_W, GRID_H, {});
+  function currentSharedQuery() {
+    const values = controls.currentValues();
+    const q = new URLSearchParams();
+    q.set('effect', effectType);
+    for (const knob of controls.getKnobs()) {
+      const value = values[knob.key];
+      if (value == null) continue;
+      q.set(knob.key, knob.type === 'int' ? String(Math.round(value)) : String(value));
     }
-    try { effect.restoreSnapshot(snap); } catch (e) { console.error('restoreSnapshot failed', e); }
+    return q.toString();
+  }
+
+  async function pushSharedConfig() {
+    if (controls.isLocked() || !controls.getSchema()) return;
+    try {
+      const resp = await fetch('/config?' + currentSharedQuery(), { method: 'POST' });
+      if (!resp.ok) throw new Error('config returned ' + resp.status);
+    } catch (err) {
+      console.error('shared config push', err);
+      log('live config push failed', 'system');
+    }
+  }
+
+  let debounceTimer = null;
+  function scheduleSharedConfigPush() {
+    if (controls.isLocked()) return;
+    if (debounceTimer) clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(pushSharedConfig, 150);
+  }
+
+  async function triggerSharedEvent(eventName) {
+    if (controls.isLocked()) return;
+    try {
+      const resp = await fetch('/trigger/' + encodeURIComponent(eventName) + '?effect=' + encodeURIComponent(effectType), {
+        method: 'POST',
+      });
+      if (!resp.ok) throw new Error('trigger returned ' + resp.status);
+    } catch (err) {
+      console.error('shared trigger', err);
+      log('trigger failed: ' + eventName, 'system');
+    }
+  }
+
+  function applySnapshot(snap) {
+    const nextType = (snap && snap.type) || 'rain';
+    const typeChanged = nextType !== effectType;
+    if (typeChanged) {
+      effectType = nextType;
+      controls.setEffect(effectType);
+      effect = newEffectInstance(effectType);
+      loadSchema(effectType);
+    }
+    try {
+      effect.restoreSnapshot(snap);
+    } catch (err) {
+      console.error('restoreSnapshot failed', err);
+    }
+    latestConfig = snap.config || null;
+    if (!typeChanged && latestConfig && controls.getSchema()) controls.setValues(latestConfig);
     if (snap.currentScene) {
-      el.sceneName.textContent = snap.currentScene.name || '—';
+      el.sceneName.textContent = snap.currentScene.name || '-';
       sceneDurationTicks = snap.currentScene.durationTicks || 0;
       sceneStartTick = snap.currentScene.startedAtTick || 0;
     }
-    if (snap.nextScene) {
-      el.nextName.textContent = snap.nextScene.name || '—';
-    }
-    if (typeof snap.entropyBytes === 'number') {
-      el.entropyCount.textContent = fmtBytes(snap.entropyBytes);
-    }
-    log('snapshot applied · tick ' + snap.tick, 'scene');
+    if (snap.nextScene) el.nextName.textContent = snap.nextScene.name || '-';
+    if (typeof snap.entropyBytes === 'number') el.entropyCount.textContent = fmtBytes(snap.entropyBytes);
+    if (typeof snap.sceneRemaining === 'number') el.sceneRemaining.textContent = fmtDuration(snap.sceneRemaining);
+    log('snapshot applied - tick ' + snap.tick, 'scene');
   }
 
-  let ready = false;
+  loadSchema(effectType);
+
   const es = new EventSource('/events');
   es.onmessage = (ev) => {
     let cmd;
-    try { cmd = JSON.parse(ev.data); } catch (e) { return; }
+    try {
+      cmd = JSON.parse(ev.data);
+    } catch (_) {
+      return;
+    }
     serverTick = cmd.tick || serverTick;
     lastBeatAt = Date.now();
 
-    // NOTE: cmd.data is already an object (server uses json.RawMessage which
-    // inlines into the enclosing JSON); no second JSON.parse needed.
     switch (cmd.kind) {
-      case 'snapshot': {
-        try { applySnapshot(cmd.data); } catch (e) { console.error(e); }
+      case 'snapshot':
+        applySnapshot(cmd.data);
         ready = true;
         break;
-      }
-      case 'config': {
-        try { effect.setConfig(cmd.data); } catch (e) {}
+      case 'config':
+        try {
+          effect.setConfig(cmd.data);
+        } catch (_) {}
+        latestConfig = cmd.data || null;
+        if (latestConfig && controls.getSchema()) controls.setValues(latestConfig);
         break;
-      }
-      case 'trigger': {
+      case 'trigger':
         effect.triggerEvent(cmd.event);
-        log(cmd.event + (cmd.desc ? ' · ' + cmd.desc : ''), 'trigger');
+        log(cmd.event + (cmd.desc ? ' - ' + cmd.desc : ''), 'trigger');
         break;
-      }
-      case 'scene': {
+      case 'scene':
         try {
-          const s = cmd.data;
-          el.sceneName.textContent = s.name || '—';
-          el.nextName.textContent = s.nextName || '—';
-          sceneDurationTicks = s.durationTicks || 0;
-          sceneStartTick = s.startedAtTick || 0;
-          log('scene → ' + s.name + ' · up next ' + s.nextName, 'scene');
+          const scene = cmd.data;
+          el.sceneName.textContent = scene.name || '-';
+          el.nextName.textContent = scene.nextName || '-';
+          sceneDurationTicks = scene.durationTicks || 0;
+          sceneStartTick = scene.startedAtTick || 0;
+          log('scene -> ' + scene.name + ' - up next ' + scene.nextName, 'scene');
           el.panel.classList.remove('flash');
-          void el.panel.offsetWidth; // restart animation
+          void el.panel.offsetWidth;
           el.panel.classList.add('flash');
-        } catch (e) { console.error(e); }
+        } catch (err) {
+          console.error(err);
+        }
         break;
-      }
-      case 'metric': {
+      case 'metric':
         try {
-          const m = cmd.data;
-          if (typeof m.entropyBytes === 'number') {
-            el.entropyCount.textContent = fmtBytes(m.entropyBytes);
-          }
-          // Metric doubles as a heartbeat for the tick/remaining display.
-        } catch (e) {}
+          const metric = cmd.data;
+          if (typeof metric.entropyBytes === 'number') el.entropyCount.textContent = fmtBytes(metric.entropyBytes);
+          if (typeof metric.sceneRemaining === 'number') el.sceneRemaining.textContent = fmtDuration(metric.sceneRemaining);
+          if (metric.currentName) el.sceneName.textContent = metric.currentName;
+          if (metric.nextName) el.nextName.textContent = metric.nextName;
+        } catch (_) {}
         break;
-      }
     }
   };
-  es.onerror = () => { log('sse disconnected · retrying', 'trigger'); };
+  es.onerror = () => {
+    log('sse disconnected - retrying', 'system');
+  };
 
-  // ── Local tick + render loop ────────────────────────────
-  setInterval(() => { if (ready) effect.step(); }, 100);
+  setInterval(() => {
+    if (ready) effect.step();
+  }, 100);
+
   (function draw() {
     effect.render(ctx, canvas.width, canvas.height);
     requestAnimationFrame(draw);
   })();
 
-  // ── Entropy capture (togglable) ─────────────────────────
-  // Keystrokes hashed to a single byte each (key charCode XOR low-byte of
-  // wall clock), buffered, POSTed to /entropy every 2s. Toggle off to stop
-  // contributing; the server keeps its accumulated entropy. Server's running
-  // byte count (via "metric" broadcasts) is authoritative for the counter.
   let entropyBuf = [];
   const ENTROPY_FLUSH_MS = 2000;
   const ENTROPY_MAX_BUFFERED = 256;
 
-  document.addEventListener('keydown', (e) => {
+  document.addEventListener('keydown', (event) => {
     if (!el.entropyToggle.checked) return;
-    // Skip modifier-only keypresses.
-    const k = (e.key && e.key.length === 1) ? e.key.charCodeAt(0) : 0;
-    if (k === 0) return;
+    const charCode = (event.key && event.key.length === 1) ? event.key.charCodeAt(0) : 0;
+    if (charCode === 0) return;
     const t = Date.now() & 0xff;
-    entropyBuf.push((k ^ t) & 0xff);
+    entropyBuf.push((charCode ^ t) & 0xff);
     if (entropyBuf.length > ENTROPY_MAX_BUFFERED) {
       entropyBuf.splice(0, entropyBuf.length - ENTROPY_MAX_BUFFERED);
     }
-    // Pulse the counter so keystrokes are visibly captured even before the
-    // server metric catches up.
     el.entropyCount.classList.remove('entropy-pulse');
     void el.entropyCount.offsetWidth;
     el.entropyCount.classList.add('entropy-pulse');
@@ -273,11 +778,10 @@
       }).then(() => {
         log('entropy +' + count + ' B', 'entropy');
       }).catch(() => {});
-    } catch (_) { /* swallow */ }
+    } catch (_) {}
   }, ENTROPY_FLUSH_MS);
 
-  // Initial log entry so the panel isn't empty on first paint.
-  log('connecting…');
+  log('connecting...', 'system');
 })();
 </script>
 </body>

--- a/cmd/ambience/web/sim.js
+++ b/cmd/ambience/web/sim.js
@@ -1356,6 +1356,434 @@
 		}
 	}
 
+	const DUST_DEFAULTS = {
+		intro_dur: 60,
+		intro_haze: 0.12,
+		intro_push: 1.5,
+		ending_dur: 60,
+		ending_linger: 20,
+		ending_residue: 0.08,
+		drift: 0.45,
+		wander: 0.35,
+		spawn: 4,
+		burst: 2,
+		max: 56,
+		trail: 3,
+		fade: 0.72,
+		hue: 32,
+		hue_sp: 10,
+		sat: 0.35,
+		lmin: 0.32,
+		lmax: 0.72,
+		layers: 2,
+		lbal: 0.45,
+		gust_p: 0,
+		calm_p: 0,
+		gust_dur: 50,
+		gust_mult: 1.8,
+		gust_front: 18,
+		calm_dur: 65,
+		calm_mult: 0.4,
+	};
+
+	function applyDustDefaults(cfg) {
+		const c = Object.assign({}, DUST_DEFAULTS, cfg || {});
+		if (c.intro_dur === 0 && c.intro_haze === 0 && c.intro_push === 0) {
+			c.intro_dur = DUST_DEFAULTS.intro_dur;
+			c.intro_haze = DUST_DEFAULTS.intro_haze;
+			c.intro_push = DUST_DEFAULTS.intro_push;
+		} else {
+			if (c.intro_dur <= 0) c.intro_dur = DUST_DEFAULTS.intro_dur;
+			if (c.intro_haze < 0) c.intro_haze = 0;
+			if (c.intro_push <= 0) c.intro_push = DUST_DEFAULTS.intro_push;
+		}
+		c.intro_haze = clamp01(c.intro_haze);
+		if (c.ending_dur === 0 && c.ending_linger === 0 && c.ending_residue === 0) {
+			c.ending_dur = DUST_DEFAULTS.ending_dur;
+			c.ending_linger = DUST_DEFAULTS.ending_linger;
+			c.ending_residue = DUST_DEFAULTS.ending_residue;
+		} else {
+			if (c.ending_dur <= 0) c.ending_dur = DUST_DEFAULTS.ending_dur;
+			if (c.ending_linger < 0) c.ending_linger = 0;
+			if (c.ending_residue < 0) c.ending_residue = 0;
+		}
+		c.ending_residue = clamp01(c.ending_residue);
+		if (c.drift === 0) c.drift = DUST_DEFAULTS.drift;
+		if (c.wander <= 0) c.wander = DUST_DEFAULTS.wander;
+		if (c.spawn <= 0) c.spawn = DUST_DEFAULTS.spawn;
+		if (c.burst <= 0) c.burst = DUST_DEFAULTS.burst;
+		if (c.max <= 0) c.max = DUST_DEFAULTS.max;
+		if (c.trail <= 0) c.trail = DUST_DEFAULTS.trail;
+		if (c.fade <= 0) c.fade = DUST_DEFAULTS.fade;
+		if (c.hue === 0) c.hue = DUST_DEFAULTS.hue;
+		if (c.hue_sp <= 0) c.hue_sp = DUST_DEFAULTS.hue_sp;
+		if (c.sat <= 0) c.sat = DUST_DEFAULTS.sat;
+		if (c.lmin <= 0) c.lmin = DUST_DEFAULTS.lmin;
+		if (c.lmax <= 0) c.lmax = DUST_DEFAULTS.lmax;
+		if (c.lmax < c.lmin) [c.lmin, c.lmax] = [c.lmax, c.lmin];
+		if (c.layers <= 0) c.layers = DUST_DEFAULTS.layers;
+		if (c.lbal <= 0) c.lbal = DUST_DEFAULTS.lbal;
+		if (c.gust_dur <= 0) c.gust_dur = DUST_DEFAULTS.gust_dur;
+		if (c.gust_mult <= 0) c.gust_mult = DUST_DEFAULTS.gust_mult;
+		if (c.gust_front <= 0) c.gust_front = DUST_DEFAULTS.gust_front;
+		if (c.calm_dur <= 0) c.calm_dur = DUST_DEFAULTS.calm_dur;
+		if (c.calm_mult <= 0) c.calm_mult = DUST_DEFAULTS.calm_mult;
+		return c;
+	}
+
+	class Dust {
+		constructor(w, h, cfg, seed) {
+			this.w = w;
+			this.h = h;
+			this.cfg = applyDustDefaults(cfg);
+			this.rng = makeRNG(seed || Date.now());
+			this.tick = 0;
+			this.grid = new Uint8ClampedArray(w * h * 3);
+			this.motes = [];
+			this.gustTicks = 0;
+			this.calmTicks = 0;
+			this.gustCenter = h * 0.5;
+			this.gustPush = 0;
+			this.introTicks = 0;
+			this.introTotal = 0;
+			this.endingTicks = 0;
+			this.endingTotal = 0;
+			this.endingFade = 0;
+		}
+
+		setConfig(cfg) {
+			const prev = this.cfg;
+			const next = applyDustDefaults(Object.assign({}, this.cfg, cfg));
+			if (prev && next.drift !== prev.drift) {
+				const delta = next.drift - prev.drift;
+				for (const mote of this.motes) {
+					mote.vCol += delta * (mote.background ? 0.72 : 1);
+				}
+			}
+			this.cfg = next;
+		}
+
+		restoreSnapshot(snap) {
+			const state = snap.state || snap;
+			this.setConfig(snap.config || {});
+			this.tick = state.tick || snap.tick || 0;
+			this.gustTicks = state.gustTicks || 0;
+			this.calmTicks = state.calmTicks || 0;
+			if (typeof state.gustCenter === 'number') this.gustCenter = state.gustCenter;
+			if (typeof state.gustPush === 'number') this.gustPush = state.gustPush;
+			this.introTicks = state.introTicks || 0;
+			this.introTotal = state.introTotal || 0;
+			this.endingTicks = state.endingTicks || 0;
+			this.endingTotal = state.endingTotal || 0;
+			this.endingFade = state.endingFade || 0;
+			if (typeof snap.seed === 'number') this.rng = makeRNG(snap.seed);
+			if (snap.gridW > 0 && snap.gridH > 0 &&
+				(snap.gridW !== this.w || snap.gridH !== this.h)) {
+				this.w = snap.gridW;
+				this.h = snap.gridH;
+				this.grid = new Uint8ClampedArray(this.w * this.h * 3);
+			}
+			this.motes = Array.isArray(state.motes) ? state.motes.map(m => ({
+				row: m.row,
+				col: m.col,
+				vRow: m.vRow,
+				vCol: m.vCol,
+				life: m.life,
+				maxLife: m.maxLife,
+				trail: m.trail,
+				color: m.color,
+				background: !!m.background,
+			})) : [];
+		}
+
+		triggerEvent(name) {
+			switch (name) {
+				case 'gust':
+					this._startGust(this.cfg.gust_mult);
+					return true;
+				case 'calm':
+					this.calmTicks = jitterInt(this.rng, this.cfg.calm_dur, 0.3);
+					return true;
+				case 'intro':
+					this._startIntro();
+					return true;
+				case 'ending':
+					this._startEnding();
+					return true;
+			}
+			return false;
+		}
+
+		step() {
+			this.tick++;
+			if (this.gustTicks > 0) this.gustTicks--;
+			else this.gustPush = 0;
+			if (this.calmTicks > 0) this.calmTicks--;
+			const introActive = this.introTicks > 0;
+			const endingActive = this.endingTicks > 0;
+
+			if (!introActive && !endingActive) {
+				if (this.gustTicks === 0 && this.rng() < this.cfg.gust_p) {
+					this._startGust(this.cfg.gust_mult);
+				}
+				if (this.calmTicks === 0 && this.rng() < this.cfg.calm_p) {
+					this.calmTicks = jitterInt(this.rng, this.cfg.calm_dur, 0.3);
+				}
+			}
+
+			this.grid.fill(0);
+			this._paintHaze();
+			this._spawnStep();
+			this._stepMotes();
+			this._paintMotes();
+
+			if (introActive) this.introTicks = Math.max(0, this.introTicks - 1);
+			if (endingActive) this.endingTicks = Math.max(0, this.endingTicks - 1);
+		}
+
+		render(ctx, canvasW, canvasH, opts) {
+			opts = opts || {};
+			if (opts.transparent) {
+				ctx.clearRect(0, 0, canvasW, canvasH);
+			} else {
+				ctx.fillStyle = opts.bg || '#0a0a0a';
+				ctx.fillRect(0, 0, canvasW, canvasH);
+			}
+			const sx = canvasW / this.w;
+			const sy = canvasH / this.h;
+			const ceilSx = Math.ceil(sx), ceilSy = Math.ceil(sy);
+			for (let y = 0; y < this.h; y++) {
+				for (let x = 0; x < this.w; x++) {
+					const i = (y * this.w + x) * 3;
+					const r = this.grid[i], g = this.grid[i + 1], b = this.grid[i + 2];
+					if (r === 0 && g === 0 && b === 0) continue;
+					ctx.fillStyle = `rgb(${r},${g},${b})`;
+					ctx.fillRect(Math.floor(x * sx), Math.floor(y * sy), ceilSx, ceilSy);
+				}
+			}
+		}
+
+		_startGust(mult) {
+			this.gustTicks = jitterInt(this.rng, this.cfg.gust_dur, 0.3);
+			this.gustCenter = this.h > 1 ? this.rng() * (this.h - 1) : 0;
+			let dir = this.cfg.drift;
+			if (Math.abs(dir) < 0.05) {
+				dir = this.rng() < 0.5 ? -0.35 : 0.35;
+			}
+			const sign = dir < 0 ? -1 : 1;
+			this.gustPush = sign * Math.max(0.18, Math.abs(dir)) * mult * (0.7 + this.rng() * 0.6);
+		}
+
+		_startIntro() {
+			this.calmTicks = 0;
+			this.gustTicks = 0;
+			this.gustPush = 0;
+			this.motes = [];
+			this.endingTicks = 0;
+			this.endingTotal = 0;
+			this.endingFade = 0;
+			this.introTotal = this.cfg.intro_dur > 0 ? this.cfg.intro_dur : DUST_DEFAULTS.intro_dur;
+			this.introTicks = this.introTotal;
+			this._startGust(Math.max(0.2, this.cfg.intro_push));
+		}
+
+		_startEnding() {
+			this.introTicks = 0;
+			this.introTotal = 0;
+			this.calmTicks = 0;
+			this.gustTicks = 0;
+			this.gustPush = 0;
+			this.endingFade = this.cfg.ending_dur > 0 ? this.cfg.ending_dur : DUST_DEFAULTS.ending_dur;
+			const linger = Math.max(0, this.cfg.ending_linger);
+			this.endingTotal = Math.max(1, this.endingFade + linger);
+			this.endingTicks = this.endingTotal;
+		}
+
+		_phaseProgress(total, left) {
+			if (left <= 1 || total <= 1) return 1;
+			const elapsed = total - left;
+			if (elapsed <= 0) return 0;
+			return clamp01(elapsed / (total - 1));
+		}
+
+		_densityLevel() {
+			let level = 1.0;
+			if (this.gustTicks > 0) level *= 1.25;
+			if (this.calmTicks > 0) level *= this.cfg.calm_mult;
+			if (this.introTicks > 0) {
+				const progress = this._phaseProgress(this.introTotal, this.introTicks);
+				level *= this.cfg.intro_haze + (1 - this.cfg.intro_haze) * progress;
+			}
+			if (this.endingTicks > 0) {
+				const progress = this._phaseProgress(this.endingTotal, this.endingTicks);
+				level *= 1 - (1 - this.cfg.ending_residue) * progress;
+			}
+			return Math.max(0.05, level);
+		}
+
+		_gustInfluence(row) {
+			if (this.gustTicks <= 0) return 0;
+			const half = Math.max(2, this.cfg.gust_front * 0.5);
+			const dist = Math.abs(row - this.gustCenter);
+			if (dist >= half) return 0;
+			return 1 - dist / half;
+		}
+
+		_spawnStep() {
+			if (this.motes.length >= this.cfg.max) return;
+			const level = this._densityLevel();
+			let spawnEvery = Math.round(this.cfg.spawn / Math.max(0.15, level));
+			if (spawnEvery < 1) spawnEvery = 1;
+			let attempts = 1;
+			if (level > 1) {
+				attempts += Math.floor(level);
+				if (this.rng() < (level - Math.floor(level))) attempts++;
+			}
+			for (let i = 0; i < attempts && this.motes.length < this.cfg.max; i++) {
+				if (this.rng.intn(spawnEvery) !== 0) continue;
+				let burst = 1;
+				if (this.cfg.burst > 1) burst = 1 + this.rng.intn(this.cfg.burst);
+				if (this.gustTicks > 0 && this.rng() < 0.35) burst++;
+				for (let j = 0; j < burst && this.motes.length < this.cfg.max; j++) {
+					this._spawnMote();
+				}
+			}
+		}
+
+		_spawnRow() {
+			if (this.h <= 1) return 0;
+			if (this.gustTicks > 0) {
+				const half = Math.max(2, this.cfg.gust_front * 0.5);
+				return Math.max(0, Math.min(this.h - 1, this.gustCenter + (this.rng() * 2 - 1) * half * 0.9));
+			}
+			const center = this.h * 0.58 + Math.sin(this.tick * 0.017) * this.h * 0.08;
+			const spread = Math.max(3, this.h * 0.28);
+			return Math.max(0, Math.min(this.h - 1, center + (this.rng() * 2 - 1) * spread));
+		}
+
+		_spawnMote() {
+			const isBG = this.cfg.layers >= 2 && this.rng() < this.cfg.lbal;
+			const row = this._spawnRow();
+			const gustInfluence = this._gustInfluence(row);
+			let drift = this.cfg.drift;
+			if (isBG) drift *= 0.72;
+			let vCol = drift * (0.7 + this.rng() * 0.6) + this.gustPush * gustInfluence * (0.45 + this.rng() * 0.25);
+			vCol += (this.rng() * 2 - 1) * this.cfg.wander * 0.05;
+			let vRow = (this.rng() * 2 - 1) * (0.03 + this.cfg.wander * 0.12);
+			if (isBG) vRow *= 0.7;
+			let trail = this.cfg.trail;
+			if (isBG) trail = Math.max(1, trail - 1);
+			const hue = ((this.cfg.hue + (this.rng() * 2 - 1) * this.cfg.hue_sp) % 360 + 360) % 360;
+			let light = this.cfg.lmin + this.rng() * (this.cfg.lmax - this.cfg.lmin);
+			if (isBG) light *= 0.78;
+			const color = hslToRGB(hue, this.cfg.sat, light);
+			const speed = Math.abs(vCol) + 0.15;
+			let lifeBase = Math.round(Math.max(24, this.w) / Math.max(0.12, speed));
+			lifeBase = Math.max(18, Math.min(260, lifeBase));
+			const life = jitterInt(this.rng, lifeBase, 0.3);
+			const edgePad = trail + 2;
+			let col = this.rng() * Math.max(1, this.w - 1);
+			if (vCol > 0.08) col = -edgePad + this.rng() * edgePad;
+			else if (vCol < -0.08) col = (this.w - 1) + this.rng() * edgePad;
+			this.motes.push({
+				row,
+				col,
+				vRow,
+				vCol,
+				life,
+				maxLife: life,
+				trail,
+				color,
+				background: isBG,
+			});
+		}
+
+		_stepMotes() {
+			if (!this.motes.length) return;
+			const alive = [];
+			for (const mote of this.motes) {
+				let wander = this.cfg.wander * 0.018;
+				if (mote.background) wander *= 0.75;
+				mote.vCol += (this.rng() * 2 - 1) * wander;
+				mote.vRow += (this.rng() * 2 - 1) * wander * 0.8;
+				let target = this.cfg.drift;
+				if (mote.background) target *= 0.72;
+				if (this.calmTicks > 0) target *= 0.88;
+				if (this.gustTicks > 0) {
+					const influence = this._gustInfluence(mote.row);
+					target += this.gustPush * (0.55 + 0.45 * influence);
+					mote.vRow += (this.rng() * 2 - 1) * influence * this.cfg.wander * 0.03;
+				}
+				mote.vCol += (target - mote.vCol) * 0.18;
+				mote.vRow = Math.max(-0.28, Math.min(0.28, mote.vRow));
+				let maxCol = Math.max(0.18, Math.abs(target) * 2.4 + 0.15);
+				if (mote.background) maxCol *= 0.8;
+				mote.vCol = Math.max(-maxCol, Math.min(maxCol, mote.vCol));
+				mote.col += mote.vCol;
+				mote.row += mote.vRow;
+				while (mote.row < 0) mote.row += Math.max(1, this.h);
+				while (mote.row >= this.h) mote.row -= Math.max(1, this.h);
+				mote.life--;
+				if (mote.life > 0 && mote.col >= -mote.trail - 2 && mote.col < this.w + mote.trail + 2) {
+					alive.push(mote);
+				}
+			}
+			this.motes = alive;
+		}
+
+		_paintHaze() {
+			const level = this._densityLevel();
+			if (level <= 0 || this.w <= 0 || this.h <= 0) return;
+			const center = this.h * 0.58 + Math.sin(this.tick * 0.013) * this.h * 0.04;
+			const spread = Math.max(4, this.h * 0.24);
+			for (let y = 0; y < this.h; y++) {
+				const rowInfluence = 1 - Math.abs(y - center) / spread;
+				if (rowInfluence <= 0) continue;
+				const gustRow = this._gustInfluence(y);
+				for (let x = 0; x < this.w; x++) {
+					const wave = 0.5 + 0.5 * Math.sin(x * 0.09 + y * 0.17 + this.tick * 0.04);
+					let strength = rowInfluence * level * (0.02 + 0.05 * wave);
+					if (gustRow > 0) {
+						const sweep = 0.6 + 0.4 * Math.sin(x * 0.12 - this.tick * 0.06);
+						strength += gustRow * 0.04 * sweep;
+					}
+					if (strength < 0.028) continue;
+					const hue = ((this.cfg.hue - 6 + Math.sin(x * 0.03) * this.cfg.hue_sp * 0.2) % 360 + 360) % 360;
+					const light = clamp01(this.cfg.lmin * (0.18 + 0.6 * strength));
+					const color = hslToRGB(hue, clamp01(this.cfg.sat * 0.35), light);
+					this._paintMax(y, x, color);
+				}
+			}
+		}
+
+		_paintMotes() {
+			for (const mote of this.motes) {
+				const lifeFade = clamp01(mote.life / Math.max(1, mote.maxLife));
+				if (lifeFade <= 0) continue;
+				const tail = Math.max(1, mote.trail);
+				for (let i = 0; i < tail; i++) {
+					const row = mote.row - i * mote.vRow * 0.75;
+					const col = mote.col - i * mote.vCol * 0.75;
+					const bright = Math.pow(this.cfg.fade, i) * (0.35 + 0.65 * lifeFade) * (mote.background ? 0.78 : 1);
+					this._paintMax(Math.round(row), Math.round(col), {
+						r: Math.floor(mote.color.r * bright),
+						g: Math.floor(mote.color.g * bright),
+						b: Math.floor(mote.color.b * bright),
+					});
+				}
+			}
+		}
+
+		_paintMax(row, col, color) {
+			if (row < 0 || row >= this.h || col < 0 || col >= this.w) return;
+			if (color.r === 0 && color.g === 0 && color.b === 0) return;
+			const i = (row * this.w + col) * 3;
+			if (color.r > this.grid[i]) this.grid[i] = color.r;
+			if (color.g > this.grid[i + 1]) this.grid[i + 1] = color.g;
+			if (color.b > this.grid[i + 2]) this.grid[i + 2] = color.b;
+		}
+	}
+
 	// Subscribe to an SSE command stream, applying messages to one effect
 	// instance. onReady is called once the initial snapshot has been applied.
 	function subscribe(url, rain, onReady) {
@@ -1390,8 +1818,103 @@
 	// server's snapshot payload — the client looks up the constructor here
 	// by name so new effects just register themselves and work without
 	// client-side changes.
-	const effects = { rain: Rain, fireflies: Fireflies, waterfall: Waterfall };
+	const effects = { rain: Rain, dust: Dust, fireflies: Fireflies, waterfall: Waterfall };
 	const presets = {
+		dust: [
+			{
+				key: 'lazy-dust',
+				label: 'lazy dust',
+				config: {
+					drift: 0.28,
+					wander: 0.22,
+					spawn: 5,
+					burst: 1,
+					max: 42,
+					trail: 2,
+					fade: 0.68,
+					hue: 28,
+					hue_sp: 8,
+					sat: 0.28,
+					lmin: 0.28,
+					lmax: 0.62,
+					gust_p: 0.0006,
+					calm_p: 0.0008,
+					gust_front: 14,
+					calm_mult: 0.35,
+				},
+			},
+			{
+				key: 'cross-breeze',
+				label: 'cross breeze',
+				config: {
+					drift: 0.58,
+					wander: 0.3,
+					spawn: 4,
+					burst: 2,
+					max: 60,
+					trail: 3,
+					fade: 0.74,
+					hue: 34,
+					hue_sp: 10,
+					sat: 0.36,
+					lmin: 0.32,
+					lmax: 0.72,
+					gust_p: 0.0012,
+					calm_p: 0.0004,
+					gust_mult: 1.7,
+					gust_front: 20,
+				},
+			},
+			{
+				key: 'dry-gusts',
+				label: 'dry gusts',
+				config: {
+					intro_push: 2.1,
+					drift: 0.78,
+					wander: 0.42,
+					spawn: 3,
+					burst: 2,
+					max: 72,
+					trail: 4,
+					fade: 0.76,
+					hue: 26,
+					hue_sp: 12,
+					sat: 0.42,
+					lmin: 0.34,
+					lmax: 0.76,
+					gust_p: 0.0018,
+					gust_dur: 65,
+					gust_mult: 2.25,
+					gust_front: 24,
+					calm_p: 0.0002,
+				},
+			},
+			{
+				key: 'dust-storm-edge',
+				label: 'dust storm edge',
+				config: {
+					intro_haze: 0.22,
+					ending_residue: 0.16,
+					drift: 1.05,
+					wander: 0.55,
+					spawn: 2,
+					burst: 3,
+					max: 92,
+					trail: 5,
+					fade: 0.8,
+					hue: 22,
+					hue_sp: 16,
+					sat: 0.48,
+					lmin: 0.36,
+					lmax: 0.8,
+					gust_p: 0.002,
+					gust_dur: 80,
+					gust_mult: 2.8,
+					gust_front: 30,
+					calm_p: 0.0001,
+				},
+			},
+		],
 		waterfall: [
 			{
 				key: 'thin-falls',
@@ -1494,5 +2017,5 @@
 		],
 	};
 
-	global.AmbienceSim = { Rain, Fireflies, Waterfall, subscribe, applyDefaults, hslToRGB, effects, presets };
+	global.AmbienceSim = { Rain, Dust, Fireflies, Waterfall, subscribe, applyDefaults, hslToRGB, effects, presets };
 })(window);

--- a/scripts/dev-deploy.ps1
+++ b/scripts/dev-deploy.ps1
@@ -1,11 +1,15 @@
 param(
 	[ValidateSet("all", "edge", "authority")]
 	[string]$Component = "all",
+	[ValidateSet("auto", "docker", "acr")]
+	[string]$Builder = "auto",
 	[string]$Namespace = "ambience-dev",
 	[string]$EdgeDeployment = "ambience-edge",
 	[string]$AuthorityStatefulSet = "ambience-authority",
 	[string]$ArgoNamespace = "argocd",
-	[string]$ArgoAppName = "ambience-dev"
+	[string]$ArgoAppName = "ambience-dev",
+	[string]$RegistryName = "romainecr",
+	[string]$ImageRepository = "ambience"
 )
 
 $ErrorActionPreference = "Stop"
@@ -51,6 +55,71 @@ function Test-ArgoApplication {
 	}
 }
 
+function Test-DockerAvailable {
+	try {
+		docker version --format '{{.Server.Version}}' *> $null
+		return $true
+	} catch {
+		return $false
+	}
+}
+
+function Test-AzAvailable {
+	try {
+		az account show --query id -o tsv *> $null
+		return $true
+	} catch {
+		return $false
+	}
+}
+
+function Resolve-BuildMode {
+	param([string]$Requested)
+
+	switch ($Requested) {
+		"docker" {
+			if (-not (Test-DockerAvailable)) {
+				throw "Builder 'docker' requested but Docker is not available."
+			}
+			return "docker"
+		}
+		"acr" {
+			if (-not (Test-AzAvailable)) {
+				throw "Builder 'acr' requested but Azure CLI is not available or not logged in."
+			}
+			return "acr"
+		}
+		default {
+			if (Test-DockerAvailable) {
+				return "docker"
+			}
+			if (Test-AzAvailable) {
+				return "acr"
+			}
+			throw "No build path available: Docker is unavailable and Azure CLI is not ready for ACR builds."
+		}
+	}
+}
+
+function Test-RegistryTagExists {
+	param(
+		[string]$RegistryName,
+		[string]$Repository,
+		[string]$Tag
+	)
+
+	try {
+		$match = az acr repository show-tags `
+			--name $RegistryName `
+			--repository $Repository `
+			--query "[?@=='$Tag'] | [0]" `
+			-o tsv 2>$null
+		return $match -eq $Tag
+	} catch {
+		return $false
+	}
+}
+
 function Set-WorkloadImage {
 	param(
 		[string]$Kind,
@@ -63,11 +132,13 @@ function Set-WorkloadImage {
 }
 
 $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+$registryLoginServer = "$RegistryName.azurecr.io"
 
 $head = (git -C $repoRoot rev-parse --short HEAD).Trim()
 $stamp = Get-Date -Format "yyyyMMddHHmmss"
 $tag = "devloop-$head-$stamp"
-$image = "romainecr.azurecr.io/ambience:$tag"
+$image = "$registryLoginServer/${ImageRepository}:$tag"
+$buildMode = Resolve-BuildMode -Requested $Builder
 
 $currentEdgeTag = Get-ImageTagFromResource -Kind deployment -Name $EdgeDeployment -Namespace $Namespace
 $currentAuthorityTag = Get-ImageTagFromResource -Kind statefulset -Name $AuthorityStatefulSet -Namespace $Namespace
@@ -94,12 +165,26 @@ $total = [System.Diagnostics.Stopwatch]::StartNew()
 $step = [System.Diagnostics.Stopwatch]::StartNew()
 $argoAppPresent = Test-ArgoApplication -Namespace $ArgoNamespace -Name $ArgoAppName
 
-docker build -t $image $repoRoot
-$buildSeconds = Format-Seconds $step
+switch ($buildMode) {
+	"docker" {
+		docker build -t $image $repoRoot
+		$buildSeconds = Format-Seconds $step
 
-$step.Restart()
-docker push $image
-$pushSeconds = Format-Seconds $step
+		$step.Restart()
+		az acr login --name $RegistryName | Out-Null
+		docker push $image
+		$pushSeconds = Format-Seconds $step
+	}
+	"acr" {
+		az acr build -r $RegistryName -t "${ImageRepository}:$tag" $repoRoot
+		$buildSeconds = Format-Seconds $step
+		$pushSeconds = 0.0
+	}
+}
+
+if (-not (Test-RegistryTagExists -RegistryName $RegistryName -Repository $ImageRepository -Tag $tag)) {
+	throw "Image tag '$tag' was not found in ACR after the build. Refusing to patch workloads."
+}
 
 if (-not $argoAppPresent) {
 	Write-Warning "Argo application '$ArgoAppName' was not found in namespace '$ArgoNamespace'. Patching live dev workloads anyway."
@@ -132,10 +217,12 @@ if ($Component -in @("all", "authority")) {
 $total.Stop()
 
 Write-Output "COMPONENT=$Component"
+Write-Output "BUILD_MODE=$buildMode"
 Write-Output "TAG=$tag"
 Write-Output "IMAGE=$image"
 Write-Output "ARGO_APP_PRESENT=$argoAppPresent"
 Write-Output "ARGO_DRIFT_EXPECTED=$argoAppPresent"
+Write-Output "REGISTRY_TAG_VERIFIED=true"
 Write-Output "EDGE_TAG=$nextEdgeTag"
 Write-Output "AUTHORITY_TAG=$nextAuthorityTag"
 Write-Output "BUILD_SECONDS=$buildSeconds"

--- a/scripts/dev-loop.ps1
+++ b/scripts/dev-loop.ps1
@@ -1,0 +1,152 @@
+param(
+	[string]$Namespace = "ambience-dev",
+	[string]$Selector = "app=ambience,component=edge",
+	[string]$LocalDir = (Join-Path $PSScriptRoot "..\\cmd\\ambience\\web"),
+	[string]$Container = "web-sync",
+	[string]$RemoteDir = "/var/run/ambience-web-override",
+	[int]$PollIntervalMs = 1000,
+	[switch]$Once
+)
+
+$ErrorActionPreference = "Stop"
+$script:TargetPod = $null
+
+if ($PollIntervalMs -lt 200) {
+	throw "PollIntervalMs must be at least 200."
+}
+
+$localRoot = (Get-Item -LiteralPath $LocalDir).FullName.TrimEnd("\", "/")
+
+function Get-ReadyEdgePodName {
+	$podList = kubectl get pod -n $Namespace -l $Selector -o json | ConvertFrom-Json
+	$candidates = @($podList.items) | Where-Object {
+		$_.status.phase -eq "Running" -and
+		@($_.status.conditions | Where-Object { $_.type -eq "Ready" -and $_.status -eq "True" }).Count -gt 0
+	} | Sort-Object { $_.metadata.creationTimestamp } -Descending
+
+	if (-not $candidates -or $candidates.Count -eq 0) {
+		throw "No ready edge pod found in namespace '$Namespace' for selector '$Selector'."
+	}
+
+	return $candidates[0].metadata.name
+}
+
+function Get-RelativeWebPath {
+	param([string]$FullPath)
+
+	$resolvedFullPath = (Get-Item -LiteralPath $FullPath).FullName
+	if (-not $resolvedFullPath.StartsWith($localRoot, [System.StringComparison]::OrdinalIgnoreCase)) {
+		throw "Path '$resolvedFullPath' is outside local root '$localRoot'."
+	}
+
+	$relative = $resolvedFullPath.Substring($localRoot.Length).TrimStart("\", "/")
+	return $relative.Replace("\", "/")
+}
+
+function Get-TargetPod {
+	if ([string]::IsNullOrWhiteSpace($script:TargetPod)) {
+		$script:TargetPod = Get-ReadyEdgePodName
+	}
+
+	return $script:TargetPod
+}
+
+function Get-RemotePath {
+	param([string]$RelativePath)
+
+	return ($RemoteDir.TrimEnd("/") + "/" + $RelativePath)
+}
+
+function Assert-DevLoopReady {
+	$pod = Get-TargetPod
+	kubectl exec $pod -n $Namespace -c $Container -- sh -c "mkdir -p '$RemoteDir' && test -d '$RemoteDir'" | Out-Null
+	return $pod
+}
+
+function Sync-WebFile {
+	param([string]$FullPath)
+
+	if (-not (Test-Path -LiteralPath $FullPath -PathType Leaf)) {
+		return
+	}
+
+	$pod = Get-TargetPod
+	$relative = Get-RelativeWebPath -FullPath $FullPath
+	$remotePath = Get-RemotePath -RelativePath $relative
+	$remoteDirPath = [System.IO.Path]::GetDirectoryName($remotePath.Replace("/", [System.IO.Path]::DirectorySeparatorChar)).Replace("\", "/")
+	if ([string]::IsNullOrWhiteSpace($remoteDirPath)) {
+		$remoteDirPath = $RemoteDir
+	}
+
+	$copySource = $relative.Replace("/", "\")
+	kubectl exec $pod -n $Namespace -c $Container -- sh -c "mkdir -p '$remoteDirPath'" | Out-Null
+	Push-Location $localRoot
+	try {
+		kubectl cp $copySource "${Namespace}/${pod}:$remotePath" -c $Container | Out-Null
+	} finally {
+		Pop-Location
+	}
+	Write-Host ("synced {0} -> {1}" -f $relative, $pod)
+}
+
+function Remove-WebFile {
+	param([string]$RelativePath)
+
+	$pod = Get-TargetPod
+	$remotePath = Get-RemotePath -RelativePath $RelativePath
+	kubectl exec $pod -n $Namespace -c $Container -- sh -c "rm -f '$remotePath'" | Out-Null
+	Write-Host ("removed {0} from {1}" -f $RelativePath, $pod)
+}
+
+function Get-WebState {
+	$state = @{}
+	Get-ChildItem -LiteralPath $localRoot -File -Recurse | ForEach-Object {
+		$relative = Get-RelativeWebPath -FullPath $_.FullName
+		$state[$relative] = "{0}:{1}" -f $_.LastWriteTimeUtc.Ticks, $_.Length
+	}
+	return $state
+}
+
+function Sync-AllWebFiles {
+	$paths = Get-ChildItem -LiteralPath $localRoot -File -Recurse | Sort-Object FullName
+	foreach ($path in $paths) {
+		Sync-WebFile -FullPath $path.FullName
+	}
+}
+
+$pod = Assert-DevLoopReady
+Write-Host ("dev loop target pod: {0}" -f $pod)
+Sync-AllWebFiles
+
+if ($Once) {
+	return
+}
+
+Write-Host ("watching {0} every {1}ms" -f $localRoot, $PollIntervalMs)
+$known = Get-WebState
+
+while ($true) {
+	Start-Sleep -Milliseconds $PollIntervalMs
+
+	try {
+		$current = Get-WebState
+
+		foreach ($relative in ($current.Keys | Sort-Object)) {
+			if (-not $known.ContainsKey($relative) -or $known[$relative] -ne $current[$relative]) {
+				$fullPath = Join-Path $localRoot ($relative -replace "/", "\")
+				Sync-WebFile -FullPath $fullPath
+			}
+		}
+
+		foreach ($relative in ($known.Keys | Sort-Object)) {
+			if (-not $current.ContainsKey($relative)) {
+				Remove-WebFile -RelativePath $relative
+			}
+		}
+
+		$known = $current
+	} catch {
+		$script:TargetPod = $null
+		Write-Warning $_
+	}
+}

--- a/sim/dust.go
+++ b/sim/dust.go
@@ -1,0 +1,907 @@
+package sim
+
+import (
+	"fmt"
+	"image/color"
+	"math"
+	"sync"
+
+	"github.com/nelsong6/ambience/rngutil"
+)
+
+type dustMote struct {
+	Row, Col   float64
+	VRow, VCol float64
+	Life       int
+	MaxLife    int
+	Trail      int
+	Color      color.RGBA
+	Background bool
+}
+
+// DustConfig tunes the drifting dust prototype used in isolated dev sessions.
+type DustConfig struct {
+	// INTRODUCTION
+	IntroDur  int     `json:"intro_dur"`
+	IntroHaze float64 `json:"intro_haze"`
+	IntroPush float64 `json:"intro_push"`
+	// ENDING
+	EndingDur     int     `json:"ending_dur"`
+	EndingLinger  int     `json:"ending_linger"`
+	EndingResidue float64 `json:"ending_residue"`
+	// LEVERS
+	Drift        float64 `json:"drift"`
+	Wander       float64 `json:"wander"`
+	SpawnEvery   int     `json:"spawn"`
+	SpawnBurst   int     `json:"burst"`
+	MaxDust      int     `json:"max"`
+	Trail        int     `json:"trail"`
+	Fade         float64 `json:"fade"`
+	Hue          float64 `json:"hue"`
+	HueSpread    float64 `json:"hue_sp"`
+	Saturation   float64 `json:"sat"`
+	LightnessMin float64 `json:"lmin"`
+	LightnessMax float64 `json:"lmax"`
+	Layers       int     `json:"layers"`
+	LayerBalance float64 `json:"lbal"`
+	// EVENT CHANCES
+	GustChance float64 `json:"gust_p"`
+	CalmChance float64 `json:"calm_p"`
+	// EVENT MODIFIERS
+	GustDur   int     `json:"gust_dur"`
+	GustMult  float64 `json:"gust_mult"`
+	GustFront float64 `json:"gust_front"`
+	CalmDur   int     `json:"calm_dur"`
+	CalmMult  float64 `json:"calm_mult"`
+}
+
+func (c DustConfig) withDefaults() DustConfig {
+	if c.IntroDur == 0 && c.IntroHaze == 0 && c.IntroPush == 0 {
+		c.IntroDur = 60
+		c.IntroHaze = 0.12
+		c.IntroPush = 1.5
+	} else {
+		if c.IntroDur <= 0 {
+			c.IntroDur = 60
+		}
+		if c.IntroHaze < 0 {
+			c.IntroHaze = 0
+		}
+		if c.IntroPush <= 0 {
+			c.IntroPush = 1.5
+		}
+	}
+	c.IntroHaze = clamp01(c.IntroHaze)
+	if c.EndingDur == 0 && c.EndingLinger == 0 && c.EndingResidue == 0 {
+		c.EndingDur = 60
+		c.EndingLinger = 20
+		c.EndingResidue = 0.08
+	} else {
+		if c.EndingDur <= 0 {
+			c.EndingDur = 60
+		}
+		if c.EndingLinger < 0 {
+			c.EndingLinger = 0
+		}
+		if c.EndingResidue < 0 {
+			c.EndingResidue = 0
+		}
+	}
+	c.EndingResidue = clamp01(c.EndingResidue)
+	if c.Drift == 0 {
+		c.Drift = 0.45
+	}
+	if c.Wander <= 0 {
+		c.Wander = 0.35
+	}
+	if c.SpawnEvery <= 0 {
+		c.SpawnEvery = 4
+	}
+	if c.SpawnBurst <= 0 {
+		c.SpawnBurst = 2
+	}
+	if c.MaxDust <= 0 {
+		c.MaxDust = 56
+	}
+	if c.Trail <= 0 {
+		c.Trail = 3
+	}
+	if c.Fade <= 0 {
+		c.Fade = 0.72
+	}
+	if c.Hue == 0 {
+		c.Hue = 32
+	}
+	if c.HueSpread <= 0 {
+		c.HueSpread = 10
+	}
+	if c.Saturation <= 0 {
+		c.Saturation = 0.35
+	}
+	if c.LightnessMin <= 0 {
+		c.LightnessMin = 0.32
+	}
+	if c.LightnessMax <= 0 {
+		c.LightnessMax = 0.72
+	}
+	if c.LightnessMax < c.LightnessMin {
+		c.LightnessMin, c.LightnessMax = c.LightnessMax, c.LightnessMin
+	}
+	if c.Layers <= 0 {
+		c.Layers = 2
+	}
+	if c.LayerBalance <= 0 {
+		c.LayerBalance = 0.45
+	}
+	if c.GustDur <= 0 {
+		c.GustDur = 50
+	}
+	if c.GustMult <= 0 {
+		c.GustMult = 1.8
+	}
+	if c.GustFront <= 0 {
+		c.GustFront = 18
+	}
+	if c.CalmDur <= 0 {
+		c.CalmDur = 65
+	}
+	if c.CalmMult <= 0 {
+		c.CalmMult = 0.4
+	}
+	return c
+}
+
+// DustSchema describes the Dust effect's tunable knobs for the dev UI.
+func DustSchema() EffectSchema {
+	return EffectSchema{
+		Name: "dust",
+		Knobs: []Knob{
+			{Key: "intro_dur", Label: "intro dur", Slot: SlotSpawn, Group: "introduction", Type: KnobInt, Min: 10, Max: 240, Step: 5, Default: 60, Trigger: "intro",
+				Description: "Ticks spent building from thin residue into a readable drifting dust field."},
+			{Key: "intro_haze", Label: "intro haze", Slot: SlotSpawn, Group: "introduction", Type: KnobFloat, Min: 0.02, Max: 0.9, Step: 0.02, Default: 0.12,
+				Description: "Starting dust-density fraction during the intro before the full field arrives."},
+			{Key: "intro_push", Label: "first-hit x", Slot: SlotSpawn, Group: "introduction", Type: KnobFloat, Min: 0.2, Max: 3, Step: 0.05, Default: 1.5,
+				Description: "Strength of the first gust front that establishes motion when intro fires."},
+			{Key: "ending_dur", Label: "ending dur", Slot: SlotEnd, Group: "ending", Type: KnobInt, Min: 10, Max: 240, Step: 5, Default: 60, Trigger: "ending",
+				Description: "Ticks spent tapering the dust field back toward thin residue."},
+			{Key: "ending_linger", Label: "ending linger", Slot: SlotEnd, Group: "ending", Type: KnobInt, Min: 0, Max: 120, Step: 5, Default: 20,
+				Description: "Extra quiet ticks after the taper so the last streaks can drift out."},
+			{Key: "ending_residue", Label: "residue", Slot: SlotEnd, Group: "ending", Type: KnobFloat, Min: 0, Max: 0.8, Step: 0.02, Default: 0.08,
+				Description: "How much dust haze remains at the end of the outro instead of dropping to black."},
+			{Key: "drift", Label: "drift", Slot: SlotLever, Group: "motion", Type: KnobFloat, Min: -2.5, Max: 2.5, Step: 0.05, Default: 0.45,
+				Description: "Base horizontal carry. Positive drifts right, negative drifts left."},
+			{Key: "wander", Label: "wander", Slot: SlotLever, Group: "motion", Type: KnobFloat, Min: 0.05, Max: 1, Step: 0.05, Default: 0.35,
+				Description: "Random jitter in the dust motion. Higher values loosen the field into rougher air."},
+			{Key: "spawn", Label: "spawn 1/", Slot: SlotLever, Group: "density", Type: KnobInt, Min: 1, Max: 20, Step: 1, Default: 4,
+				Description: "One-in-N roll for a new dust burst each tick while under the particle cap."},
+			{Key: "burst", Label: "burst max", Slot: SlotLever, Group: "density", Type: KnobInt, Min: 1, Max: 8, Step: 1, Default: 2,
+				Description: "Maximum motes emitted per successful spawn roll."},
+			{Key: "max", Label: "max motes", Slot: SlotLever, Group: "density", Type: KnobInt, Min: 4, Max: 160, Step: 1, Default: 56,
+				Description: "Maximum number of live dust motes drifting across the field."},
+			{Key: "trail", Label: "trail", Slot: SlotLever, Group: "shape", Type: KnobInt, Min: 1, Max: 8, Step: 1, Default: 3,
+				Description: "Pixels painted behind each mote along its current motion vector."},
+			{Key: "fade", Label: "fade", Slot: SlotLever, Group: "shape", Type: KnobFloat, Min: 0.35, Max: 1, Step: 0.01, Default: 0.72,
+				Description: "Brightness multiplier down each dust trail. Lower values give a softer tail."},
+			{Key: "hue", Label: "hue", Slot: SlotLever, Group: "color", Type: KnobFloat, Min: 8, Max: 80, Step: 1, Default: 32,
+				Description: "Base dust hue. Lower values warm toward rust; higher values lean pale straw."},
+			{Key: "hue_sp", Label: "hue spread", Slot: SlotLever, Group: "color", Type: KnobFloat, Min: 0, Max: 40, Step: 1, Default: 10,
+				Description: "Variation in dust color across the field and haze."},
+			{Key: "sat", Label: "saturation", Slot: SlotLever, Group: "color", Type: KnobFloat, Min: 0.05, Max: 1, Step: 0.01, Default: 0.35,
+				Description: "Overall color saturation of the dust."},
+			{Key: "lmin", Label: "light min", Slot: SlotLever, Group: "color", Type: KnobFloat, Min: 0.05, Max: 0.8, Step: 0.01, Default: 0.32,
+				Description: "Minimum lightness used for the haze and dimmer motes."},
+			{Key: "lmax", Label: "light max", Slot: SlotLever, Group: "color", Type: KnobFloat, Min: 0.05, Max: 0.95, Step: 0.01, Default: 0.72,
+				Description: "Maximum lightness used for the brightest dust streaks."},
+			{Key: "layers", Label: "layers", Slot: SlotLever, Group: "depth", Type: KnobInt, Min: 1, Max: 2, Step: 1, Default: 2,
+				Description: "1 = single layer. 2 = adds a dimmer background layer for more atmospheric depth."},
+			{Key: "lbal", Label: "bg balance", Slot: SlotLever, Group: "depth", Type: KnobFloat, Min: 0.05, Max: 0.95, Step: 0.05, Default: 0.45,
+				Description: "Fraction of dust motes assigned to the background layer when layers=2."},
+			{Key: "gust_p", Label: "gust", Slot: SlotEvent, Type: KnobFloat, Min: 0, Max: 0.02, Step: 0.0005, Default: 0, Trigger: "gust",
+				Description: "Per-tick chance of a stronger gust front sweeping through the field."},
+			{Key: "calm_p", Label: "calm", Slot: SlotEvent, Type: KnobFloat, Min: 0, Max: 0.02, Step: 0.0005, Default: 0, Trigger: "calm",
+				Description: "Per-tick chance of a quieter low-density stretch."},
+			{Key: "gust_dur", Label: "gust dur", Slot: SlotEventMod, Group: "gust", Type: KnobInt, Min: 10, Max: 240, Step: 5, Default: 50,
+				Description: "Typical gust duration in ticks (jittered by +/-30%)."},
+			{Key: "gust_mult", Label: "gust x", Slot: SlotEventMod, Group: "gust", Type: KnobFloat, Min: 1.05, Max: 4, Step: 0.05, Default: 1.8,
+				Description: "Strength multiplier applied to the gust's lateral push."},
+			{Key: "gust_front", Label: "front width", Slot: SlotEventMod, Group: "gust", Type: KnobFloat, Min: 4, Max: 60, Step: 1, Default: 18,
+				Description: "Vertical thickness of the active gust front band."},
+			{Key: "calm_dur", Label: "calm dur", Slot: SlotEventMod, Group: "calm", Type: KnobInt, Min: 10, Max: 240, Step: 5, Default: 65,
+				Description: "Duration of the calmer low-density window."},
+			{Key: "calm_mult", Label: "calm x", Slot: SlotEventMod, Group: "calm", Type: KnobFloat, Min: 0.1, Max: 1, Step: 0.05, Default: 0.4,
+				Description: "Density multiplier applied while calm is active."},
+		},
+	}
+}
+
+type DustState struct {
+	Tick        int     `json:"tick"`
+	GustTicks   int     `json:"gustTicks"`
+	CalmTicks   int     `json:"calmTicks"`
+	GustCenter  float64 `json:"gustCenter"`
+	GustPush    float64 `json:"gustPush"`
+	IntroTicks  int     `json:"introTicks"`
+	IntroTotal  int     `json:"introTotal"`
+	EndingTicks int     `json:"endingTicks"`
+	EndingTotal int     `json:"endingTotal"`
+	EndingFade  int     `json:"endingFade"`
+}
+
+type DustMote struct {
+	Row        float64 `json:"row"`
+	Col        float64 `json:"col"`
+	VRow       float64 `json:"vRow"`
+	VCol       float64 `json:"vCol"`
+	Life       int     `json:"life"`
+	MaxLife    int     `json:"maxLife"`
+	Trail      int     `json:"trail"`
+	Color      RGB     `json:"color"`
+	Background bool    `json:"background"`
+}
+
+type DustSnapshot struct {
+	DustState
+	Motes []DustMote `json:"motes"`
+}
+
+type DustPersistedState struct {
+	DustState
+	RNGState uint64     `json:"rngState"`
+	Motes    []DustMote `json:"motes"`
+}
+
+// Dust is a drifting field of horizontal dust motes for isolated dev sessions.
+type Dust struct {
+	mu sync.Mutex
+
+	W, H  int
+	Grid  [][]Pixel
+	motes []dustMote
+	rng   *rngutil.RNG
+	cfg   DustConfig
+	tick  int
+
+	gustTicks   int
+	calmTicks   int
+	gustCenter  float64
+	gustPush    float64
+	introTicks  int
+	introTotal  int
+	endingTicks int
+	endingTotal int
+	endingFade  int
+
+	log []LogEntry
+}
+
+func NewDust(w, h int, seed int64, cfg DustConfig) *Dust {
+	grid := make([][]Pixel, h)
+	for i := range grid {
+		grid[i] = make([]Pixel, w)
+	}
+	return &Dust{
+		W:          w,
+		H:          h,
+		Grid:       grid,
+		rng:        rngutil.New(seed),
+		cfg:        cfg.withDefaults(),
+		gustCenter: float64(h) * 0.5,
+	}
+}
+
+func (d *Dust) Resize(w, h int) {
+	if w <= 0 || h <= 0 {
+		return
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if w == d.W && h == d.H {
+		return
+	}
+	d.W = w
+	d.H = h
+	d.Grid = make([][]Pixel, h)
+	for i := range d.Grid {
+		d.Grid[i] = make([]Pixel, w)
+	}
+	if d.gustCenter >= float64(h) {
+		d.gustCenter = float64(h) * 0.5
+	}
+}
+
+func (d *Dust) SetConfig(cfg DustConfig) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	newCfg := cfg.withDefaults()
+	if newCfg.Drift != d.cfg.Drift {
+		delta := newCfg.Drift - d.cfg.Drift
+		for i := range d.motes {
+			scale := 1.0
+			if d.motes[i].Background {
+				scale = 0.72
+			}
+			d.motes[i].VCol += delta * scale
+		}
+	}
+	d.cfg = newCfg
+}
+
+func (d *Dust) EffectiveConfig() DustConfig {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.cfg
+}
+
+func (d *Dust) SnapshotState() DustState {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.snapshotStateLocked()
+}
+
+func (d *Dust) Snapshot() DustSnapshot {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return DustSnapshot{
+		DustState: d.snapshotStateLocked(),
+		Motes:     d.copyMotesLocked(),
+	}
+}
+
+func (d *Dust) RestoreState(s DustState) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.restoreStateLocked(s)
+}
+
+func (d *Dust) RestoreSnapshot(s DustSnapshot) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.restoreStateLocked(s.DustState)
+	d.restoreMotesLocked(s.Motes)
+	d.rebuildGridLocked()
+}
+
+func (d *Dust) SnapshotPersistedState() DustPersistedState {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return DustPersistedState{
+		DustState: d.snapshotStateLocked(),
+		RNGState:  d.rng.State(),
+		Motes:     d.copyMotesLocked(),
+	}
+}
+
+func (d *Dust) RestorePersistedState(s DustPersistedState) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.restoreStateLocked(s.DustState)
+	if s.RNGState != 0 {
+		d.rng.SetState(s.RNGState)
+	}
+	d.restoreMotesLocked(s.Motes)
+	d.rebuildGridLocked()
+}
+
+func (d *Dust) CurrentTick() int {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.tick
+}
+
+func (d *Dust) PerturbRNG(delta int64) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.rng.Mix(delta)
+}
+
+func (d *Dust) TriggerEvent(name string) bool {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	switch name {
+	case "gust":
+		d.startGustLocked(d.cfg.GustMult)
+		d.appendLog("gust", fmt.Sprintf("triggered (dur=%d, row=%.0f, push=%+.2f)", d.gustTicks, d.gustCenter, d.gustPush))
+	case "calm":
+		d.calmTicks = jitterInt(d.rng, d.cfg.CalmDur, 0.3)
+		d.appendLog("calm", fmt.Sprintf("triggered (dur=%d, x%.2f)", d.calmTicks, d.cfg.CalmMult))
+	case "intro":
+		d.startIntroductionLocked()
+		d.appendLog("intro", fmt.Sprintf("started (dur=%d, haze=%.2f, push=%.2f)", d.introTotal, d.cfg.IntroHaze, d.cfg.IntroPush))
+	case "ending":
+		d.startEndingLocked()
+		d.appendLog("ending", fmt.Sprintf("started (fade=%d, linger=%d, residue=%.2f)", d.endingFade, d.endingTotal-d.endingFade, d.cfg.EndingResidue))
+	default:
+		return false
+	}
+	return true
+}
+
+func (d *Dust) DrainLog() []LogEntry {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if len(d.log) == 0 {
+		return nil
+	}
+	out := d.log
+	d.log = nil
+	return out
+}
+
+func (d *Dust) appendLog(kind, desc string) {
+	d.log = append(d.log, LogEntry{Tick: d.tick, Type: kind, Desc: desc})
+	if len(d.log) > 200 {
+		d.log = d.log[len(d.log)-200:]
+	}
+}
+
+func (d *Dust) Step() {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	d.tick++
+	if d.gustTicks > 0 {
+		d.gustTicks--
+	} else {
+		d.gustPush = 0
+	}
+	if d.calmTicks > 0 {
+		d.calmTicks--
+	}
+	introActive := d.introTicks > 0
+	endingActive := d.endingTicks > 0
+
+	if !introActive && !endingActive {
+		if d.gustTicks == 0 && d.rng.Float64() < d.cfg.GustChance {
+			d.startGustLocked(d.cfg.GustMult)
+			d.appendLog("gust", fmt.Sprintf("started (dur=%d, row=%.0f, push=%+.2f)", d.gustTicks, d.gustCenter, d.gustPush))
+		}
+		if d.calmTicks == 0 && d.rng.Float64() < d.cfg.CalmChance {
+			d.calmTicks = jitterInt(d.rng, d.cfg.CalmDur, 0.3)
+			d.appendLog("calm", fmt.Sprintf("started (dur=%d, x%.2f)", d.calmTicks, d.cfg.CalmMult))
+		}
+	}
+
+	d.clearGridLocked()
+	d.paintHazeLocked()
+	d.spawnStepLocked()
+	d.stepMotesLocked()
+	d.paintMotesLocked()
+
+	if introActive {
+		d.introTicks--
+		if d.introTicks < 0 {
+			d.introTicks = 0
+		}
+	}
+	if endingActive {
+		d.endingTicks--
+		if d.endingTicks < 0 {
+			d.endingTicks = 0
+		}
+	}
+}
+
+func (d *Dust) snapshotStateLocked() DustState {
+	return DustState{
+		Tick:        d.tick,
+		GustTicks:   d.gustTicks,
+		CalmTicks:   d.calmTicks,
+		GustCenter:  d.gustCenter,
+		GustPush:    d.gustPush,
+		IntroTicks:  d.introTicks,
+		IntroTotal:  d.introTotal,
+		EndingTicks: d.endingTicks,
+		EndingTotal: d.endingTotal,
+		EndingFade:  d.endingFade,
+	}
+}
+
+func (d *Dust) restoreStateLocked(s DustState) {
+	d.tick = s.Tick
+	d.gustTicks = s.GustTicks
+	d.calmTicks = s.CalmTicks
+	d.gustCenter = s.GustCenter
+	d.gustPush = s.GustPush
+	d.introTicks = s.IntroTicks
+	d.introTotal = s.IntroTotal
+	d.endingTicks = s.EndingTicks
+	d.endingTotal = s.EndingTotal
+	d.endingFade = s.EndingFade
+}
+
+func (d *Dust) copyMotesLocked() []DustMote {
+	out := make([]DustMote, len(d.motes))
+	for i, m := range d.motes {
+		out[i] = DustMote{
+			Row:        m.Row,
+			Col:        m.Col,
+			VRow:       m.VRow,
+			VCol:       m.VCol,
+			Life:       m.Life,
+			MaxLife:    m.MaxLife,
+			Trail:      m.Trail,
+			Color:      RGB{R: m.Color.R, G: m.Color.G, B: m.Color.B},
+			Background: m.Background,
+		}
+	}
+	return out
+}
+
+func (d *Dust) restoreMotesLocked(list []DustMote) {
+	d.motes = make([]dustMote, len(list))
+	for i, m := range list {
+		d.motes[i] = dustMote{
+			Row:        m.Row,
+			Col:        m.Col,
+			VRow:       m.VRow,
+			VCol:       m.VCol,
+			Life:       m.Life,
+			MaxLife:    m.MaxLife,
+			Trail:      m.Trail,
+			Color:      color.RGBA{R: m.Color.R, G: m.Color.G, B: m.Color.B, A: 255},
+			Background: m.Background,
+		}
+	}
+}
+
+func (d *Dust) rebuildGridLocked() {
+	d.clearGridLocked()
+	d.paintHazeLocked()
+	d.paintMotesLocked()
+}
+
+func (d *Dust) startGustLocked(mult float64) {
+	d.gustTicks = jitterInt(d.rng, d.cfg.GustDur, 0.3)
+	if d.H > 1 {
+		d.gustCenter = d.rng.Float64() * float64(d.H-1)
+	} else {
+		d.gustCenter = 0
+	}
+	dir := d.cfg.Drift
+	if math.Abs(dir) < 0.05 {
+		dir = 0.35
+		if d.rng.Float64() < 0.5 {
+			dir = -dir
+		}
+	}
+	sign := 1.0
+	if dir < 0 {
+		sign = -1
+	}
+	d.gustPush = sign * math.Max(0.18, math.Abs(dir)) * mult * (0.7 + d.rng.Float64()*0.6)
+}
+
+func (d *Dust) startIntroductionLocked() {
+	d.calmTicks = 0
+	d.gustTicks = 0
+	d.gustPush = 0
+	d.motes = nil
+	d.endingTicks = 0
+	d.endingTotal = 0
+	d.endingFade = 0
+	d.introTotal = d.cfg.IntroDur
+	if d.introTotal <= 0 {
+		d.introTotal = 60
+	}
+	d.introTicks = d.introTotal
+	d.startGustLocked(math.Max(0.2, d.cfg.IntroPush))
+}
+
+func (d *Dust) startEndingLocked() {
+	d.introTicks = 0
+	d.introTotal = 0
+	d.calmTicks = 0
+	d.gustTicks = 0
+	d.gustPush = 0
+	d.endingFade = d.cfg.EndingDur
+	if d.endingFade <= 0 {
+		d.endingFade = 60
+	}
+	linger := d.cfg.EndingLinger
+	if linger < 0 {
+		linger = 0
+	}
+	d.endingTotal = d.endingFade + linger
+	if d.endingTotal < 1 {
+		d.endingTotal = d.endingFade
+	}
+	d.endingTicks = d.endingTotal
+}
+
+func (d *Dust) densityLevelLocked() float64 {
+	level := 1.0
+	if d.gustTicks > 0 {
+		level *= 1.25
+	}
+	if d.calmTicks > 0 {
+		level *= d.cfg.CalmMult
+	}
+	if d.introTicks > 0 {
+		progress := phaseProgress(d.introTotal, d.introTicks)
+		level *= d.cfg.IntroHaze + (1-d.cfg.IntroHaze)*progress
+	}
+	if d.endingTicks > 0 {
+		progress := phaseProgress(d.endingTotal, d.endingTicks)
+		level *= 1 - (1-d.cfg.EndingResidue)*progress
+	}
+	if level < 0.05 {
+		level = 0.05
+	}
+	return level
+}
+
+func (d *Dust) gustInfluenceAtRowLocked(row float64) float64 {
+	if d.gustTicks <= 0 {
+		return 0
+	}
+	half := math.Max(2, d.cfg.GustFront*0.5)
+	dist := math.Abs(row - d.gustCenter)
+	if dist >= half {
+		return 0
+	}
+	return 1 - dist/half
+}
+
+func (d *Dust) clearGridLocked() {
+	for y := range d.Grid {
+		for x := range d.Grid[y] {
+			d.Grid[y][x] = Pixel{}
+		}
+	}
+}
+
+func (d *Dust) spawnStepLocked() {
+	if len(d.motes) >= d.cfg.MaxDust {
+		return
+	}
+	level := d.densityLevelLocked()
+	spawnEvery := int(math.Round(float64(d.cfg.SpawnEvery) / math.Max(0.15, level)))
+	if spawnEvery < 1 {
+		spawnEvery = 1
+	}
+	attempts := 1
+	if level > 1 {
+		attempts += int(math.Floor(level))
+		if d.rng.Float64() < level-math.Floor(level) {
+			attempts++
+		}
+	}
+	for i := 0; i < attempts && len(d.motes) < d.cfg.MaxDust; i++ {
+		if d.rng.Intn(spawnEvery) != 0 {
+			continue
+		}
+		burst := 1
+		if d.cfg.SpawnBurst > 1 {
+			burst = 1 + d.rng.Intn(d.cfg.SpawnBurst)
+		}
+		if d.gustTicks > 0 && d.rng.Float64() < 0.35 {
+			burst++
+		}
+		for j := 0; j < burst && len(d.motes) < d.cfg.MaxDust; j++ {
+			d.spawnMoteLocked()
+		}
+	}
+}
+
+func (d *Dust) spawnRowLocked() float64 {
+	if d.H <= 1 {
+		return 0
+	}
+	if d.gustTicks > 0 {
+		half := math.Max(2, d.cfg.GustFront*0.5)
+		row := d.gustCenter + (d.rng.Float64()*2-1)*half*0.9
+		if row < 0 {
+			row = 0
+		}
+		if row > float64(d.H-1) {
+			row = float64(d.H - 1)
+		}
+		return row
+	}
+	center := float64(d.H)*0.58 + math.Sin(float64(d.tick)*0.017)*float64(d.H)*0.08
+	spread := math.Max(3, float64(d.H)*0.28)
+	row := center + (d.rng.Float64()*2-1)*spread
+	if row < 0 {
+		row = 0
+	}
+	if row > float64(d.H-1) {
+		row = float64(d.H - 1)
+	}
+	return row
+}
+
+func (d *Dust) spawnMoteLocked() {
+	if d.W <= 0 || d.H <= 0 {
+		return
+	}
+	isBG := d.cfg.Layers >= 2 && d.rng.Float64() < d.cfg.LayerBalance
+	row := d.spawnRowLocked()
+	gustInfluence := d.gustInfluenceAtRowLocked(row)
+	drift := d.cfg.Drift
+	if isBG {
+		drift *= 0.72
+	}
+	vCol := drift*(0.7+d.rng.Float64()*0.6) + d.gustPush*gustInfluence*(0.45+d.rng.Float64()*0.25)
+	vCol += (d.rng.Float64()*2 - 1) * d.cfg.Wander * 0.05
+	vRow := (d.rng.Float64()*2 - 1) * (0.03 + d.cfg.Wander*0.12)
+	if isBG {
+		vRow *= 0.7
+	}
+	trail := d.cfg.Trail
+	if isBG {
+		trail = max(1, trail-1)
+	}
+	hue := math.Mod(d.cfg.Hue+(d.rng.Float64()*2-1)*d.cfg.HueSpread+360, 360)
+	light := d.cfg.LightnessMin + d.rng.Float64()*(d.cfg.LightnessMax-d.cfg.LightnessMin)
+	if isBG {
+		light *= 0.78
+	}
+	c := hslToRGB(hue, d.cfg.Saturation, light)
+	speed := math.Abs(vCol) + 0.15
+	lifeBase := int(math.Round(float64(max(24, d.W)) / math.Max(0.12, speed)))
+	if lifeBase < 18 {
+		lifeBase = 18
+	}
+	if lifeBase > 260 {
+		lifeBase = 260
+	}
+	life := jitterInt(d.rng, lifeBase, 0.3)
+	edgePad := float64(trail + 2)
+	col := d.rng.Float64() * float64(max(1, d.W-1))
+	switch {
+	case vCol > 0.08:
+		col = -edgePad + d.rng.Float64()*edgePad
+	case vCol < -0.08:
+		col = float64(d.W-1) + d.rng.Float64()*edgePad
+	}
+	d.motes = append(d.motes, dustMote{
+		Row:        row,
+		Col:        col,
+		VRow:       vRow,
+		VCol:       vCol,
+		Life:       life,
+		MaxLife:    life,
+		Trail:      trail,
+		Color:      c,
+		Background: isBG,
+	})
+}
+
+func (d *Dust) stepMotesLocked() {
+	if len(d.motes) == 0 {
+		return
+	}
+	alive := d.motes[:0]
+	for _, m := range d.motes {
+		wander := d.cfg.Wander * 0.018
+		if m.Background {
+			wander *= 0.75
+		}
+		m.VCol += (d.rng.Float64()*2 - 1) * wander
+		m.VRow += (d.rng.Float64()*2 - 1) * wander * 0.8
+		target := d.cfg.Drift
+		if m.Background {
+			target *= 0.72
+		}
+		if d.calmTicks > 0 {
+			target *= 0.88
+		}
+		if d.gustTicks > 0 {
+			influence := d.gustInfluenceAtRowLocked(m.Row)
+			target += d.gustPush * (0.55 + 0.45*influence)
+			m.VRow += (d.rng.Float64()*2 - 1) * influence * d.cfg.Wander * 0.03
+		}
+		m.VCol += (target - m.VCol) * 0.18
+		if m.VRow > 0.28 {
+			m.VRow = 0.28
+		}
+		if m.VRow < -0.28 {
+			m.VRow = -0.28
+		}
+		maxCol := math.Max(0.18, math.Abs(target)*2.4+0.15)
+		if m.Background {
+			maxCol *= 0.8
+		}
+		if m.VCol > maxCol {
+			m.VCol = maxCol
+		}
+		if m.VCol < -maxCol {
+			m.VCol = -maxCol
+		}
+		m.Col += m.VCol
+		m.Row += m.VRow
+		for m.Row < 0 {
+			m.Row += float64(max(1, d.H))
+		}
+		for m.Row >= float64(d.H) {
+			m.Row -= float64(max(1, d.H))
+		}
+		m.Life--
+		if m.Life > 0 && m.Col >= -float64(m.Trail)-2 && m.Col < float64(d.W)+float64(m.Trail)+2 {
+			alive = append(alive, m)
+		}
+	}
+	d.motes = alive
+}
+
+func (d *Dust) paintHazeLocked() {
+	level := d.densityLevelLocked()
+	if level <= 0 || d.W <= 0 || d.H <= 0 {
+		return
+	}
+	center := float64(d.H)*0.58 + math.Sin(float64(d.tick)*0.013)*float64(d.H)*0.04
+	spread := math.Max(4, float64(d.H)*0.24)
+	for y := 0; y < d.H; y++ {
+		rowInfluence := 1 - math.Abs(float64(y)-center)/spread
+		if rowInfluence <= 0 {
+			continue
+		}
+		gustRow := d.gustInfluenceAtRowLocked(float64(y))
+		for x := 0; x < d.W; x++ {
+			wave := 0.5 + 0.5*math.Sin(float64(x)*0.09+float64(y)*0.17+float64(d.tick)*0.04)
+			strength := rowInfluence * level * (0.02 + 0.05*wave)
+			if gustRow > 0 {
+				sweep := 0.6 + 0.4*math.Sin(float64(x)*0.12-float64(d.tick)*0.06)
+				strength += gustRow * 0.04 * sweep
+			}
+			if strength < 0.028 {
+				continue
+			}
+			hue := math.Mod(d.cfg.Hue-6+math.Sin(float64(x)*0.03)*d.cfg.HueSpread*0.2+360, 360)
+			light := clamp01(d.cfg.LightnessMin * (0.18 + 0.6*strength))
+			c := hslToRGB(hue, clamp01(d.cfg.Saturation*0.35), light)
+			d.paintMax(y, x, c)
+		}
+	}
+}
+
+func (d *Dust) paintMotesLocked() {
+	for _, m := range d.motes {
+		fadeLife := clamp01(float64(m.Life) / float64(max(1, m.MaxLife)))
+		if fadeLife <= 0 {
+			continue
+		}
+		tail := max(1, m.Trail)
+		for i := 0; i < tail; i++ {
+			row := m.Row - float64(i)*m.VRow*0.75
+			col := m.Col - float64(i)*m.VCol*0.75
+			gr := int(math.Round(row))
+			gc := int(math.Round(col))
+			bright := math.Pow(d.cfg.Fade, float64(i)) * (0.35 + 0.65*fadeLife)
+			if m.Background {
+				bright *= 0.78
+			}
+			c := m.Color
+			c.R = uint8(float64(c.R) * bright)
+			c.G = uint8(float64(c.G) * bright)
+			c.B = uint8(float64(c.B) * bright)
+			d.paintMax(gr, gc, c)
+		}
+	}
+}
+
+func (d *Dust) paintMax(row, col int, c color.RGBA) {
+	if row < 0 || row >= d.H || col < 0 || col >= d.W {
+		return
+	}
+	if c.R == 0 && c.G == 0 && c.B == 0 {
+		return
+	}
+	cur := d.Grid[row][col]
+	if !cur.Filled {
+		d.Grid[row][col] = Pixel{Filled: true, C: c}
+		return
+	}
+	if c.R > cur.C.R {
+		cur.C.R = c.R
+	}
+	if c.G > cur.C.G {
+		cur.C.G = c.G
+	}
+	if c.B > cur.C.B {
+		cur.C.B = c.B
+	}
+	cur.C.A = 255
+	cur.Filled = true
+	d.Grid[row][col] = cur
+}

--- a/sim/dust_test.go
+++ b/sim/dust_test.go
@@ -1,0 +1,78 @@
+package sim
+
+import "testing"
+
+func TestNewDustAppliesDefaults(t *testing.T) {
+	d := NewDust(24, 14, 1, DustConfig{})
+	cfg := d.EffectiveConfig()
+	if cfg.Drift == 0 {
+		t.Fatal("expected default drift")
+	}
+	if cfg.SpawnEvery <= 0 || cfg.MaxDust <= 0 {
+		t.Fatal("expected default dust density config")
+	}
+	if cfg.GustDur <= 0 || cfg.GustFront <= 0 {
+		t.Fatal("expected default gust config")
+	}
+}
+
+func TestDustStepPaintsGrid(t *testing.T) {
+	d := NewDust(40, 20, 1, DustConfig{
+		SpawnEvery: 1,
+		SpawnBurst: 2,
+		MaxDust:    16,
+		GustChance: 0,
+		CalmChance: 0,
+	})
+	for i := 0; i < 8; i++ {
+		d.Step()
+	}
+
+	filled := 0
+	for y := range d.Grid {
+		for x := range d.Grid[y] {
+			if d.Grid[y][x].Filled {
+				filled++
+			}
+		}
+	}
+	if filled == 0 {
+		t.Fatal("expected dust step to paint at least one pixel")
+	}
+}
+
+func TestDustSnapshotRestoreRoundTrip(t *testing.T) {
+	d := NewDust(48, 24, 42, DustConfig{
+		SpawnEvery: 1,
+		SpawnBurst: 2,
+		MaxDust:    18,
+		GustChance: 0,
+		CalmChance: 0,
+	})
+	for i := 0; i < 6; i++ {
+		d.Step()
+	}
+	if !d.TriggerEvent("intro") {
+		t.Fatal("expected intro trigger to succeed")
+	}
+	d.Step()
+	snap := d.Snapshot()
+
+	restored := NewDust(48, 24, 9, DustConfig{})
+	restored.SetConfig(d.EffectiveConfig())
+	restored.RestoreSnapshot(snap)
+	got := restored.Snapshot()
+
+	if got.Tick != snap.Tick {
+		t.Fatalf("tick = %d, want %d", got.Tick, snap.Tick)
+	}
+	if got.GustTicks != snap.GustTicks {
+		t.Fatalf("gust ticks = %d, want %d", got.GustTicks, snap.GustTicks)
+	}
+	if got.IntroTicks != snap.IntroTicks {
+		t.Fatalf("intro ticks = %d, want %d", got.IntroTicks, snap.IntroTicks)
+	}
+	if len(got.Motes) != len(snap.Motes) {
+		t.Fatalf("mote count = %d, want %d", len(got.Motes), len(snap.Motes))
+	}
+}

--- a/sim/rain.go
+++ b/sim/rain.go
@@ -83,6 +83,12 @@ type Config struct {
 	SplashSize   int     `json:"splash_size"`
 }
 
+// NormalizeConfig applies Rain's defaulting rules so callers outside the sim
+// package can reason about the effective config without constructing a Rain.
+func NormalizeConfig(c Config) Config {
+	return c.withDefaults()
+}
+
 func (c Config) withDefaults() Config {
 	if c.Speed <= 0 {
 		c.Speed = 1.0


### PR DESCRIPTION
## Summary
- add a schema-driven live control panel to / that mirrors the /dev knobs and presets
- keep the live panel locked by default, with an explicit unlock path before shared config and trigger mutations are sent
- expose shared /config and /trigger/<event> endpoints and route them through the edge proxy

## Testing
- not run (per request)
