### PR TITLE
Add the snow dev effect prototype

### DIFF
--- a/cmd/ambience/dev_sessions_test.go
+++ b/cmd/ambience/dev_sessions_test.go
@@ -15,6 +15,7 @@ func TestDevPageEffectFromPath(t *testing.T) {
 		{path: "/dev/", want: "rain", wantOK: true},
 		{path: "/dev/dust", want: "dust", wantOK: true},
 		{path: "/dev/fireflies", want: "fireflies", wantOK: true},
+		{path: "/dev/snow", want: "snow", wantOK: true},
 		{path: "/dev/waterfall", want: "waterfall", wantOK: true},
 		{path: "/dev/unknown", wantOK: false},
 		{path: "/dev/fireflies/extra", wantOK: false},
@@ -39,6 +40,7 @@ func TestEffectFromSchemaPath(t *testing.T) {
 		{path: "/effects/rain/schema", want: "rain", wantOK: true},
 		{path: "/effects/dust/schema", want: "dust", wantOK: true},
 		{path: "/effects/fireflies/schema", want: "fireflies", wantOK: true},
+		{path: "/effects/snow/schema", want: "snow", wantOK: true},
 		{path: "/effects/waterfall/schema", want: "waterfall", wantOK: true},
 		{path: "/effects/unknown/schema", wantOK: false},
 		{path: "/effects/fireflies/not-schema", wantOK: false},
@@ -84,6 +86,17 @@ func TestNewDevSessionWaterfallSnapshotType(t *testing.T) {
 	snap := session.snapshot()
 	if snap.Type != "waterfall" {
 		t.Fatalf("snapshot type = %q, want waterfall", snap.Type)
+	}
+}
+
+func TestNewDevSessionSnowSnapshotType(t *testing.T) {
+	session, err := newDevSession("snow")
+	if err != nil {
+		t.Fatalf("newDevSession: %v", err)
+	}
+	snap := session.snapshot()
+	if snap.Type != "snow" {
+		t.Fatalf("snapshot type = %q, want snow", snap.Type)
 	}
 }
 

--- a/cmd/ambience/effects.go
+++ b/cmd/ambience/effects.go
@@ -71,6 +71,11 @@ var effectRegistry = map[string]effectDefinition{
 		Schema:     sim.WaterfallSchema,
 		NewRuntime: newWaterfallRuntime,
 	},
+	"snow": {
+		Type:       "snow",
+		Schema:     sim.SnowSchema,
+		NewRuntime: newSnowRuntime,
+	},
 }
 
 func lookupEffectDefinition(effectType string) (effectDefinition, bool) {
@@ -153,6 +158,11 @@ type waterfallRuntime struct {
 	sim *sim.Waterfall
 }
 
+type proceduralRuntime struct {
+	kind string
+	sim  *sim.Procedural
+}
+
 func newRainRuntime(w, h int, seed int64, cfg json.RawMessage) (effectRuntime, error) {
 	var parsed sim.Config
 	if len(cfg) > 0 {
@@ -191,6 +201,23 @@ func newWaterfallRuntime(w, h int, seed int64, cfg json.RawMessage) (effectRunti
 		}
 	}
 	return &waterfallRuntime{sim: sim.NewWaterfall(w, h, seed, parsed)}, nil
+}
+
+func newProceduralRuntime(kind string, w, h int, seed int64, cfg json.RawMessage) (effectRuntime, error) {
+	var parsed sim.ProceduralConfig
+	if len(cfg) > 0 {
+		if err := json.Unmarshal(cfg, &parsed); err != nil {
+			return nil, fmt.Errorf("decode %s config: %w", kind, err)
+		}
+	}
+	return &proceduralRuntime{
+		kind: kind,
+		sim:  sim.NewProcedural(kind, w, h, seed, parsed),
+	}, nil
+}
+
+func newSnowRuntime(w, h int, seed int64, cfg json.RawMessage) (effectRuntime, error) {
+	return newProceduralRuntime("snow", w, h, seed, cfg)
 }
 
 func (r *rainRuntime) Type() string { return "rain" }
@@ -596,3 +623,111 @@ func (w *waterfallRuntime) ApplyConfig(data json.RawMessage) error {
 }
 
 func (w *waterfallRuntime) AddEntropy(delta int64) { w.sim.PerturbRNG(delta) }
+
+func (p *proceduralRuntime) Type() string { return p.kind }
+
+func (p *proceduralRuntime) Schema() sim.EffectSchema {
+	switch p.kind {
+	case "snow":
+		return sim.SnowSchema()
+	default:
+		return sim.EffectSchema{}
+	}
+}
+
+func (p *proceduralRuntime) Snapshot() (effectEnvelope, error) {
+	configData, err := json.Marshal(p.sim.EffectiveConfig())
+	if err != nil {
+		return effectEnvelope{}, err
+	}
+	snap := p.sim.Snapshot()
+	stateData, err := json.Marshal(snap)
+	if err != nil {
+		return effectEnvelope{}, err
+	}
+	return effectEnvelope{
+		Tick:   snap.Tick,
+		Config: configData,
+		State:  stateData,
+		GridW:  p.sim.W,
+		GridH:  p.sim.H,
+	}, nil
+}
+
+func (p *proceduralRuntime) Restore(s effectEnvelope) error {
+	if len(s.Config) > 0 {
+		if err := p.ApplyConfig(s.Config); err != nil {
+			return err
+		}
+	}
+	if len(s.State) == 0 {
+		return nil
+	}
+	var state sim.ProceduralSnapshot
+	if err := json.Unmarshal(s.State, &state); err != nil {
+		return fmt.Errorf("decode %s snapshot: %w", p.kind, err)
+	}
+	if s.GridW > 0 && s.GridH > 0 && (p.sim.W != s.GridW || p.sim.H != s.GridH) {
+		p.sim.Resize(s.GridW, s.GridH)
+	}
+	p.sim.RestoreSnapshot(state)
+	return nil
+}
+
+func (p *proceduralRuntime) Persisted() (persistedEffectState, error) {
+	configData, err := json.Marshal(p.sim.EffectiveConfig())
+	if err != nil {
+		return persistedEffectState{}, err
+	}
+	stateData, err := json.Marshal(p.sim.SnapshotPersistedState())
+	if err != nil {
+		return persistedEffectState{}, err
+	}
+	return persistedEffectState{
+		Config: configData,
+		State:  stateData,
+		GridW:  p.sim.W,
+		GridH:  p.sim.H,
+	}, nil
+}
+
+func (p *proceduralRuntime) RestorePersisted(s persistedEffectState) error {
+	if len(s.Config) > 0 {
+		if err := p.ApplyConfig(s.Config); err != nil {
+			return err
+		}
+	}
+	if len(s.State) == 0 {
+		return nil
+	}
+	var state sim.ProceduralPersistedState
+	if err := json.Unmarshal(s.State, &state); err != nil {
+		return fmt.Errorf("decode %s persisted state: %w", p.kind, err)
+	}
+	if s.GridW > 0 && s.GridH > 0 && (p.sim.W != s.GridW || p.sim.H != s.GridH) {
+		p.sim.Resize(s.GridW, s.GridH)
+	}
+	p.sim.RestorePersistedState(state)
+	return nil
+}
+
+func (p *proceduralRuntime) Trigger(name string) bool { return p.sim.TriggerEvent(name) }
+
+func (p *proceduralRuntime) Step() { p.sim.Step() }
+
+func (p *proceduralRuntime) CurrentTick() int { return p.sim.CurrentTick() }
+
+func (p *proceduralRuntime) DrainLog() []sim.LogEntry { return p.sim.DrainLog() }
+
+func (p *proceduralRuntime) ApplyConfig(data json.RawMessage) error {
+	var cfg sim.ProceduralConfig
+	if len(data) > 0 {
+		if err := json.Unmarshal(data, &cfg); err != nil {
+			return fmt.Errorf("decode %s config: %w", p.kind, err)
+		}
+	}
+	p.sim.SetConfig(cfg)
+	return nil
+}
+
+func (p *proceduralRuntime) AddEntropy(delta int64) { p.sim.PerturbRNG(delta) }

--- a/cmd/ambience/web/sim.js
+++ b/cmd/ambience/web/sim.js
@@ -1785,6 +1785,279 @@
 		}
 	}
 
