### PR TITLE
Add the starfield dev effect prototype

### DIFF
--- a/cmd/ambience/dev_sessions_test.go
+++ b/cmd/ambience/dev_sessions_test.go
@@ -17,6 +17,7 @@ func TestDevPageEffectFromPath(t *testing.T) {
 		{path: "/dev/autumn-leaves", want: "autumn-leaves", wantOK: true},
 		{path: "/dev/fireflies", want: "fireflies", wantOK: true},
 		{path: "/dev/snow", want: "snow", wantOK: true},
+		{path: "/dev/starfield", want: "starfield", wantOK: true},
 		{path: "/dev/waterfall", want: "waterfall", wantOK: true},
 		{path: "/dev/unknown", wantOK: false},
 		{path: "/dev/fireflies/extra", wantOK: false},
@@ -43,6 +44,7 @@ func TestEffectFromSchemaPath(t *testing.T) {
 		{path: "/effects/dust/schema", want: "dust", wantOK: true},
 		{path: "/effects/fireflies/schema", want: "fireflies", wantOK: true},
 		{path: "/effects/snow/schema", want: "snow", wantOK: true},
+		{path: "/effects/starfield/schema", want: "starfield", wantOK: true},
 		{path: "/effects/waterfall/schema", want: "waterfall", wantOK: true},
 		{path: "/effects/unknown/schema", wantOK: false},
 		{path: "/effects/fireflies/not-schema", wantOK: false},
@@ -110,6 +112,17 @@ func TestNewDevSessionAutumnLeavesSnapshotType(t *testing.T) {
 	snap := session.snapshot()
 	if snap.Type != "autumn-leaves" {
 		t.Fatalf("snapshot type = %q, want autumn-leaves", snap.Type)
+	}
+}
+
+func TestNewDevSessionStarfieldSnapshotType(t *testing.T) {
+	session, err := newDevSession("starfield")
+	if err != nil {
+		t.Fatalf("newDevSession: %v", err)
+	}
+	snap := session.snapshot()
+	if snap.Type != "starfield" {
+		t.Fatalf("snapshot type = %q, want starfield", snap.Type)
 	}
 }
 

--- a/cmd/ambience/effects.go
+++ b/cmd/ambience/effects.go
@@ -81,6 +81,11 @@ var effectRegistry = map[string]effectDefinition{
 		Schema:     sim.AutumnLeavesSchema,
 		NewRuntime: newAutumnLeavesRuntime,
 	},
+	"starfield": {
+		Type:       "starfield",
+		Schema:     sim.StarfieldSchema,
+		NewRuntime: newStarfieldRuntime,
+	},
 }
 
 func lookupEffectDefinition(effectType string) (effectDefinition, bool) {
@@ -227,6 +232,10 @@ func newSnowRuntime(w, h int, seed int64, cfg json.RawMessage) (effectRuntime, e
 
 func newAutumnLeavesRuntime(w, h int, seed int64, cfg json.RawMessage) (effectRuntime, error) {
 	return newProceduralRuntime("autumn-leaves", w, h, seed, cfg)
+}
+
+func newStarfieldRuntime(w, h int, seed int64, cfg json.RawMessage) (effectRuntime, error) {
+	return newProceduralRuntime("starfield", w, h, seed, cfg)
 }
 
 func (r *rainRuntime) Type() string { return "rain" }
@@ -641,6 +650,8 @@ func (p *proceduralRuntime) Schema() sim.EffectSchema {
 		return sim.SnowSchema()
 	case "autumn-leaves":
 		return sim.AutumnLeavesSchema()
+	case "starfield":
+		return sim.StarfieldSchema()
 	default:
 		return sim.EffectSchema{}
 	}

--- a/cmd/ambience/web/sim.js
+++ b/cmd/ambience/web/sim.js
@@ -1786,6 +1786,29 @@
 	}
 
 	const PROCEDURAL_DEFAULTS = {
+		starfield: {
+			intro_dur: 50,
+			intro_density: 0.08,
+			ending_dur: 60,
+			ending_linger: 16,
+			ending_density: 0.03,
+			density: 0.22,
+			speed: 0.12,
+			drift: 0.04,
+			layers: 3,
+			size: 1,
+			hue: 218,
+			hue_sp: 18,
+			sat: 0.18,
+			lmin: 0.55,
+			lmax: 0.95,
+			shooting_star_p: 0,
+			twinkle_burst_p: 0,
+			shooting_star_dur: 26,
+			shooting_star_mult: 1.8,
+			twinkle_burst_dur: 42,
+			twinkle_burst_mult: 1.7,
+		},
 		'autumn-leaves': {
 			intro_dur: 55,
 			intro_density: 0.12,
@@ -1843,6 +1866,27 @@
 		const base = PROCEDURAL_DEFAULTS[kind] || {};
 		const c = Object.assign({}, base, cfg || {});
 		switch (kind) {
+			case 'starfield':
+				if (c.intro_dur <= 0) c.intro_dur = base.intro_dur;
+				c.intro_density = clamp01(c.intro_density);
+				if (c.ending_dur <= 0) c.ending_dur = base.ending_dur;
+				if (c.ending_linger < 0) c.ending_linger = 0;
+				c.ending_density = clamp01(c.ending_density);
+				if (c.density <= 0) c.density = base.density;
+				if (c.speed <= 0) c.speed = base.speed;
+				if (c.layers < 1) c.layers = base.layers;
+				if (c.size <= 0) c.size = base.size;
+				if (c.hue === 0) c.hue = base.hue;
+				if (c.hue_sp < 0) c.hue_sp = 0;
+				if (c.sat <= 0) c.sat = base.sat;
+				if (c.lmin <= 0) c.lmin = base.lmin;
+				if (c.lmax <= 0) c.lmax = base.lmax;
+				if (c.lmax < c.lmin) [c.lmin, c.lmax] = [c.lmax, c.lmin];
+				if (c.shooting_star_dur <= 0) c.shooting_star_dur = base.shooting_star_dur;
+				if (c.shooting_star_mult <= 0) c.shooting_star_mult = base.shooting_star_mult;
+				if (c.twinkle_burst_dur <= 0) c.twinkle_burst_dur = base.twinkle_burst_dur;
+				if (c.twinkle_burst_mult <= 0) c.twinkle_burst_mult = base.twinkle_burst_mult;
+				break;
 			case 'autumn-leaves':
 				if (c.intro_dur <= 0) c.intro_dur = base.intro_dur;
 				c.intro_density = clamp01(c.intro_density);
@@ -1931,6 +1975,8 @@
 
 		triggerEvent(name) {
 			switch (this.kind) {
+				case 'starfield':
+					return this._triggerStarfield(name);
 				case 'autumn-leaves':
 					return this._triggerAutumnLeaves(name);
 				case 'snow':
@@ -1955,6 +2001,8 @@
 
 		render(ctx, canvasW, canvasH, opts) {
 			switch (this.kind) {
+				case 'starfield':
+					return this._renderStarfield(ctx, canvasW, canvasH, opts);
 				case 'autumn-leaves':
 					return this._renderAutumnLeaves(ctx, canvasW, canvasH, opts);
 				case 'snow':
@@ -2051,6 +2099,37 @@
 			return false;
 		}
 
+		_triggerStarfield(name) {
+			const rng = this._eventRng(name.length + 41);
+			switch (name) {
+				case 'shooting-star':
+					this.timers['shooting-star'] = jitterInt(rng, this.cfg.shooting_star_dur, 0.3);
+					this.values['shooting-star_total'] = this.timers['shooting-star'];
+					this.values.shooting_dir = rng() < 0.5 ? -1 : 1;
+					this.values.shooting_row = 6 + rng() * Math.max(4, this.h / 3);
+					this.values.shooting_start = rng() * this.w;
+					return true;
+				case 'twinkle-burst':
+					this.timers['twinkle-burst'] = jitterInt(rng, this.cfg.twinkle_burst_dur, 0.3);
+					return true;
+				case 'intro':
+					this.timers.ending = 0;
+					this.timers['shooting-star'] = 0;
+					this.timers['twinkle-burst'] = 0;
+					this.timers.intro = Math.max(1, Math.round(this.cfg.intro_dur));
+					this.values.intro_total = this.timers.intro;
+					return true;
+				case 'ending':
+					this.timers.intro = 0;
+					this.timers['shooting-star'] = 0;
+					this.timers['twinkle-burst'] = 0;
+					this.timers.ending = Math.max(1, Math.round(this.cfg.ending_dur + Math.max(0, this.cfg.ending_linger)));
+					this.values.ending_total = this.timers.ending;
+					return true;
+			}
+			return false;
+		}
+
 		_densityLevelSnow() {
 			let level = this.cfg.density;
 			if (this.timers.gust > 0) level *= 1.28;
@@ -2083,6 +2162,21 @@
 				level *= 1 - (1 - this.cfg.ending_density) * progress;
 			}
 			return Math.max(0.015, level);
+		}
+
+		_densityLevelStarfield() {
+			let level = this.cfg.density;
+			if (this.timers.intro > 0) {
+				const total = this.values.intro_total || this.cfg.intro_dur;
+				const progress = this._phaseProgress(total, this.timers.intro);
+				level *= this.cfg.intro_density + (1 - this.cfg.intro_density) * progress;
+			}
+			if (this.timers.ending > 0) {
+				const total = this.values.ending_total || (this.cfg.ending_dur + this.cfg.ending_linger);
+				const progress = this._phaseProgress(total, this.timers.ending);
+				level *= 1 - (1 - this.cfg.ending_density) * progress;
+			}
+			return Math.max(0.02, level);
 		}
 
 		_renderSnow(ctx, canvasW, canvasH, opts) {
@@ -2234,6 +2328,72 @@
 				}
 			}
 		}
+
+		_renderStarfield(ctx, canvasW, canvasH, opts) {
+			opts = opts || {};
+			if (opts.transparent) {
+				ctx.clearRect(0, 0, canvasW, canvasH);
+			} else {
+				const sky = ctx.createLinearGradient(0, 0, 0, canvasH);
+				sky.addColorStop(0, '#050912');
+				sky.addColorStop(0.6, '#090f20');
+				sky.addColorStop(1, '#0b1128');
+				ctx.fillStyle = sky;
+				ctx.fillRect(0, 0, canvasW, canvasH);
+			}
+
+			const sx = canvasW / this.w;
+			const sy = canvasH / this.h;
+			const ceilSx = Math.ceil(sx);
+			const ceilSy = Math.ceil(sy);
+			const density = this._densityLevelStarfield();
+			const layers = Math.max(1, Math.round(this.cfg.layers));
+			const burst = this.timers['twinkle-burst'] > 0 ? this.cfg.twinkle_burst_mult : 1;
+
+			for (let layer = 0; layer < layers; layer++) {
+				const layerRatio = layers === 1 ? 1 : layer / (layers - 1);
+				const layerCount = Math.max(10, Math.round(this.w * density * (0.4 + layerRatio * 1.2)));
+				const speed = this.cfg.speed * (0.18 + layerRatio * 0.82);
+				const drift = this.cfg.drift * (0.25 + layerRatio * 0.9);
+				const size = Math.max(1, Math.round(this.cfg.size + layerRatio));
+				for (let i = 0; i < layerCount; i++) {
+					const idx = layer * 1400 + i;
+					const baseX = this._hash(15000 + idx) * this.w;
+					const baseY = this._hash(16000 + idx) * this.h;
+					const col = positiveMod(baseX + this.tick * drift * speed * 2, this.w);
+					const row = baseY;
+					const hue = ((this.cfg.hue + (this._hash(17000 + idx) * 2 - 1) * this.cfg.hue_sp) % 360 + 360) % 360;
+					const twinkle = 0.4 + 0.6 * Math.pow(0.5 + 0.5 * Math.sin(this.tick * (0.02 + this._hash(18000 + idx) * 0.03) + idx), 2);
+					const light = clamp01((this.cfg.lmin + (this.cfg.lmax - this.cfg.lmin) * (0.3 + layerRatio * 0.7)) * twinkle * burst);
+					const alpha = clamp01(0.35 + 0.25 * layerRatio + 0.25 * twinkle);
+					const color = hslToRGB(hue, this.cfg.sat, light);
+					this._fillCell(ctx, sx, sy, ceilSx, ceilSy, Math.round(col), Math.round(row), size, size, `rgb(${color.r},${color.g},${color.b})`, alpha);
+				}
+			}
+
+			if (this.timers['shooting-star'] > 0) {
+				const total = Math.max(1, this.values['shooting-star_total'] || this.cfg.shooting_star_dur);
+				const progress = 1 - (this.timers['shooting-star'] / total);
+				const dir = this.values.shooting_dir || 1;
+				const row = this.values.shooting_row || this.h * 0.25;
+				const start = this.values.shooting_start || this.w * 0.25;
+				const head = positiveMod(start + dir * progress * this.w * 0.6, this.w);
+				for (let i = 0; i < 7; i++) {
+					const fade = 1 - i / 7;
+					const x = Math.round(head - dir * i * 1.5);
+					const y = Math.round(row + i * 0.6);
+					const light = clamp01(this.cfg.lmax * this.cfg.shooting_star_mult * fade * 0.55);
+					const color = hslToRGB(this.cfg.hue - 8, clamp01(this.cfg.sat * 0.9), light);
+					this._fillCell(ctx, sx, sy, ceilSx, ceilSy, x, y, 1 + (i === 0 ? 1 : 0), 1, `rgb(${color.r},${color.g},${color.b})`, fade);
+				}
+			}
+		}
+	}
+
+	class Starfield extends ProceduralScene {
+		constructor(w, h, cfg, seed) {
+			super('starfield', w, h, cfg, seed);
+		}
 	}
 
 	class AutumnLeaves extends ProceduralScene {
@@ -2282,8 +2442,79 @@
 	// server's snapshot payload — the client looks up the constructor here
 	// by name so new effects just register themselves and work without
 	// client-side changes.
-	const effects = { rain: Rain, dust: Dust, fireflies: Fireflies, waterfall: Waterfall, snow: Snow, 'autumn-leaves': AutumnLeaves };
+	const effects = { rain: Rain, dust: Dust, fireflies: Fireflies, waterfall: Waterfall, snow: Snow, 'autumn-leaves': AutumnLeaves, starfield: Starfield };
 	const presets = {
+		starfield: [
+			{
+				key: 'still-night',
+				label: 'still night',
+				config: {
+					density: 0.16,
+					speed: 0.08,
+					drift: 0.02,
+					layers: 2,
+					size: 1,
+					hue: 214,
+					hue_sp: 12,
+					sat: 0.16,
+					lmin: 0.5,
+					lmax: 0.9,
+				},
+			},
+			{
+				key: 'soft-parallax',
+				label: 'soft parallax',
+				config: {
+					density: 0.22,
+					speed: 0.12,
+					drift: 0.04,
+					layers: 3,
+					size: 1,
+					hue: 218,
+					hue_sp: 18,
+					sat: 0.18,
+					lmin: 0.55,
+					lmax: 0.95,
+					twinkle_burst_p: 0.0006,
+				},
+			},
+			{
+				key: 'meteor-watch',
+				label: 'meteor watch',
+				config: {
+					density: 0.24,
+					speed: 0.14,
+					drift: 0.06,
+					layers: 3,
+					size: 1.2,
+					hue: 214,
+					hue_sp: 22,
+					sat: 0.2,
+					lmin: 0.56,
+					lmax: 0.96,
+					shooting_star_p: 0.0012,
+					shooting_star_mult: 2.4,
+				},
+			},
+			{
+				key: 'cold-deep-space',
+				label: 'cold deep space',
+				config: {
+					density: 0.2,
+					speed: 0.09,
+					drift: 0.03,
+					layers: 4,
+					size: 1,
+					hue: 226,
+					hue_sp: 26,
+					sat: 0.22,
+					lmin: 0.52,
+					lmax: 0.94,
+					twinkle_burst_p: 0.0009,
+					twinkle_burst_mult: 1.9,
+				},
+			},
+		],
 		'autumn-leaves': [
 			{
 				key: 'few-leaves',
@@ -2639,5 +2870,5 @@
 		],
 	};
 
-	global.AmbienceSim = { Rain, Dust, Fireflies, Waterfall, AutumnLeaves, Snow, subscribe, applyDefaults, hslToRGB, effects, presets };
+	global.AmbienceSim = { Rain, Dust, Fireflies, Waterfall, AutumnLeaves, Snow, Starfield, subscribe, applyDefaults, hslToRGB, effects, presets };
 })(window);

--- a/sim/procedural.go
+++ b/sim/procedural.go
@@ -99,6 +99,30 @@ var autumnLeavesDefaults = ProceduralConfig{
 	"swirl_pull":     1.15,
 }
 
+var starfieldDefaults = ProceduralConfig{
+	"intro_dur":          50,
+	"intro_density":      0.08,
+	"ending_dur":         60,
+	"ending_linger":      16,
+	"ending_density":     0.03,
+	"density":            0.22,
+	"speed":              0.12,
+	"drift":              0.04,
+	"layers":             3,
+	"size":               1.0,
+	"hue":                218,
+	"hue_sp":             18,
+	"sat":                0.18,
+	"lmin":               0.55,
+	"lmax":               0.95,
+	"shooting_star_p":    0.0,
+	"twinkle_burst_p":    0.0,
+	"shooting_star_dur":  26,
+	"shooting_star_mult": 1.8,
+	"twinkle_burst_dur":  42,
+	"twinkle_burst_mult": 1.7,
+}
+
 func SnowSchema() EffectSchema {
 	return EffectSchema{
 		Name: "snow",
@@ -209,6 +233,56 @@ func AutumnLeavesSchema() EffectSchema {
 	}
 }
 
+func StarfieldSchema() EffectSchema {
+	return EffectSchema{
+		Name: "starfield",
+		Knobs: []Knob{
+			{Key: "intro_dur", Label: "intro dur", Slot: SlotSpawn, Group: "introduction", Type: KnobInt, Min: 10, Max: 220, Step: 5, Default: 50, Trigger: "intro",
+				Description: "Ticks spent populating the star layers from sparse points into the full field."},
+			{Key: "intro_density", Label: "intro density", Slot: SlotSpawn, Group: "introduction", Type: KnobFloat, Min: 0.01, Max: 0.4, Step: 0.01, Default: 0.08,
+				Description: "Starting fraction of the full star density before the field finishes blooming in."},
+			{Key: "ending_dur", Label: "ending dur", Slot: SlotEnd, Group: "ending", Type: KnobInt, Min: 10, Max: 220, Step: 5, Default: 60, Trigger: "ending",
+				Description: "Ticks spent dimming the starfield back toward near-darkness."},
+			{Key: "ending_linger", Label: "ending linger", Slot: SlotEnd, Group: "ending", Type: KnobInt, Min: 0, Max: 120, Step: 5, Default: 16,
+				Description: "Extra quiet ticks after the fade so the last points can linger."},
+			{Key: "ending_density", Label: "ending residue", Slot: SlotEnd, Group: "ending", Type: KnobFloat, Min: 0, Max: 0.3, Step: 0.01, Default: 0.03,
+				Description: "How much of the far starfield remains near the end of the outro."},
+			{Key: "density", Label: "density", Slot: SlotLever, Group: "field", Type: KnobFloat, Min: 0.05, Max: 0.6, Step: 0.01, Default: 0.22,
+				Description: "Base star density across the full field."},
+			{Key: "speed", Label: "parallax", Slot: SlotLever, Group: "field", Type: KnobFloat, Min: 0.02, Max: 0.4, Step: 0.01, Default: 0.12,
+				Description: "How quickly the parallax layers drift across the scene."},
+			{Key: "drift", Label: "drift", Slot: SlotLever, Group: "field", Type: KnobFloat, Min: -0.25, Max: 0.25, Step: 0.01, Default: 0.04,
+				Description: "Baseline horizontal drift direction for the starfield."},
+			{Key: "layers", Label: "layers", Slot: SlotLever, Group: "field", Type: KnobInt, Min: 1, Max: 4, Step: 1, Default: 3,
+				Description: "Number of parallax layers."},
+			{Key: "size", Label: "star size", Slot: SlotLever, Group: "field", Type: KnobFloat, Min: 0.5, Max: 2.5, Step: 0.1, Default: 1,
+				Description: "Pixel size of the nearest stars."},
+			{Key: "hue", Label: "hue", Slot: SlotLever, Group: "color", Type: KnobFloat, Min: 190, Max: 250, Step: 1, Default: 218,
+				Description: "Base star tint. Lower values lean blue-cyan; higher values lean violet."},
+			{Key: "hue_sp", Label: "hue spread", Slot: SlotLever, Group: "color", Type: KnobFloat, Min: 0, Max: 36, Step: 1, Default: 18,
+				Description: "Variation in the star tint across the field."},
+			{Key: "sat", Label: "saturation", Slot: SlotLever, Group: "color", Type: KnobFloat, Min: 0.01, Max: 0.5, Step: 0.01, Default: 0.18,
+				Description: "Overall star color saturation."},
+			{Key: "lmin", Label: "light min", Slot: SlotLever, Group: "color", Type: KnobFloat, Min: 0.2, Max: 0.85, Step: 0.01, Default: 0.55,
+				Description: "Minimum lightness used for the dimmest background stars."},
+			{Key: "lmax", Label: "light max", Slot: SlotLever, Group: "color", Type: KnobFloat, Min: 0.3, Max: 1.0, Step: 0.01, Default: 0.95,
+				Description: "Maximum lightness used for the nearest stars and bright accents."},
+			{Key: "shooting_star_p", Label: "shooting star", Slot: SlotEvent, Type: KnobFloat, Min: 0, Max: 0.01, Step: 0.0002, Default: 0, Trigger: "shooting-star",
+				Description: "Per-tick chance of a rare shooting star crossing the field."},
+			{Key: "twinkle_burst_p", Label: "twinkle burst", Slot: SlotEvent, Type: KnobFloat, Min: 0, Max: 0.02, Step: 0.0005, Default: 0, Trigger: "twinkle-burst",
+				Description: "Per-tick chance of a brief field-wide brightening."},
+			{Key: "shooting_star_dur", Label: "shoot dur", Slot: SlotEventMod, Group: "shooting-star", Type: KnobInt, Min: 6, Max: 80, Step: 2, Default: 26,
+				Description: "How long a shooting star remains visible."},
+			{Key: "shooting_star_mult", Label: "shoot x", Slot: SlotEventMod, Group: "shooting-star", Type: KnobFloat, Min: 1.05, Max: 4, Step: 0.05, Default: 1.8,
+				Description: "Brightness multiplier for the shooting star accent."},
+			{Key: "twinkle_burst_dur", Label: "burst dur", Slot: SlotEventMod, Group: "twinkle-burst", Type: KnobInt, Min: 10, Max: 160, Step: 5, Default: 42,
+				Description: "Duration of the twinkle burst brightening window."},
+			{Key: "twinkle_burst_mult", Label: "burst x", Slot: SlotEventMod, Group: "twinkle-burst", Type: KnobFloat, Min: 1.05, Max: 3, Step: 0.05, Default: 1.7,
+				Description: "Brightness multiplier applied during a twinkle burst."},
+		},
+	}
+}
+
 func cloneProceduralConfig(src ProceduralConfig) ProceduralConfig {
 	if src == nil {
 		return ProceduralConfig{}
@@ -253,6 +327,8 @@ func proceduralDefaults(kind string) ProceduralConfig {
 		return cloneProceduralConfig(snowDefaults)
 	case "autumn-leaves":
 		return cloneProceduralConfig(autumnLeavesDefaults)
+	case "starfield":
+		return cloneProceduralConfig(starfieldDefaults)
 	default:
 		return ProceduralConfig{}
 	}
@@ -377,6 +453,60 @@ func mergeProceduralDefaults(kind string, cfg ProceduralConfig) ProceduralConfig
 		}
 		if out["swirl_pull"] <= 0 {
 			out["swirl_pull"] = autumnLeavesDefaults["swirl_pull"]
+		}
+	case "starfield":
+		if out["intro_dur"] <= 0 {
+			out["intro_dur"] = starfieldDefaults["intro_dur"]
+		}
+		out["intro_density"] = clamp01(out["intro_density"])
+		if out["ending_dur"] <= 0 {
+			out["ending_dur"] = starfieldDefaults["ending_dur"]
+		}
+		if out["ending_linger"] < 0 {
+			out["ending_linger"] = 0
+		}
+		out["ending_density"] = clamp01(out["ending_density"])
+		if out["density"] <= 0 {
+			out["density"] = starfieldDefaults["density"]
+		}
+		if out["speed"] <= 0 {
+			out["speed"] = starfieldDefaults["speed"]
+		}
+		if out["layers"] < 1 {
+			out["layers"] = starfieldDefaults["layers"]
+		}
+		if out["size"] <= 0 {
+			out["size"] = starfieldDefaults["size"]
+		}
+		if out["hue"] == 0 {
+			out["hue"] = starfieldDefaults["hue"]
+		}
+		if out["hue_sp"] < 0 {
+			out["hue_sp"] = 0
+		}
+		if out["sat"] <= 0 {
+			out["sat"] = starfieldDefaults["sat"]
+		}
+		if out["lmin"] <= 0 {
+			out["lmin"] = starfieldDefaults["lmin"]
+		}
+		if out["lmax"] <= 0 {
+			out["lmax"] = starfieldDefaults["lmax"]
+		}
+		if out["lmax"] < out["lmin"] {
+			out["lmin"], out["lmax"] = out["lmax"], out["lmin"]
+		}
+		if out["shooting_star_dur"] <= 0 {
+			out["shooting_star_dur"] = starfieldDefaults["shooting_star_dur"]
+		}
+		if out["shooting_star_mult"] <= 0 {
+			out["shooting_star_mult"] = starfieldDefaults["shooting_star_mult"]
+		}
+		if out["twinkle_burst_dur"] <= 0 {
+			out["twinkle_burst_dur"] = starfieldDefaults["twinkle_burst_dur"]
+		}
+		if out["twinkle_burst_mult"] <= 0 {
+			out["twinkle_burst_mult"] = starfieldDefaults["twinkle_burst_mult"]
 		}
 	}
 	return out
@@ -542,6 +672,22 @@ func (p *Procedural) TriggerEvent(name string) bool {
 			return false
 		}
 		return true
+	case "starfield":
+		switch name {
+		case "shooting-star":
+			p.startStarfieldShootingStarLocked("triggered")
+		case "twinkle-burst":
+			p.startStarfieldTwinkleBurstLocked("triggered")
+		case "intro":
+			p.startStarfieldIntroLocked()
+			p.appendLog("intro", fmt.Sprintf("started (dur=%d, density=%.2f)", p.timers["intro"], p.cfg["intro_density"]))
+		case "ending":
+			p.startStarfieldEndingLocked()
+			p.appendLog("ending", fmt.Sprintf("started (fade=%d, linger=%d)", p.intCfg("ending_dur"), p.intCfg("ending_linger")))
+		default:
+			return false
+		}
+		return true
 	default:
 		return false
 	}
@@ -581,6 +727,8 @@ func (p *Procedural) Step() {
 		p.stepSnowLocked()
 	case "autumn-leaves":
 		p.stepAutumnLeavesLocked()
+	case "starfield":
+		p.stepStarfieldLocked()
 	}
 }
 
@@ -723,5 +871,60 @@ func (p *Procedural) stepAutumnLeavesLocked() {
 	}
 	if p.timers["swirl"] <= 0 && p.cfg["swirl_p"] > 0 && p.rng.Float64() < p.cfg["swirl_p"] {
 		p.startAutumnSwirlLocked("started")
+	}
+}
+
+func (p *Procedural) startStarfieldShootingStarLocked(verb string) {
+	p.timers["shooting-star"] = jitterInt(p.rng, p.intCfg("shooting_star_dur"), 0.3)
+	sign := 1.0
+	if p.rng.Float64() < 0.5 {
+		sign = -1
+	}
+	p.values["shooting_dir"] = sign
+	p.values["shooting_row"] = 6 + p.rng.Float64()*math.Max(4, float64(p.H)/3)
+	p.values["shooting_start"] = p.rng.Float64() * float64(max(1, p.W))
+	p.appendLog("shooting-star", fmt.Sprintf("%s (dur=%d, dir=%+.0f)", verb, p.timers["shooting-star"], sign))
+}
+
+func (p *Procedural) startStarfieldTwinkleBurstLocked(verb string) {
+	p.timers["twinkle-burst"] = jitterInt(p.rng, p.intCfg("twinkle_burst_dur"), 0.3)
+	p.appendLog("twinkle-burst", fmt.Sprintf("%s (dur=%d, x%.2f)", verb, p.timers["twinkle-burst"], p.cfg["twinkle_burst_mult"]))
+}
+
+func (p *Procedural) startStarfieldIntroLocked() {
+	p.timers["ending"] = 0
+	p.timers["shooting-star"] = 0
+	p.timers["twinkle-burst"] = 0
+	p.timers["intro"] = p.intCfg("intro_dur")
+	p.values["intro_total"] = float64(p.timers["intro"])
+}
+
+func (p *Procedural) startStarfieldEndingLocked() {
+	p.timers["intro"] = 0
+	p.timers["shooting-star"] = 0
+	p.timers["twinkle-burst"] = 0
+	endingTotal := p.intCfg("ending_dur") + max(0, p.intCfg("ending_linger"))
+	if endingTotal < 1 {
+		endingTotal = max(1, p.intCfg("ending_dur"))
+	}
+	p.timers["ending"] = endingTotal
+	p.values["ending_total"] = float64(endingTotal)
+}
+
+func (p *Procedural) stepStarfieldLocked() {
+	if p.timers["intro"] <= 0 {
+		delete(p.values, "intro_total")
+	}
+	if p.timers["ending"] <= 0 {
+		delete(p.values, "ending_total")
+	}
+	if p.timers["intro"] > 0 || p.timers["ending"] > 0 {
+		return
+	}
+	if p.timers["shooting-star"] <= 0 && p.cfg["shooting_star_p"] > 0 && p.rng.Float64() < p.cfg["shooting_star_p"] {
+		p.startStarfieldShootingStarLocked("started")
+	}
+	if p.timers["twinkle-burst"] <= 0 && p.cfg["twinkle_burst_p"] > 0 && p.rng.Float64() < p.cfg["twinkle_burst_p"] {
+		p.startStarfieldTwinkleBurstLocked("started")
 	}
 }

--- a/sim/procedural_test.go
+++ b/sim/procedural_test.go
@@ -22,6 +22,16 @@ func TestAutumnLeavesSchema(t *testing.T) {
 	}
 }
 
+func TestStarfieldSchema(t *testing.T) {
+	schema := StarfieldSchema()
+	if schema.Name != "starfield" {
+		t.Fatalf("schema name = %q, want starfield", schema.Name)
+	}
+	if len(schema.Knobs) == 0 {
+		t.Fatal("expected starfield schema knobs")
+	}
+}
+
 func TestProceduralSnowSnapshotRestore(t *testing.T) {
 	p := NewProcedural("snow", 160, 80, 42, nil)
 	if !p.TriggerEvent("gust") {
@@ -71,5 +81,25 @@ func TestProceduralAutumnLeavesSnapshotRestore(t *testing.T) {
 	again := restored.Snapshot()
 	if again.Timers["swirl"] != snap.Timers["swirl"] {
 		t.Fatalf("restored swirl timer = %d, want %d", again.Timers["swirl"], snap.Timers["swirl"])
+	}
+}
+
+func TestProceduralStarfieldSnapshotRestore(t *testing.T) {
+	p := NewProcedural("starfield", 160, 80, 12, nil)
+	if !p.TriggerEvent("shooting-star") {
+		t.Fatal("expected shooting-star trigger to succeed")
+	}
+	p.Step()
+
+	snap := p.Snapshot()
+	if snap.Timers["shooting-star"] <= 0 {
+		t.Fatal("expected shooting-star timer in snapshot")
+	}
+
+	restored := NewProcedural("starfield", 160, 80, 7, nil)
+	restored.RestoreSnapshot(snap)
+	again := restored.Snapshot()
+	if again.Timers["shooting-star"] != snap.Timers["shooting-star"] {
+		t.Fatalf("restored shooting-star timer = %d, want %d", again.Timers["shooting-star"], snap.Timers["shooting-star"])
 	}
 }


### PR DESCRIPTION
## Summary
- extend the procedural scenic runtime with a layered starfield effect
- add schema/dev routing coverage and snapshot tests for /dev/starfield
- add the browser-side parallax starfield renderer with shooting-star and twinkle-burst events

## Testing
- go test ./...
- powershell -ExecutionPolicy Bypass -File scripts/dev-deploy.ps1 -Component all
- validated visually at https://ambience.dev.romaine.life/dev/starfield

Closes #19