+	const PROCEDURAL_DEFAULTS = {
+		snow: {
+			intro_dur: 60,
+			intro_density: 0.16,
+			ending_dur: 70,
+			ending_linger: 22,
+			ending_density: 0.08,
+			density: 0.32,
+			speed: 0.48,
+			drift: 0.08,
+			sway: 0.42,
+			layers: 3,
+			size: 1,
+			hue: 210,
+			hue_sp: 12,
+			sat: 0.16,
+			lmin: 0.74,
+			lmax: 0.98,
+			gust_p: 0,
+			calm_p: 0,
+			gust_dur: 55,
+			gust_mult: 1.85,
+			calm_dur: 80,
+			calm_mult: 0.42,
+		},
+	};
+
+	function applyProceduralDefaults(kind, cfg) {
+		const base = PROCEDURAL_DEFAULTS[kind] || {};
+		const c = Object.assign({}, base, cfg || {});
+		switch (kind) {
+			case 'snow':
+				if (c.intro_dur <= 0) c.intro_dur = base.intro_dur;
+				c.intro_density = clamp01(c.intro_density);
+				if (c.ending_dur <= 0) c.ending_dur = base.ending_dur;
+				if (c.ending_linger < 0) c.ending_linger = 0;
+				c.ending_density = clamp01(c.ending_density);
+				if (c.density <= 0) c.density = base.density;
+				if (c.speed <= 0) c.speed = base.speed;
+				if (c.layers < 1) c.layers = base.layers;
+				if (c.size <= 0) c.size = base.size;
+				if (c.hue === 0) c.hue = base.hue;
+				if (c.hue_sp < 0) c.hue_sp = 0;
+				if (c.sat <= 0) c.sat = base.sat;
+				if (c.lmin <= 0) c.lmin = base.lmin;
+				if (c.lmax <= 0) c.lmax = base.lmax;
+				if (c.lmax < c.lmin) [c.lmin, c.lmax] = [c.lmax, c.lmin];
+				if (c.gust_dur <= 0) c.gust_dur = base.gust_dur;
+				if (c.gust_mult <= 0) c.gust_mult = base.gust_mult;
+				if (c.calm_dur <= 0) c.calm_dur = base.calm_dur;
+				if (c.calm_mult <= 0) c.calm_mult = base.calm_mult;
+				break;
+		}
+		return c;
+	}
+
+	function positiveMod(value, mod) {
+		if (mod === 0) return 0;
+		return ((value % mod) + mod) % mod;
+	}
+
+	class ProceduralScene {
+		constructor(kind, w, h, cfg, seed) {
+			this.kind = kind;
+			this.w = w;
+			this.h = h;
+			this.seed = Number(seed || Date.now());
+			this.tick = 0;
+			this.timers = {};
+			this.values = {};
+			this.cfg = applyProceduralDefaults(kind, cfg);
+		}
+
+		setConfig(cfg) {
+			this.cfg = applyProceduralDefaults(this.kind, Object.assign({}, this.cfg, cfg));
+		}
+
+		restoreSnapshot(snap) {
+			const state = snap.state || snap;
+			this.setConfig(snap.config || {});
+			this.tick = state.tick || snap.tick || 0;
+			this.timers = Object.assign({}, state.timers || {});
+			this.values = Object.assign({}, state.values || {});
+			if (typeof snap.seed === 'number') this.seed = snap.seed;
+			if (snap.gridW > 0 && snap.gridH > 0) {
+				this.w = snap.gridW;
+				this.h = snap.gridH;
+			}
+		}
+
+		_eventRng(salt) {
+			return makeRNG(((this.seed >>> 0) ^ (((this.tick + salt) * 2654435761) >>> 0)) >>> 0);
+		}
+
+		triggerEvent(name) {
+			switch (this.kind) {
+				case 'snow':
+					return this._triggerSnow(name);
+			}
+			return false;
+		}
+
+		step() {
+			this.tick++;
+			for (const key of Object.keys(this.timers)) {
+				if (this.timers[key] > 0) this.timers[key]--;
+			}
+			if (this.kind === 'snow' && (!this.timers.gust || this.timers.gust <= 0)) {
+				this.values.gust_push = 0;
+			}
+		}
+
+		render(ctx, canvasW, canvasH, opts) {
+			switch (this.kind) {
+				case 'snow':
+					return this._renderSnow(ctx, canvasW, canvasH, opts);
+			}
+		}
+
+		_hash(index) {
+			const x = Math.sin((this.seed * 0.000001 + index * 12.9898) * 43758.5453);
+			return x - Math.floor(x);
+		}
+
+		_phaseProgress(total, left) {
+			if (left <= 1 || total <= 1) return 1;
+			const elapsed = total - left;
+			if (elapsed <= 0) return 0;
+			return clamp01(elapsed / Math.max(1, total - 1));
+		}
+
+		_fillCell(ctx, sx, sy, ceilSx, ceilSy, x, y, w, h, color, alpha) {
+			ctx.fillStyle = color;
+			ctx.globalAlpha = alpha == null ? 1 : alpha;
+			ctx.fillRect(Math.floor(x * sx), Math.floor(y * sy), Math.max(1, Math.ceil(w * sx || ceilSx)), Math.max(1, Math.ceil(h * sy || ceilSy)));
+			ctx.globalAlpha = 1;
+		}
+
+		_triggerSnow(name) {
+			const rng = this._eventRng(name.length + 17);
+			switch (name) {
+				case 'gust':
+					this.timers.gust = jitterInt(rng, this.cfg.gust_dur, 0.3);
+					this.values.gust_push = (rng() < 0.5 ? -1 : 1) * this.cfg.gust_mult * (0.45 + rng() * 0.55);
+					return true;
+				case 'calm':
+					this.timers.calm = jitterInt(rng, this.cfg.calm_dur, 0.3);
+					return true;
+				case 'intro':
+					this.timers.gust = 0;
+					this.timers.calm = 0;
+					this.timers.ending = 0;
+					this.values.gust_push = 0;
+					this.timers.intro = Math.max(1, Math.round(this.cfg.intro_dur));
+					this.values.intro_total = this.timers.intro;
+					return true;
+				case 'ending':
+					this.timers.intro = 0;
+					this.timers.gust = 0;
+					this.timers.calm = 0;
+					this.values.gust_push = 0;
+					this.timers.ending = Math.max(1, Math.round(this.cfg.ending_dur + Math.max(0, this.cfg.ending_linger)));
+					this.values.ending_total = this.timers.ending;
+					return true;
+			}
+			return false;
+		}
+
+		_densityLevelSnow() {
+			let level = this.cfg.density;
+			if (this.timers.gust > 0) level *= 1.28;
+			if (this.timers.calm > 0) level *= this.cfg.calm_mult;
+			if (this.timers.intro > 0) {
+				const total = this.values.intro_total || this.cfg.intro_dur;
+				const progress = this._phaseProgress(total, this.timers.intro);
+				level *= this.cfg.intro_density + (1 - this.cfg.intro_density) * progress;
+			}
+			if (this.timers.ending > 0) {
+				const total = this.values.ending_total || (this.cfg.ending_dur + this.cfg.ending_linger);
+				const progress = this._phaseProgress(total, this.timers.ending);
+				level *= 1 - (1 - this.cfg.ending_density) * progress;
+			}
+			return Math.max(0.02, level);
+		}
+
+		_renderSnow(ctx, canvasW, canvasH, opts) {
+			opts = opts || {};
+			if (opts.transparent) {
+				ctx.clearRect(0, 0, canvasW, canvasH);
+			} else {
+				const sky = ctx.createLinearGradient(0, 0, 0, canvasH);
+				sky.addColorStop(0, '#09111d');
+				sky.addColorStop(0.58, '#102033');
+				sky.addColorStop(1, '#17263a');
+				ctx.fillStyle = sky;
+				ctx.fillRect(0, 0, canvasW, canvasH);
+			}
+
+			const sx = canvasW / this.w;
+			const sy = canvasH / this.h;
+			const ceilSx = Math.ceil(sx);
+			const ceilSy = Math.ceil(sy);
+			const groundRow = Math.floor(this.h * 0.8);
+
+			const moonX = canvasW * (0.16 + this._hash(401) * 0.18);
+			const moonY = canvasH * (0.14 + this._hash(402) * 0.08);
+			const moonR = Math.max(12, Math.min(canvasW, canvasH) * 0.035);
+			const moon = ctx.createRadialGradient(moonX, moonY, 0, moonX, moonY, moonR * 2.6);
+			moon.addColorStop(0, 'rgba(225, 234, 255, 0.18)');
+			moon.addColorStop(1, 'rgba(225, 234, 255, 0)');
+			ctx.fillStyle = moon;
+			ctx.fillRect(0, 0, canvasW, canvasH);
+
+			for (let y = groundRow; y < this.h; y++) {
+				const ratio = (y - groundRow) / Math.max(1, this.h - groundRow);
+				const hue = ((this.cfg.hue - 8) % 360 + 360) % 360;
+				const light = clamp01(0.06 + 0.2 * ratio);
+				const color = hslToRGB(hue, clamp01(this.cfg.sat * 0.55), light);
+				this._fillCell(ctx, sx, sy, ceilSx, ceilSy, 0, y, this.w, 1, `rgb(${color.r},${color.g},${color.b})`, 1);
+			}
+
+			const treeCount = 13;
+			for (let i = 0; i < treeCount; i++) {
+				const center = Math.floor((i + 0.5) * this.w / treeCount + (this._hash(500 + i) - 0.5) * 6);
+				const trunkH = 1 + Math.floor(this._hash(530 + i) * 2);
+				const crownH = 8 + Math.floor(this._hash(560 + i) * 9);
+				const maxHalf = 2 + Math.floor(this._hash(590 + i) * 4);
+				const hue = ((this.cfg.hue - 26) % 360 + 360) % 360;
+				const treeColor = hslToRGB(hue, clamp01(this.cfg.sat * 0.6), 0.18 + this._hash(620 + i) * 0.08);
+				for (let row = 0; row < crownH; row++) {
+					const width = Math.max(1, maxHalf - Math.floor(row / 2));
+					const y = groundRow - crownH + row;
+					for (let dx = -width; dx <= width; dx++) {
+						this._fillCell(ctx, sx, sy, ceilSx, ceilSy, center + dx, y, 1, 1, `rgb(${treeColor.r},${treeColor.g},${treeColor.b})`, 1);
+					}
+				}
+				for (let row = 0; row < trunkH; row++) {
+					this._fillCell(ctx, sx, sy, ceilSx, ceilSy, center, groundRow + row - trunkH, 1, 1, `rgb(${treeColor.r},${treeColor.g},${treeColor.b})`, 1);
+				}
+			}
+
+			const density = this._densityLevelSnow();
+			const layers = Math.max(1, Math.round(this.cfg.layers));
+			for (let layer = 0; layer < layers; layer++) {
+				const layerRatio = layers === 1 ? 1 : layer / (layers - 1);
+				const layerCount = Math.max(8, Math.round(this.w * density * (0.35 + layerRatio * 0.8)));
+				const baseSpeed = this.cfg.speed * (0.4 + layerRatio * 0.85);
+				const drift = this.cfg.drift * (0.35 + layerRatio * 0.65) + (this.values.gust_push || 0) * 0.035 * (0.5 + layerRatio * 0.65);
+				const size = Math.max(1, Math.round(this.cfg.size + layerRatio));
+				for (let i = 0; i < layerCount; i++) {
+					const idx = layer * 1000 + i;
+					const baseX = this._hash(1000 + idx) * this.w;
+					const baseY = this._hash(2000 + idx) * Math.max(1, groundRow - 2);
+					const sway = (this._hash(3000 + idx) * 2 - 1) * this.cfg.sway * (1.4 + layerRatio * 2.4);
+					const fall = baseY + this.tick * baseSpeed * (0.75 + this._hash(4000 + idx) * 0.5);
+					const row = positiveMod(fall, Math.max(1, groundRow - 2));
+					const col = positiveMod(baseX + this.tick * drift + Math.sin(this.tick * 0.035 + idx * 0.19) * sway, this.w);
+					const hue = ((this.cfg.hue + (this._hash(5000 + idx) * 2 - 1) * this.cfg.hue_sp) % 360 + 360) % 360;
+					const light = clamp01(this.cfg.lmin + (this.cfg.lmax - this.cfg.lmin) * (0.35 + 0.55 * (0.3 + layerRatio * 0.7)));
+					const alpha = clamp01(0.35 + 0.55 * (0.25 + layerRatio * 0.75));
+					const color = hslToRGB(hue, this.cfg.sat, light);
+					this._fillCell(ctx, sx, sy, ceilSx, ceilSy, Math.round(col), Math.round(row), size, size, `rgb(${color.r},${color.g},${color.b})`, alpha);
+				}
+			}
+		}
+	}
+
+	class Snow extends ProceduralScene {
+		constructor(w, h, cfg, seed) {
+			super('snow', w, h, cfg, seed);
+		}
+	}
+
 	// Subscribe to an SSE command stream, applying messages to one effect
 	// instance. onReady is called once the initial snapshot has been applied.
 	function subscribe(url, rain, onReady) {
@@ -1819,8 +2092,89 @@
 	// server's snapshot payload — the client looks up the constructor here
 	// by name so new effects just register themselves and work without
 	// client-side changes.
-	const effects = { rain: Rain, dust: Dust, fireflies: Fireflies, waterfall: Waterfall };
+	const effects = { rain: Rain, dust: Dust, fireflies: Fireflies, waterfall: Waterfall, snow: Snow };
 	const presets = {
+		snow: [
+			{
+				key: 'quiet-flurries',
+				label: 'quiet flurries',
+				config: {
+					density: 0.2,
+					speed: 0.38,
+					drift: 0.04,
+					sway: 0.35,
+					layers: 2,
+					size: 1,
+					hue: 208,
+					hue_sp: 8,
+					sat: 0.12,
+					lmin: 0.76,
+					lmax: 0.96,
+					calm_p: 0.0012,
+				},
+			},
+			{
+				key: 'pine-evening',
+				label: 'pine evening',
+				config: {
+					density: 0.3,
+					speed: 0.5,
+					drift: 0.08,
+					sway: 0.4,
+					layers: 3,
+					size: 1,
+					hue: 214,
+					hue_sp: 12,
+					sat: 0.16,
+					lmin: 0.74,
+					lmax: 0.98,
+					gust_p: 0.0008,
+				},
+			},
+			{
+				key: 'crosswind',
+				label: 'crosswind',
+				config: {
+					density: 0.34,
+					speed: 0.56,
+					drift: 0.16,
+					sway: 0.58,
+					layers: 3,
+					size: 1.2,
+					hue: 206,
+					hue_sp: 10,
+					sat: 0.14,
+					lmin: 0.72,
+					lmax: 0.98,
+					gust_p: 0.0015,
+					gust_mult: 2.25,
+					gust_dur: 68,
+				},
+			},
+			{
+				key: 'whiteout-edge',
+				label: 'whiteout edge',
+				config: {
+					intro_density: 0.22,
+					ending_density: 0.14,
+					density: 0.52,
+					speed: 0.7,
+					drift: 0.12,
+					sway: 0.74,
+					layers: 4,
+					size: 1.5,
+					hue: 212,
+					hue_sp: 16,
+					sat: 0.18,
+					lmin: 0.76,
+					lmax: 1,
+					gust_p: 0.0018,
+					gust_mult: 2.8,
+					gust_dur: 76,
+					calm_p: 0.0003,
+				},
+			},
+		],
 		dust: [
 			{
 				key: 'lazy-dust',
@@ -2018,5 +2372,5 @@
 		],
 	};
 
-	global.AmbienceSim = { Rain, Dust, Fireflies, Waterfall, subscribe, applyDefaults, hslToRGB, effects, presets };
+	global.AmbienceSim = { Rain, Dust, Fireflies, Waterfall, Snow, subscribe, applyDefaults, hslToRGB, effects, presets };
 })(window);

--- a/sim/procedural.go
+++ b/sim/procedural.go
@@ -1,0 +1,479 @@
+package sim
+
+import (
+	"fmt"
+	"math"
+	"sync"
+
+	"github.com/nelsong6/ambience/rngutil"
+)
+
+// ProceduralConfig is a lightweight numeric config map used by browser-first
+// scenic prototypes. The server owns event timing and snapshot/restore state;
+// the browser owns the richer deterministic render derived from tick + seed.
+type ProceduralConfig map[string]float64
+
+type ProceduralState struct {
+	Tick   int                `json:"tick"`
+	Timers map[string]int     `json:"timers,omitempty"`
+	Values map[string]float64 `json:"values,omitempty"`
+}
+
+type ProceduralSnapshot struct {
+	ProceduralState
+}
+
+type ProceduralPersistedState struct {
+	ProceduralState
+	RNGState uint64 `json:"rngState"`
+}
+
+// Procedural hosts lightweight browser-first scenic prototypes. It tracks
+// authoritative tick/event state so join-in-progress dev sessions can restore
+// a consistent mood without the server needing a full particle simulation.
+type Procedural struct {
+	mu sync.Mutex
+
+	Kind string
+	W, H int
+	Grid [][]Pixel
+
+	rng    *rngutil.RNG
+	cfg    ProceduralConfig
+	tick   int
+	timers map[string]int
+	values map[string]float64
+	log    []LogEntry
+}
+
+var snowDefaults = ProceduralConfig{
+	"intro_dur":      60,
+	"intro_density":  0.16,
+	"ending_dur":     70,
+	"ending_linger":  22,
+	"ending_density": 0.08,
+	"density":        0.32,
+	"speed":          0.48,
+	"drift":          0.08,
+	"sway":           0.42,
+	"layers":         3,
+	"size":           1.0,
+	"hue":            210,
+	"hue_sp":         12,
+	"sat":            0.16,
+	"lmin":           0.74,
+	"lmax":           0.98,
+	"gust_p":         0.0,
+	"calm_p":         0.0,
+	"gust_dur":       55,
+	"gust_mult":      1.85,
+	"calm_dur":       80,
+	"calm_mult":      0.42,
+}
+
+func SnowSchema() EffectSchema {
+	return EffectSchema{
+		Name: "snow",
+		Knobs: []Knob{
+			{Key: "intro_dur", Label: "intro dur", Slot: SlotSpawn, Group: "introduction", Type: KnobInt, Min: 10, Max: 240, Step: 5, Default: 60, Trigger: "intro",
+				Description: "Ticks spent ramping from a few first flakes into the full snowfall."},
+			{Key: "intro_density", Label: "intro density", Slot: SlotSpawn, Group: "introduction", Type: KnobFloat, Min: 0.02, Max: 0.6, Step: 0.02, Default: 0.16,
+				Description: "Starting snowfall fraction before the full field settles in."},
+			{Key: "ending_dur", Label: "ending dur", Slot: SlotEnd, Group: "ending", Type: KnobInt, Min: 10, Max: 240, Step: 5, Default: 70, Trigger: "ending",
+				Description: "Ticks spent tapering the snowfall down toward still air."},
+			{Key: "ending_linger", Label: "ending linger", Slot: SlotEnd, Group: "ending", Type: KnobInt, Min: 0, Max: 160, Step: 5, Default: 22,
+				Description: "Extra quiet ticks after the taper so the last flakes can drift out."},
+			{Key: "ending_density", Label: "ending residue", Slot: SlotEnd, Group: "ending", Type: KnobFloat, Min: 0, Max: 0.5, Step: 0.02, Default: 0.08,
+				Description: "How much low-level snowfall remains near the end of the outro."},
+			{Key: "density", Label: "density", Slot: SlotLever, Group: "fall", Type: KnobFloat, Min: 0.05, Max: 0.9, Step: 0.01, Default: 0.32,
+				Description: "Base snowfall density across all layers."},
+			{Key: "speed", Label: "fall speed", Slot: SlotLever, Group: "fall", Type: KnobFloat, Min: 0.1, Max: 1.5, Step: 0.02, Default: 0.48,
+				Description: "How quickly flakes descend through the field."},
+			{Key: "drift", Label: "drift", Slot: SlotLever, Group: "fall", Type: KnobFloat, Min: -0.5, Max: 0.5, Step: 0.01, Default: 0.08,
+				Description: "Baseline sideways carry. Positive drifts right, negative drifts left."},
+			{Key: "sway", Label: "sway", Slot: SlotLever, Group: "fall", Type: KnobFloat, Min: 0, Max: 1.2, Step: 0.02, Default: 0.42,
+				Description: "Side-to-side meander in each flake's path."},
+			{Key: "layers", Label: "layers", Slot: SlotLever, Group: "fall", Type: KnobInt, Min: 1, Max: 4, Step: 1, Default: 3,
+				Description: "Number of snowfall depth layers."},
+			{Key: "size", Label: "flake size", Slot: SlotLever, Group: "fall", Type: KnobFloat, Min: 0.5, Max: 2.5, Step: 0.1, Default: 1,
+				Description: "Pixel size of the brightest foreground flakes."},
+			{Key: "hue", Label: "hue", Slot: SlotLever, Group: "color", Type: KnobFloat, Min: 180, Max: 240, Step: 1, Default: 210,
+				Description: "Base snow tint. Lower values warm toward dusk; higher values cool toward ice."},
+			{Key: "hue_sp", Label: "hue spread", Slot: SlotLever, Group: "color", Type: KnobFloat, Min: 0, Max: 30, Step: 1, Default: 12,
+				Description: "Variation in the flake tint and sky reflection."},
+			{Key: "sat", Label: "saturation", Slot: SlotLever, Group: "color", Type: KnobFloat, Min: 0.01, Max: 0.45, Step: 0.01, Default: 0.16,
+				Description: "Overall color saturation of the snow scene."},
+			{Key: "lmin", Label: "light min", Slot: SlotLever, Group: "color", Type: KnobFloat, Min: 0.2, Max: 0.9, Step: 0.01, Default: 0.74,
+				Description: "Minimum lightness used for dim flakes and distant haze."},
+			{Key: "lmax", Label: "light max", Slot: SlotLever, Group: "color", Type: KnobFloat, Min: 0.3, Max: 1.0, Step: 0.01, Default: 0.98,
+				Description: "Maximum lightness used for the brightest near flakes."},
+			{Key: "gust_p", Label: "gust", Slot: SlotEvent, Type: KnobFloat, Min: 0, Max: 0.02, Step: 0.0005, Default: 0, Trigger: "gust",
+				Description: "Per-tick chance of a crosswind kicking the snowfall sideways."},
+			{Key: "calm_p", Label: "calm", Slot: SlotEvent, Type: KnobFloat, Min: 0, Max: 0.02, Step: 0.0005, Default: 0, Trigger: "calm",
+				Description: "Per-tick chance of the snowfall briefly thinning into stillness."},
+			{Key: "gust_dur", Label: "gust dur", Slot: SlotEventMod, Group: "gust", Type: KnobInt, Min: 10, Max: 220, Step: 5, Default: 55,
+				Description: "Typical gust duration in ticks (jittered by +/-30%)."},
+			{Key: "gust_mult", Label: "gust x", Slot: SlotEventMod, Group: "gust", Type: KnobFloat, Min: 1.05, Max: 4, Step: 0.05, Default: 1.85,
+				Description: "How strongly a gust bends the snowfall sideways."},
+			{Key: "calm_dur", Label: "calm dur", Slot: SlotEventMod, Group: "calm", Type: KnobInt, Min: 10, Max: 220, Step: 5, Default: 80,
+				Description: "Duration of the quieter low-density window."},
+			{Key: "calm_mult", Label: "calm x", Slot: SlotEventMod, Group: "calm", Type: KnobFloat, Min: 0.05, Max: 1, Step: 0.05, Default: 0.42,
+				Description: "Density multiplier applied while calm is active."},
+		},
+	}
+}
+
+func cloneProceduralConfig(src ProceduralConfig) ProceduralConfig {
+	if src == nil {
+		return ProceduralConfig{}
+	}
+	out := make(ProceduralConfig, len(src))
+	for k, v := range src {
+		out[k] = v
+	}
+	return out
+}
+
+func cloneTimerMap(src map[string]int) map[string]int {
+	if len(src) == 0 {
+		return nil
+	}
+	out := make(map[string]int, len(src))
+	for k, v := range src {
+		if v > 0 {
+			out[k] = v
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func cloneValueMap(src map[string]float64) map[string]float64 {
+	if len(src) == 0 {
+		return nil
+	}
+	out := make(map[string]float64, len(src))
+	for k, v := range src {
+		out[k] = v
+	}
+	return out
+}
+
+func proceduralDefaults(kind string) ProceduralConfig {
+	switch kind {
+	case "snow":
+		return cloneProceduralConfig(snowDefaults)
+	default:
+		return ProceduralConfig{}
+	}
+}
+
+func mergeProceduralDefaults(kind string, cfg ProceduralConfig) ProceduralConfig {
+	out := proceduralDefaults(kind)
+	for k, v := range cfg {
+		out[k] = v
+	}
+	switch kind {
+	case "snow":
+		if out["intro_dur"] <= 0 {
+			out["intro_dur"] = snowDefaults["intro_dur"]
+		}
+		out["intro_density"] = clamp01(out["intro_density"])
+		if out["ending_dur"] <= 0 {
+			out["ending_dur"] = snowDefaults["ending_dur"]
+		}
+		if out["ending_linger"] < 0 {
+			out["ending_linger"] = 0
+		}
+		out["ending_density"] = clamp01(out["ending_density"])
+		if out["density"] <= 0 {
+			out["density"] = snowDefaults["density"]
+		}
+		if out["speed"] <= 0 {
+			out["speed"] = snowDefaults["speed"]
+		}
+		if out["layers"] < 1 {
+			out["layers"] = snowDefaults["layers"]
+		}
+		if out["size"] <= 0 {
+			out["size"] = snowDefaults["size"]
+		}
+		if out["hue"] == 0 {
+			out["hue"] = snowDefaults["hue"]
+		}
+		if out["hue_sp"] < 0 {
+			out["hue_sp"] = 0
+		}
+		if out["sat"] <= 0 {
+			out["sat"] = snowDefaults["sat"]
+		}
+		if out["lmin"] <= 0 {
+			out["lmin"] = snowDefaults["lmin"]
+		}
+		if out["lmax"] <= 0 {
+			out["lmax"] = snowDefaults["lmax"]
+		}
+		if out["lmax"] < out["lmin"] {
+			out["lmin"], out["lmax"] = out["lmax"], out["lmin"]
+		}
+		if out["gust_dur"] <= 0 {
+			out["gust_dur"] = snowDefaults["gust_dur"]
+		}
+		if out["gust_mult"] <= 0 {
+			out["gust_mult"] = snowDefaults["gust_mult"]
+		}
+		if out["calm_dur"] <= 0 {
+			out["calm_dur"] = snowDefaults["calm_dur"]
+		}
+		if out["calm_mult"] <= 0 {
+			out["calm_mult"] = snowDefaults["calm_mult"]
+		}
+	}
+	return out
+}
+
+func NewProcedural(kind string, w, h int, seed int64, cfg ProceduralConfig) *Procedural {
+	grid := make([][]Pixel, h)
+	for i := range grid {
+		grid[i] = make([]Pixel, w)
+	}
+	return &Procedural{
+		Kind:   kind,
+		W:      w,
+		H:      h,
+		Grid:   grid,
+		rng:    rngutil.New(seed),
+		cfg:    mergeProceduralDefaults(kind, cfg),
+		timers: make(map[string]int),
+		values: make(map[string]float64),
+	}
+}
+
+func (p *Procedural) Resize(w, h int) {
+	if w <= 0 || h <= 0 {
+		return
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if w == p.W && h == p.H {
+		return
+	}
+	p.W = w
+	p.H = h
+	p.Grid = make([][]Pixel, h)
+	for i := range p.Grid {
+		p.Grid[i] = make([]Pixel, w)
+	}
+}
+
+func (p *Procedural) SetConfig(cfg ProceduralConfig) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.cfg = mergeProceduralDefaults(p.Kind, cfg)
+}
+
+func (p *Procedural) EffectiveConfig() ProceduralConfig {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return cloneProceduralConfig(p.cfg)
+}
+
+func (p *Procedural) Snapshot() ProceduralSnapshot {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return ProceduralSnapshot{
+		ProceduralState: p.snapshotStateLocked(),
+	}
+}
+
+func (p *Procedural) RestoreSnapshot(s ProceduralSnapshot) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.restoreStateLocked(s.ProceduralState)
+}
+
+func (p *Procedural) SnapshotPersistedState() ProceduralPersistedState {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return ProceduralPersistedState{
+		ProceduralState: p.snapshotStateLocked(),
+		RNGState:        p.rng.State(),
+	}
+}
+
+func (p *Procedural) RestorePersistedState(s ProceduralPersistedState) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.restoreStateLocked(s.ProceduralState)
+	if s.RNGState != 0 {
+		p.rng.SetState(s.RNGState)
+	}
+}
+
+func (p *Procedural) SnapshotState() ProceduralState {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.snapshotStateLocked()
+}
+
+func (p *Procedural) RestoreState(s ProceduralState) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.restoreStateLocked(s)
+}
+
+func (p *Procedural) snapshotStateLocked() ProceduralState {
+	return ProceduralState{
+		Tick:   p.tick,
+		Timers: cloneTimerMap(p.timers),
+		Values: cloneValueMap(p.values),
+	}
+}
+
+func (p *Procedural) restoreStateLocked(s ProceduralState) {
+	p.tick = s.Tick
+	p.timers = cloneTimerMap(s.Timers)
+	if p.timers == nil {
+		p.timers = make(map[string]int)
+	}
+	p.values = cloneValueMap(s.Values)
+	if p.values == nil {
+		p.values = make(map[string]float64)
+	}
+}
+
+func (p *Procedural) CurrentTick() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.tick
+}
+
+func (p *Procedural) PerturbRNG(delta int64) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.rng.Mix(delta)
+}
+
+func (p *Procedural) TriggerEvent(name string) bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	switch p.Kind {
+	case "snow":
+		switch name {
+		case "gust":
+			p.startSnowGustLocked("triggered")
+		case "calm":
+			p.startSnowCalmLocked("triggered")
+		case "intro":
+			p.startSnowIntroLocked()
+			p.appendLog("intro", fmt.Sprintf("started (dur=%d, density=%.2f)", p.timers["intro"], p.cfg["intro_density"]))
+		case "ending":
+			p.startSnowEndingLocked()
+			p.appendLog("ending", fmt.Sprintf("started (fade=%d, linger=%d)", p.intCfg("ending_dur"), p.intCfg("ending_linger")))
+		default:
+			return false
+		}
+		return true
+	default:
+		return false
+	}
+}
+
+func (p *Procedural) DrainLog() []LogEntry {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if len(p.log) == 0 {
+		return nil
+	}
+	out := p.log
+	p.log = nil
+	return out
+}
+
+func (p *Procedural) appendLog(kind, desc string) {
+	p.log = append(p.log, LogEntry{Tick: p.tick, Type: kind, Desc: desc})
+	if len(p.log) > 200 {
+		p.log = p.log[len(p.log)-200:]
+	}
+}
+
+func (p *Procedural) Step() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	p.tick++
+	for key, value := range p.timers {
+		if value > 0 {
+			p.timers[key] = value - 1
+		}
+	}
+
+	switch p.Kind {
+	case "snow":
+		p.stepSnowLocked()
+	}
+}
+
+func (p *Procedural) intCfg(key string) int {
+	return int(math.Round(p.cfg[key]))
+}
+
+func (p *Procedural) startSnowGustLocked(verb string) {
+	p.timers["gust"] = jitterInt(p.rng, p.intCfg("gust_dur"), 0.3)
+	sign := 1.0
+	if p.rng.Float64() < 0.5 {
+		sign = -1
+	}
+	p.values["gust_push"] = sign * p.cfg["gust_mult"] * (0.45 + p.rng.Float64()*0.55)
+	p.appendLog("gust", fmt.Sprintf("%s (dur=%d, push=%+.2f)", verb, p.timers["gust"], p.values["gust_push"]))
+}
+
+func (p *Procedural) startSnowCalmLocked(verb string) {
+	p.timers["calm"] = jitterInt(p.rng, p.intCfg("calm_dur"), 0.3)
+	p.appendLog("calm", fmt.Sprintf("%s (dur=%d, x%.2f)", verb, p.timers["calm"], p.cfg["calm_mult"]))
+}
+
+func (p *Procedural) startSnowIntroLocked() {
+	p.timers["gust"] = 0
+	p.timers["calm"] = 0
+	p.timers["ending"] = 0
+	p.values["gust_push"] = 0
+	p.timers["intro"] = p.intCfg("intro_dur")
+	p.values["intro_total"] = float64(p.timers["intro"])
+}
+
+func (p *Procedural) startSnowEndingLocked() {
+	p.timers["intro"] = 0
+	p.timers["gust"] = 0
+	p.timers["calm"] = 0
+	p.values["gust_push"] = 0
+	endingTotal := p.intCfg("ending_dur") + max(0, p.intCfg("ending_linger"))
+	if endingTotal < 1 {
+		endingTotal = max(1, p.intCfg("ending_dur"))
+	}
+	p.timers["ending"] = endingTotal
+	p.values["ending_total"] = float64(endingTotal)
+}
+
+func (p *Procedural) stepSnowLocked() {
+	if p.timers["gust"] <= 0 {
+		p.values["gust_push"] = 0
+	}
+	if p.timers["intro"] <= 0 {
+		delete(p.values, "intro_total")
+	}
+	if p.timers["ending"] <= 0 {
+		delete(p.values, "ending_total")
+	}
+	if p.timers["intro"] > 0 || p.timers["ending"] > 0 {
+		return
+	}
+	if p.timers["gust"] <= 0 && p.cfg["gust_p"] > 0 && p.rng.Float64() < p.cfg["gust_p"] {
+		p.startSnowGustLocked("started")
+	}
+	if p.timers["calm"] <= 0 && p.cfg["calm_p"] > 0 && p.rng.Float64() < p.cfg["calm_p"] {
+		p.startSnowCalmLocked("started")
+	}
+}

--- a/sim/procedural_test.go
+++ b/sim/procedural_test.go
@@ -1,0 +1,42 @@
+package sim
+
+import "testing"
+
+func TestSnowSchema(t *testing.T) {
+	schema := SnowSchema()
+	if schema.Name != "snow" {
+		t.Fatalf("schema name = %q, want snow", schema.Name)
+	}
+	if len(schema.Knobs) == 0 {
+		t.Fatal("expected snow schema knobs")
+	}
+}
+
+func TestProceduralSnowSnapshotRestore(t *testing.T) {
+	p := NewProcedural("snow", 160, 80, 42, nil)
+	if !p.TriggerEvent("gust") {
+		t.Fatal("expected gust trigger to succeed")
+	}
+	if !p.TriggerEvent("intro") {
+		t.Fatal("expected intro trigger to succeed")
+	}
+	p.Step()
+
+	snap := p.Snapshot()
+	if snap.Tick != 1 {
+		t.Fatalf("tick = %d, want 1", snap.Tick)
+	}
+	if snap.Timers["intro"] <= 0 {
+		t.Fatal("expected intro timer in snapshot")
+	}
+
+	restored := NewProcedural("snow", 160, 80, 7, nil)
+	restored.RestoreSnapshot(snap)
+	again := restored.Snapshot()
+	if again.Tick != snap.Tick {
+		t.Fatalf("restored tick = %d, want %d", again.Tick, snap.Tick)
+	}
+	if again.Timers["intro"] != snap.Timers["intro"] {
+		t.Fatalf("restored intro timer = %d, want %d", again.Timers["intro"], snap.Timers["intro"])
+	}
+}


### PR DESCRIPTION
## Summary
- add a lightweight procedural scenic runtime for browser-first dev effects
- register a new snow effect with schema, dev routing coverage, and snapshot tests
- add the browser-side snow renderer and presets for /dev/snow

## Testing
- go test ./...
- powershell -ExecutionPolicy Bypass -File scripts/dev-deploy.ps1 -Component all
- validated visually at https://ambience.dev.romaine.life/dev/snow

Closes #18