### PR TITLE
Add the aurora dev effect prototype

### DIFF
--- a/cmd/ambience/dev_sessions_test.go
+++ b/cmd/ambience/dev_sessions_test.go
@@ -13,6 +13,7 @@ func TestDevPageEffectFromPath(t *testing.T) {
 	}{
 		{path: "/dev", want: "rain", wantOK: true},
 		{path: "/dev/", want: "rain", wantOK: true},
+		{path: "/dev/aurora", want: "aurora", wantOK: true},
 		{path: "/dev/dust", want: "dust", wantOK: true},
 		{path: "/dev/autumn-leaves", want: "autumn-leaves", wantOK: true},
 		{path: "/dev/fireflies", want: "fireflies", wantOK: true},
@@ -40,6 +41,7 @@ func TestEffectFromSchemaPath(t *testing.T) {
 		wantOK bool
 	}{
 		{path: "/effects/rain/schema", want: "rain", wantOK: true},
+		{path: "/effects/aurora/schema", want: "aurora", wantOK: true},
 		{path: "/effects/autumn-leaves/schema", want: "autumn-leaves", wantOK: true},
 		{path: "/effects/dust/schema", want: "dust", wantOK: true},
 		{path: "/effects/fireflies/schema", want: "fireflies", wantOK: true},
@@ -101,6 +103,17 @@ func TestNewDevSessionSnowSnapshotType(t *testing.T) {
 	snap := session.snapshot()
 	if snap.Type != "snow" {
 		t.Fatalf("snapshot type = %q, want snow", snap.Type)
+	}
+}
+
+func TestNewDevSessionAuroraSnapshotType(t *testing.T) {
+	session, err := newDevSession("aurora")
+	if err != nil {
+		t.Fatalf("newDevSession: %v", err)
+	}
+	snap := session.snapshot()
+	if snap.Type != "aurora" {
+		t.Fatalf("snapshot type = %q, want aurora", snap.Type)
 	}
 }
 

--- a/cmd/ambience/effects.go
+++ b/cmd/ambience/effects.go
@@ -86,6 +86,11 @@ var effectRegistry = map[string]effectDefinition{
 		Schema:     sim.StarfieldSchema,
 		NewRuntime: newStarfieldRuntime,
 	},
+	"aurora": {
+		Type:       "aurora",
+		Schema:     sim.AuroraSchema,
+		NewRuntime: newAuroraRuntime,
+	},
 }
 
 func lookupEffectDefinition(effectType string) (effectDefinition, bool) {
@@ -236,6 +241,10 @@ func newAutumnLeavesRuntime(w, h int, seed int64, cfg json.RawMessage) (effectRu
 
 func newStarfieldRuntime(w, h int, seed int64, cfg json.RawMessage) (effectRuntime, error) {
 	return newProceduralRuntime("starfield", w, h, seed, cfg)
+}
+
+func newAuroraRuntime(w, h int, seed int64, cfg json.RawMessage) (effectRuntime, error) {
+	return newProceduralRuntime("aurora", w, h, seed, cfg)
 }
 
 func (r *rainRuntime) Type() string { return "rain" }
@@ -652,6 +661,8 @@ func (p *proceduralRuntime) Schema() sim.EffectSchema {
 		return sim.AutumnLeavesSchema()
 	case "starfield":
 		return sim.StarfieldSchema()
+	case "aurora":
+		return sim.AuroraSchema()
 	default:
 		return sim.EffectSchema{}
 	}

--- a/cmd/ambience/web/sim.js
+++ b/cmd/ambience/web/sim.js
@@ -1786,6 +1786,35 @@
 	}
 
 	const PROCEDURAL_DEFAULTS = {
+		aurora: {
+			intro_dur: 70,
+			intro_glow: 0.18,
+			ending_dur: 80,
+			ending_linger: 20,
+			ending_glow: 0.05,
+			intensity: 0.56,
+			speed: 0.11,
+			drift: 0.08,
+			bands: 3,
+			thickness: 9,
+			wave_amp: 6,
+			wave_freq: 0.16,
+			curtain_len: 15,
+			hue: 138,
+			hue_sp: 26,
+			sat: 0.72,
+			lmin: 0.2,
+			lmax: 0.74,
+			brighten_p: 0,
+			shift_p: 0,
+			fade_p: 0,
+			brighten_dur: 42,
+			brighten_mult: 1.45,
+			shift_dur: 64,
+			shift_amt: 1.1,
+			fade_dur: 58,
+			fade_mult: 0.6,
+		},
 		starfield: {
 			intro_dur: 50,
 			intro_density: 0.08,
@@ -1866,6 +1895,32 @@
 		const base = PROCEDURAL_DEFAULTS[kind] || {};
 		const c = Object.assign({}, base, cfg || {});
 		switch (kind) {
+			case 'aurora':
+				if (c.intro_dur <= 0) c.intro_dur = base.intro_dur;
+				c.intro_glow = clamp01(c.intro_glow);
+				if (c.ending_dur <= 0) c.ending_dur = base.ending_dur;
+				if (c.ending_linger < 0) c.ending_linger = 0;
+				c.ending_glow = clamp01(c.ending_glow);
+				if (c.intensity <= 0) c.intensity = base.intensity;
+				if (c.speed <= 0) c.speed = base.speed;
+				if (c.bands < 1) c.bands = base.bands;
+				if (c.thickness <= 0) c.thickness = base.thickness;
+				if (c.wave_amp <= 0) c.wave_amp = base.wave_amp;
+				if (c.wave_freq <= 0) c.wave_freq = base.wave_freq;
+				if (c.curtain_len <= 0) c.curtain_len = base.curtain_len;
+				if (c.hue === 0) c.hue = base.hue;
+				if (c.hue_sp < 0) c.hue_sp = 0;
+				if (c.sat <= 0) c.sat = base.sat;
+				if (c.lmin <= 0) c.lmin = base.lmin;
+				if (c.lmax <= 0) c.lmax = base.lmax;
+				if (c.lmax < c.lmin) [c.lmin, c.lmax] = [c.lmax, c.lmin];
+				if (c.brighten_dur <= 0) c.brighten_dur = base.brighten_dur;
+				if (c.brighten_mult <= 0) c.brighten_mult = base.brighten_mult;
+				if (c.shift_dur <= 0) c.shift_dur = base.shift_dur;
+				if (c.shift_amt <= 0) c.shift_amt = base.shift_amt;
+				if (c.fade_dur <= 0) c.fade_dur = base.fade_dur;
+				if (c.fade_mult <= 0) c.fade_mult = base.fade_mult;
+				break;
 			case 'starfield':
 				if (c.intro_dur <= 0) c.intro_dur = base.intro_dur;
 				c.intro_density = clamp01(c.intro_density);
@@ -1975,6 +2030,8 @@
 
 		triggerEvent(name) {
 			switch (this.kind) {
+				case 'aurora':
+					return this._triggerAurora(name);
 				case 'starfield':
 					return this._triggerStarfield(name);
 				case 'autumn-leaves':
@@ -1997,10 +2054,19 @@
 				if (!this.timers.gust || this.timers.gust <= 0) this.values.gust_push = 0;
 				if (!this.timers.swirl || this.timers.swirl <= 0) this.values.swirl_spin = 0;
 			}
+			if (this.kind === 'aurora') {
+				if (!this.timers.brighten || this.timers.brighten <= 0) this.values.brighten_gain = 0;
+				if (!this.timers.shift || this.timers.shift <= 0) {
+					this.values.shift_push = 0;
+					this.values.shift_seed = 0;
+				}
+			}
 		}
 
 		render(ctx, canvasW, canvasH, opts) {
 			switch (this.kind) {
+				case 'aurora':
+					return this._renderAurora(ctx, canvasW, canvasH, opts);
 				case 'starfield':
 					return this._renderStarfield(ctx, canvasW, canvasH, opts);
 				case 'autumn-leaves':
@@ -2099,6 +2165,47 @@
 			return false;
 		}
 
+		_triggerAurora(name) {
+			const rng = this._eventRng(name.length + 53);
+			switch (name) {
+				case 'brighten':
+					this.timers.brighten = jitterInt(rng, this.cfg.brighten_dur, 0.3);
+					this.values.brighten_gain = this.cfg.brighten_mult * (0.85 + rng() * 0.35);
+					return true;
+				case 'shift':
+					this.timers.shift = jitterInt(rng, this.cfg.shift_dur, 0.3);
+					this.values.shift_push = (rng() < 0.5 ? -1 : 1) * this.cfg.shift_amt * (0.55 + rng() * 0.55);
+					this.values.shift_seed = rng() * Math.PI * 2;
+					return true;
+				case 'fade':
+					this.timers.fade = jitterInt(rng, this.cfg.fade_dur, 0.3);
+					return true;
+				case 'intro':
+					this.timers.brighten = 0;
+					this.timers.shift = 0;
+					this.timers.fade = 0;
+					this.timers.ending = 0;
+					this.values.brighten_gain = 0;
+					this.values.shift_push = 0;
+					this.values.shift_seed = 0;
+					this.timers.intro = Math.max(1, Math.round(this.cfg.intro_dur));
+					this.values.intro_total = this.timers.intro;
+					return true;
+				case 'ending':
+					this.timers.intro = 0;
+					this.timers.brighten = 0;
+					this.timers.shift = 0;
+					this.timers.fade = 0;
+					this.values.brighten_gain = 0;
+					this.values.shift_push = 0;
+					this.values.shift_seed = 0;
+					this.timers.ending = Math.max(1, Math.round(this.cfg.ending_dur + Math.max(0, this.cfg.ending_linger)));
+					this.values.ending_total = this.timers.ending;
+					return true;
+			}
+			return false;
+		}
+
 		_triggerStarfield(name) {
 			const rng = this._eventRng(name.length + 41);
 			switch (name) {
@@ -2175,6 +2282,23 @@
 				const total = this.values.ending_total || (this.cfg.ending_dur + this.cfg.ending_linger);
 				const progress = this._phaseProgress(total, this.timers.ending);
 				level *= 1 - (1 - this.cfg.ending_density) * progress;
+			}
+			return Math.max(0.02, level);
+		}
+
+		_intensityLevelAurora() {
+			let level = this.cfg.intensity;
+			if (this.timers.brighten > 0) level *= this.values.brighten_gain || this.cfg.brighten_mult;
+			if (this.timers.fade > 0) level *= this.cfg.fade_mult;
+			if (this.timers.intro > 0) {
+				const total = this.values.intro_total || this.cfg.intro_dur;
+				const progress = this._phaseProgress(total, this.timers.intro);
+				level *= this.cfg.intro_glow + (1 - this.cfg.intro_glow) * progress;
+			}
+			if (this.timers.ending > 0) {
+				const total = this.values.ending_total || (this.cfg.ending_dur + this.cfg.ending_linger);
+				const progress = this._phaseProgress(total, this.timers.ending);
+				level *= 1 - (1 - this.cfg.ending_glow) * progress;
 			}
 			return Math.max(0.02, level);
 		}
@@ -2388,6 +2512,139 @@
 				}
 			}
 		}
+
+		_renderAurora(ctx, canvasW, canvasH, opts) {
+			opts = opts || {};
+			if (opts.transparent) {
+				ctx.clearRect(0, 0, canvasW, canvasH);
+			} else {
+				const sky = ctx.createLinearGradient(0, 0, 0, canvasH);
+				sky.addColorStop(0, '#02060f');
+				sky.addColorStop(0.52, '#07101c');
+				sky.addColorStop(1, '#0a1220');
+				ctx.fillStyle = sky;
+				ctx.fillRect(0, 0, canvasW, canvasH);
+			}
+
+			const sx = canvasW / this.w;
+			const sy = canvasH / this.h;
+			const ceilSx = Math.ceil(sx);
+			const ceilSy = Math.ceil(sy);
+			const groundRow = Math.floor(this.h * 0.82);
+			const intensity = this._intensityLevelAurora();
+			const bands = Math.max(1, Math.round(this.cfg.bands));
+			const shiftPush = this.values.shift_push || 0;
+			const shiftSeed = this.values.shift_seed || 0;
+
+			const horizonGlow = ctx.createLinearGradient(0, canvasH * 0.5, 0, canvasH);
+			horizonGlow.addColorStop(0, 'rgba(36, 84, 92, 0)');
+			horizonGlow.addColorStop(1, `rgba(48, 168, 140, ${clamp01(0.18 + intensity * 0.16)})`);
+			ctx.fillStyle = horizonGlow;
+			ctx.fillRect(0, canvasH * 0.48, canvasW, canvasH * 0.52);
+
+			const baseGround = hslToRGB(212, 0.2, 0.04);
+			this._fillCell(ctx, sx, sy, ceilSx, ceilSy, 0, groundRow - 1, this.w, this.h - groundRow + 1, `rgb(${baseGround.r},${baseGround.g},${baseGround.b})`, 1);
+
+			const starCount = Math.max(12, Math.round(this.w * 0.18));
+			for (let i = 0; i < starCount; i++) {
+				const col = Math.floor(this._hash(19000 + i) * this.w);
+				const row = Math.floor(this._hash(19100 + i) * Math.max(1, groundRow - 10));
+				const twinkle = 0.35 + 0.65 * Math.pow(0.5 + 0.5 * Math.sin(this.tick * (0.018 + this._hash(19200 + i) * 0.02) + i), 2);
+				const alpha = clamp01((0.14 + twinkle * 0.22) * (1 - Math.min(0.65, intensity * 0.55)));
+				const color = hslToRGB(205 + this._hash(19300 + i) * 18, 0.18, 0.72 + this._hash(19400 + i) * 0.2);
+				this._fillCell(ctx, sx, sy, ceilSx, ceilSy, col, row, 1, 1, `rgb(${color.r},${color.g},${color.b})`, alpha);
+			}
+
+			const ridgePoints = [];
+			const ridgeSegments = 7;
+			const ridgeColor = hslToRGB(210, 0.24, 0.055);
+			for (let i = 0; i <= ridgeSegments; i++) {
+				ridgePoints.push(groundRow - 4 - Math.floor(this._hash(19500 + i) * 6) - Math.floor((0.5 + 0.5 * Math.sin(i * 1.3 + this._hash(19600 + i) * 4)) * 4));
+			}
+			const ridgeCoords = [];
+			for (let x = 0; x < this.w; x++) {
+				const pos = (x / Math.max(1, this.w - 1)) * ridgeSegments;
+				const idx = Math.min(ridgeSegments - 1, Math.floor(pos));
+				const frac = pos - idx;
+				const eased = frac * frac * (3 - 2 * frac);
+				const ridge = Math.round(ridgePoints[idx] + (ridgePoints[idx + 1] - ridgePoints[idx]) * eased + Math.sin(x * 0.08 + shiftSeed) * 0.8);
+				ridgeCoords.push({ x, ridge });
+			}
+			ctx.fillStyle = `rgb(${ridgeColor.r},${ridgeColor.g},${ridgeColor.b})`;
+			ctx.beginPath();
+			ctx.moveTo(0, canvasH);
+			for (const point of ridgeCoords) {
+				ctx.lineTo(Math.floor(point.x * sx), Math.floor(point.ridge * sy));
+			}
+			ctx.lineTo(canvasW, canvasH);
+			ctx.closePath();
+			ctx.fill();
+
+			const treeCount = 12;
+			for (let i = 0; i < treeCount; i++) {
+				const center = Math.floor((i + 0.5) * this.w / treeCount + (this._hash(19900 + i) - 0.5) * 5);
+				const trunkH = 1 + Math.floor(this._hash(20000 + i) * 2);
+				const crownH = 5 + Math.floor(this._hash(20100 + i) * 5);
+				const half = 1 + Math.floor(this._hash(20200 + i) * 2);
+				const baseY = groundRow - 1 - Math.floor(this._hash(20300 + i) * 4);
+				const treeColor = hslToRGB(210 + this._hash(20400 + i) * 10, 0.22, 0.045 + this._hash(20500 + i) * 0.02);
+				for (let row = 0; row < crownH; row++) {
+					const width = Math.max(1, half - Math.floor(row / 2));
+					const y = baseY - crownH + row;
+					for (let dx = -width; dx <= width; dx++) {
+						this._fillCell(ctx, sx, sy, ceilSx, ceilSy, center + dx, y, 1, 1, `rgb(${treeColor.r},${treeColor.g},${treeColor.b})`, 1);
+					}
+				}
+				for (let row = 0; row < trunkH; row++) {
+					this._fillCell(ctx, sx, sy, ceilSx, ceilSy, center, baseY - row, 1, 1, `rgb(${treeColor.r},${treeColor.g},${treeColor.b})`, 1);
+				}
+			}
+
+			for (let band = 0; band < bands; band++) {
+				const bandRatio = bands === 1 ? 0.5 : band / (bands - 1);
+				const phase = this.tick * this.cfg.speed * (0.18 + bandRatio * 0.12) + band * 1.6 + shiftSeed;
+				const amp = this.cfg.wave_amp * (0.8 + bandRatio * 0.35);
+				const freq = this.cfg.wave_freq * (0.82 + bandRatio * 0.26);
+				const thickness = this.cfg.thickness * (0.8 + bandRatio * 0.28);
+				const curtain = this.cfg.curtain_len * (0.8 + bandRatio * 0.22);
+				const baseY = this.h * (0.16 + bandRatio * 0.08) + Math.sin(this.tick * 0.01 + band * 0.8) * 1.1;
+				const hueBase = ((this.cfg.hue + (bandRatio - 0.5) * this.cfg.hue_sp * 1.15 + shiftPush * 5) % 360 + 360) % 360;
+
+				for (let x = 0; x < this.w; x++) {
+					const nx = x / Math.max(1, this.w - 1);
+					const arch = Math.sin(nx * Math.PI * (1.08 + bandRatio * 0.24) + band * 0.75);
+					const wave = Math.sin(x * freq + phase + this.tick * this.cfg.drift * 0.04);
+					const subWave = Math.sin(x * freq * 0.47 - phase * 0.62 + band * 2.1);
+					const center = baseY + arch * amp * 0.72 + wave * amp * 0.52 + subWave * amp * 0.22 + shiftPush * Math.sin(x * 0.07 + phase) * 1.05;
+					const startY = Math.max(0, Math.floor(center - thickness * 1.15));
+					const endY = Math.min(groundRow - 2, Math.ceil(center + curtain));
+					for (let y = startY; y <= endY; y++) {
+						const dy = y - center;
+						const core = Math.exp(-(dy * dy) / Math.max(1, thickness * thickness * 1.4));
+						const tail = y >= center ? Math.exp(-(y - center) / Math.max(1, curtain)) : 0;
+						const shimmer = 0.76 + 0.24 * Math.sin(this.tick * 0.03 + x * 0.1 + band * 1.7);
+						const strength = (core * 0.9 + tail * 0.7) * intensity * shimmer * (0.58 + 0.42 * Math.max(0.2, arch));
+						if (strength < 0.025) continue;
+						const hue = ((hueBase + Math.sin(y * 0.18 + x * 0.06 + phase) * this.cfg.hue_sp * 0.32 + band * 6) % 360 + 360) % 360;
+						const sat = clamp01(this.cfg.sat * (0.84 + core * 0.28));
+						const light = clamp01(this.cfg.lmin + (this.cfg.lmax - this.cfg.lmin) * Math.min(1, 0.24 + strength));
+						const color = hslToRGB(hue, sat, light);
+						const alpha = clamp01(strength * (0.34 + core * 0.46));
+						this._fillCell(ctx, sx, sy, ceilSx, ceilSy, x, y, 1, 1, `rgb(${color.r},${color.g},${color.b})`, alpha);
+						if (core > 0.62 && y < groundRow - 3) {
+							const accent = hslToRGB((hue + 12) % 360, clamp01(sat * 0.9), clamp01(light * 1.08));
+							this._fillCell(ctx, sx, sy, ceilSx, ceilSy, x, y, 1, 1, `rgb(${accent.r},${accent.g},${accent.b})`, alpha * 0.45);
+						}
+					}
+				}
+			}
+		}
+	}
+
+	class Aurora extends ProceduralScene {
+		constructor(w, h, cfg, seed) {
+			super('aurora', w, h, cfg, seed);
+		}
 	}
 
 	class Starfield extends ProceduralScene {
@@ -2442,8 +2699,93 @@
 	// server's snapshot payload — the client looks up the constructor here
 	// by name so new effects just register themselves and work without
 	// client-side changes.
-	const effects = { rain: Rain, dust: Dust, fireflies: Fireflies, waterfall: Waterfall, snow: Snow, 'autumn-leaves': AutumnLeaves, starfield: Starfield };
+	const effects = { rain: Rain, dust: Dust, fireflies: Fireflies, waterfall: Waterfall, aurora: Aurora, snow: Snow, 'autumn-leaves': AutumnLeaves, starfield: Starfield };
 	const presets = {
+		aurora: [
+			{
+				key: 'green-veil',
+				label: 'green veil',
+				config: {
+					intensity: 0.54,
+					speed: 0.1,
+					drift: 0.06,
+					bands: 3,
+					thickness: 9,
+					wave_amp: 5.5,
+					wave_freq: 0.15,
+					curtain_len: 14,
+					hue: 134,
+					hue_sp: 18,
+					sat: 0.7,
+					lmin: 0.2,
+					lmax: 0.72,
+					shift_p: 0.0007,
+				},
+			},
+			{
+				key: 'cold-ribbons',
+				label: 'cold ribbons',
+				config: {
+					intensity: 0.48,
+					speed: 0.12,
+					drift: 0.1,
+					bands: 4,
+					thickness: 7.5,
+					wave_amp: 6.5,
+					wave_freq: 0.18,
+					curtain_len: 13,
+					hue: 164,
+					hue_sp: 34,
+					sat: 0.66,
+					lmin: 0.18,
+					lmax: 0.76,
+					shift_p: 0.0011,
+					fade_p: 0.0005,
+				},
+			},
+			{
+				key: 'quiet-sky',
+				label: 'quiet sky',
+				config: {
+					intensity: 0.34,
+					speed: 0.07,
+					drift: 0.03,
+					bands: 2,
+					thickness: 8.5,
+					wave_amp: 4.5,
+					wave_freq: 0.12,
+					curtain_len: 11,
+					hue: 142,
+					hue_sp: 14,
+					sat: 0.58,
+					lmin: 0.16,
+					lmax: 0.64,
+					fade_p: 0.0008,
+				},
+			},
+			{
+				key: 'bright-aurora',
+				label: 'bright aurora',
+				config: {
+					intensity: 0.72,
+					speed: 0.14,
+					drift: 0.12,
+					bands: 4,
+					thickness: 10,
+					wave_amp: 7.2,
+					wave_freq: 0.19,
+					curtain_len: 18,
+					hue: 136,
+					hue_sp: 30,
+					sat: 0.78,
+					lmin: 0.22,
+					lmax: 0.82,
+					brighten_p: 0.0012,
+					brighten_mult: 1.7,
+					shift_p: 0.001,
+				},
+			},
+		],
 		starfield: [
 			{
 				key: 'still-night',
@@ -2870,5 +3212,5 @@
 		],
 	};
 
-	global.AmbienceSim = { Rain, Dust, Fireflies, Waterfall, AutumnLeaves, Snow, Starfield, subscribe, applyDefaults, hslToRGB, effects, presets };
+	global.AmbienceSim = { Rain, Dust, Fireflies, Waterfall, Aurora, AutumnLeaves, Snow, Starfield, subscribe, applyDefaults, hslToRGB, effects, presets };
 })(window);

--- a/sim/procedural.go
+++ b/sim/procedural.go
@@ -123,6 +123,36 @@ var starfieldDefaults = ProceduralConfig{
 	"twinkle_burst_mult": 1.7,
 }
 
+var auroraDefaults = ProceduralConfig{
+	"intro_dur":     70,
+	"intro_glow":    0.18,
+	"ending_dur":    80,
+	"ending_linger": 20,
+	"ending_glow":   0.05,
+	"intensity":     0.56,
+	"speed":         0.11,
+	"drift":         0.08,
+	"bands":         3,
+	"thickness":     9,
+	"wave_amp":      6,
+	"wave_freq":     0.16,
+	"curtain_len":   15,
+	"hue":           138,
+	"hue_sp":        26,
+	"sat":           0.72,
+	"lmin":          0.20,
+	"lmax":          0.74,
+	"brighten_p":    0.0,
+	"shift_p":       0.0,
+	"fade_p":        0.0,
+	"brighten_dur":  42,
+	"brighten_mult": 1.45,
+	"shift_dur":     64,
+	"shift_amt":     1.10,
+	"fade_dur":      58,
+	"fade_mult":     0.60,
+}
+
 func SnowSchema() EffectSchema {
 	return EffectSchema{
 		Name: "snow",
@@ -283,6 +313,68 @@ func StarfieldSchema() EffectSchema {
 	}
 }
 
+func AuroraSchema() EffectSchema {
+	return EffectSchema{
+		Name: "aurora",
+		Knobs: []Knob{
+			{Key: "intro_dur", Label: "intro dur", Slot: SlotSpawn, Group: "introduction", Type: KnobInt, Min: 10, Max: 260, Step: 5, Default: 70, Trigger: "intro",
+				Description: "Ticks spent blooming from a faint horizon glow into the full aurora."},
+			{Key: "intro_glow", Label: "intro glow", Slot: SlotSpawn, Group: "introduction", Type: KnobFloat, Min: 0.01, Max: 0.6, Step: 0.01, Default: 0.18,
+				Description: "Starting brightness fraction before the ribbons fully form."},
+			{Key: "ending_dur", Label: "ending dur", Slot: SlotEnd, Group: "ending", Type: KnobInt, Min: 10, Max: 260, Step: 5, Default: 80, Trigger: "ending",
+				Description: "Ticks spent dimming and narrowing back toward a dark sky."},
+			{Key: "ending_linger", Label: "ending linger", Slot: SlotEnd, Group: "ending", Type: KnobInt, Min: 0, Max: 160, Step: 5, Default: 20,
+				Description: "Extra quiet ticks for the last faint glow to hang over the horizon."},
+			{Key: "ending_glow", Label: "ending glow", Slot: SlotEnd, Group: "ending", Type: KnobFloat, Min: 0, Max: 0.4, Step: 0.01, Default: 0.05,
+				Description: "Residual brightness fraction that remains near the end of the outro."},
+			{Key: "intensity", Label: "intensity", Slot: SlotLever, Group: "sky", Type: KnobFloat, Min: 0.05, Max: 1.2, Step: 0.01, Default: 0.56,
+				Description: "Overall luminance of the aurora ribbons."},
+			{Key: "speed", Label: "motion", Slot: SlotLever, Group: "sky", Type: KnobFloat, Min: 0.02, Max: 0.45, Step: 0.01, Default: 0.11,
+				Description: "How quickly the ribbons undulate across the sky."},
+			{Key: "drift", Label: "drift", Slot: SlotLever, Group: "sky", Type: KnobFloat, Min: -0.5, Max: 0.5, Step: 0.01, Default: 0.08,
+				Description: "Baseline sideways drift for the whole veil field."},
+			{Key: "bands", Label: "bands", Slot: SlotLever, Group: "sky", Type: KnobInt, Min: 1, Max: 5, Step: 1, Default: 3,
+				Description: "Number of main aurora ribbons."},
+			{Key: "thickness", Label: "thickness", Slot: SlotLever, Group: "sky", Type: KnobFloat, Min: 2, Max: 18, Step: 0.5, Default: 9,
+				Description: "Vertical thickness of each bright ribbon core."},
+			{Key: "wave_amp", Label: "wave amp", Slot: SlotLever, Group: "sky", Type: KnobFloat, Min: 1, Max: 18, Step: 0.5, Default: 6,
+				Description: "How far each ribbon arches and sways."},
+			{Key: "wave_freq", Label: "wave freq", Slot: SlotLever, Group: "sky", Type: KnobFloat, Min: 0.04, Max: 0.4, Step: 0.01, Default: 0.16,
+				Description: "Horizontal frequency of the ribbon arches."},
+			{Key: "curtain_len", Label: "curtain", Slot: SlotLever, Group: "sky", Type: KnobFloat, Min: 2, Max: 28, Step: 0.5, Default: 15,
+				Description: "How far the glow trails downward from each ribbon."},
+			{Key: "hue", Label: "hue", Slot: SlotLever, Group: "color", Type: KnobFloat, Min: 100, Max: 220, Step: 1, Default: 138,
+				Description: "Base aurora hue. Lower values lean green; higher values tip toward cyan-violet."},
+			{Key: "hue_sp", Label: "hue spread", Slot: SlotLever, Group: "color", Type: KnobFloat, Min: 0, Max: 60, Step: 1, Default: 26,
+				Description: "Variation between the different bands and edge glow."},
+			{Key: "sat", Label: "saturation", Slot: SlotLever, Group: "color", Type: KnobFloat, Min: 0.05, Max: 1, Step: 0.01, Default: 0.72,
+				Description: "Overall color saturation of the sky glow."},
+			{Key: "lmin", Label: "light min", Slot: SlotLever, Group: "color", Type: KnobFloat, Min: 0.05, Max: 0.7, Step: 0.01, Default: 0.20,
+				Description: "Minimum lightness used for the faint outer glow."},
+			{Key: "lmax", Label: "light max", Slot: SlotLever, Group: "color", Type: KnobFloat, Min: 0.15, Max: 0.95, Step: 0.01, Default: 0.74,
+				Description: "Maximum lightness used for the brightest ribbon centers."},
+			{Key: "brighten_p", Label: "brighten", Slot: SlotEvent, Type: KnobFloat, Min: 0, Max: 0.02, Step: 0.0005, Default: 0, Trigger: "brighten",
+				Description: "Per-tick chance of the sky blooming into a brighter curtain."},
+			{Key: "shift_p", Label: "shift", Slot: SlotEvent, Type: KnobFloat, Min: 0, Max: 0.02, Step: 0.0005, Default: 0, Trigger: "shift",
+				Description: "Per-tick chance of the aurora sliding into a new wave alignment."},
+			{Key: "fade_p", Label: "fade", Slot: SlotEvent, Type: KnobFloat, Min: 0, Max: 0.02, Step: 0.0005, Default: 0, Trigger: "fade",
+				Description: "Per-tick chance of the ribbons briefly thinning into a dimmer phase."},
+			{Key: "brighten_dur", Label: "bright dur", Slot: SlotEventMod, Group: "brighten", Type: KnobInt, Min: 10, Max: 200, Step: 5, Default: 42,
+				Description: "How long a brighten bloom lasts."},
+			{Key: "brighten_mult", Label: "bright x", Slot: SlotEventMod, Group: "brighten", Type: KnobFloat, Min: 1.05, Max: 3, Step: 0.05, Default: 1.45,
+				Description: "Brightness multiplier applied during a bloom."},
+			{Key: "shift_dur", Label: "shift dur", Slot: SlotEventMod, Group: "shift", Type: KnobInt, Min: 10, Max: 220, Step: 5, Default: 64,
+				Description: "How long the shifted alignment remains active."},
+			{Key: "shift_amt", Label: "shift amt", Slot: SlotEventMod, Group: "shift", Type: KnobFloat, Min: 0.1, Max: 3, Step: 0.05, Default: 1.1,
+				Description: "How strongly a shift event pulls the ribbons into a new phase."},
+			{Key: "fade_dur", Label: "fade dur", Slot: SlotEventMod, Group: "fade", Type: KnobInt, Min: 10, Max: 220, Step: 5, Default: 58,
+				Description: "How long the dimmer phase lasts."},
+			{Key: "fade_mult", Label: "fade x", Slot: SlotEventMod, Group: "fade", Type: KnobFloat, Min: 0.05, Max: 1, Step: 0.05, Default: 0.6,
+				Description: "Brightness multiplier applied during a fade event."},
+		},
+	}
+}
+
 func cloneProceduralConfig(src ProceduralConfig) ProceduralConfig {
 	if src == nil {
 		return ProceduralConfig{}
@@ -329,6 +421,8 @@ func proceduralDefaults(kind string) ProceduralConfig {
 		return cloneProceduralConfig(autumnLeavesDefaults)
 	case "starfield":
 		return cloneProceduralConfig(starfieldDefaults)
+	case "aurora":
+		return cloneProceduralConfig(auroraDefaults)
 	default:
 		return ProceduralConfig{}
 	}
@@ -507,6 +601,75 @@ func mergeProceduralDefaults(kind string, cfg ProceduralConfig) ProceduralConfig
 		}
 		if out["twinkle_burst_mult"] <= 0 {
 			out["twinkle_burst_mult"] = starfieldDefaults["twinkle_burst_mult"]
+		}
+	case "aurora":
+		if out["intro_dur"] <= 0 {
+			out["intro_dur"] = auroraDefaults["intro_dur"]
+		}
+		out["intro_glow"] = clamp01(out["intro_glow"])
+		if out["ending_dur"] <= 0 {
+			out["ending_dur"] = auroraDefaults["ending_dur"]
+		}
+		if out["ending_linger"] < 0 {
+			out["ending_linger"] = 0
+		}
+		out["ending_glow"] = clamp01(out["ending_glow"])
+		if out["intensity"] <= 0 {
+			out["intensity"] = auroraDefaults["intensity"]
+		}
+		if out["speed"] <= 0 {
+			out["speed"] = auroraDefaults["speed"]
+		}
+		if out["bands"] < 1 {
+			out["bands"] = auroraDefaults["bands"]
+		}
+		if out["thickness"] <= 0 {
+			out["thickness"] = auroraDefaults["thickness"]
+		}
+		if out["wave_amp"] <= 0 {
+			out["wave_amp"] = auroraDefaults["wave_amp"]
+		}
+		if out["wave_freq"] <= 0 {
+			out["wave_freq"] = auroraDefaults["wave_freq"]
+		}
+		if out["curtain_len"] <= 0 {
+			out["curtain_len"] = auroraDefaults["curtain_len"]
+		}
+		if out["hue"] == 0 {
+			out["hue"] = auroraDefaults["hue"]
+		}
+		if out["hue_sp"] < 0 {
+			out["hue_sp"] = 0
+		}
+		if out["sat"] <= 0 {
+			out["sat"] = auroraDefaults["sat"]
+		}
+		if out["lmin"] <= 0 {
+			out["lmin"] = auroraDefaults["lmin"]
+		}
+		if out["lmax"] <= 0 {
+			out["lmax"] = auroraDefaults["lmax"]
+		}
+		if out["lmax"] < out["lmin"] {
+			out["lmin"], out["lmax"] = out["lmax"], out["lmin"]
+		}
+		if out["brighten_dur"] <= 0 {
+			out["brighten_dur"] = auroraDefaults["brighten_dur"]
+		}
+		if out["brighten_mult"] <= 0 {
+			out["brighten_mult"] = auroraDefaults["brighten_mult"]
+		}
+		if out["shift_dur"] <= 0 {
+			out["shift_dur"] = auroraDefaults["shift_dur"]
+		}
+		if out["shift_amt"] <= 0 {
+			out["shift_amt"] = auroraDefaults["shift_amt"]
+		}
+		if out["fade_dur"] <= 0 {
+			out["fade_dur"] = auroraDefaults["fade_dur"]
+		}
+		if out["fade_mult"] <= 0 {
+			out["fade_mult"] = auroraDefaults["fade_mult"]
 		}
 	}
 	return out
@@ -688,6 +851,24 @@ func (p *Procedural) TriggerEvent(name string) bool {
 			return false
 		}
 		return true
+	case "aurora":
+		switch name {
+		case "brighten":
+			p.startAuroraBrightenLocked("triggered")
+		case "shift":
+			p.startAuroraShiftLocked("triggered")
+		case "fade":
+			p.startAuroraFadeLocked("triggered")
+		case "intro":
+			p.startAuroraIntroLocked()
+			p.appendLog("intro", fmt.Sprintf("started (dur=%d, glow=%.2f)", p.timers["intro"], p.cfg["intro_glow"]))
+		case "ending":
+			p.startAuroraEndingLocked()
+			p.appendLog("ending", fmt.Sprintf("started (fade=%d, linger=%d)", p.intCfg("ending_dur"), p.intCfg("ending_linger")))
+		default:
+			return false
+		}
+		return true
 	default:
 		return false
 	}
@@ -729,6 +910,8 @@ func (p *Procedural) Step() {
 		p.stepAutumnLeavesLocked()
 	case "starfield":
 		p.stepStarfieldLocked()
+	case "aurora":
+		p.stepAuroraLocked()
 	}
 }
 
@@ -926,5 +1109,83 @@ func (p *Procedural) stepStarfieldLocked() {
 	}
 	if p.timers["twinkle-burst"] <= 0 && p.cfg["twinkle_burst_p"] > 0 && p.rng.Float64() < p.cfg["twinkle_burst_p"] {
 		p.startStarfieldTwinkleBurstLocked("started")
+	}
+}
+
+func (p *Procedural) startAuroraBrightenLocked(verb string) {
+	p.timers["brighten"] = jitterInt(p.rng, p.intCfg("brighten_dur"), 0.3)
+	p.values["brighten_gain"] = p.cfg["brighten_mult"] * (0.85 + p.rng.Float64()*0.35)
+	p.appendLog("brighten", fmt.Sprintf("%s (dur=%d, x%.2f)", verb, p.timers["brighten"], p.values["brighten_gain"]))
+}
+
+func (p *Procedural) startAuroraShiftLocked(verb string) {
+	p.timers["shift"] = jitterInt(p.rng, p.intCfg("shift_dur"), 0.3)
+	sign := 1.0
+	if p.rng.Float64() < 0.5 {
+		sign = -1
+	}
+	p.values["shift_push"] = sign * p.cfg["shift_amt"] * (0.55 + p.rng.Float64()*0.55)
+	p.values["shift_seed"] = p.rng.Float64() * math.Pi * 2
+	p.appendLog("shift", fmt.Sprintf("%s (dur=%d, push=%+.2f)", verb, p.timers["shift"], p.values["shift_push"]))
+}
+
+func (p *Procedural) startAuroraFadeLocked(verb string) {
+	p.timers["fade"] = jitterInt(p.rng, p.intCfg("fade_dur"), 0.3)
+	p.appendLog("fade", fmt.Sprintf("%s (dur=%d, x%.2f)", verb, p.timers["fade"], p.cfg["fade_mult"]))
+}
+
+func (p *Procedural) startAuroraIntroLocked() {
+	p.timers["brighten"] = 0
+	p.timers["shift"] = 0
+	p.timers["fade"] = 0
+	p.timers["ending"] = 0
+	p.values["brighten_gain"] = 0
+	p.values["shift_push"] = 0
+	p.values["shift_seed"] = 0
+	p.timers["intro"] = p.intCfg("intro_dur")
+	p.values["intro_total"] = float64(p.timers["intro"])
+}
+
+func (p *Procedural) startAuroraEndingLocked() {
+	p.timers["intro"] = 0
+	p.timers["brighten"] = 0
+	p.timers["shift"] = 0
+	p.timers["fade"] = 0
+	p.values["brighten_gain"] = 0
+	p.values["shift_push"] = 0
+	p.values["shift_seed"] = 0
+	endingTotal := p.intCfg("ending_dur") + max(0, p.intCfg("ending_linger"))
+	if endingTotal < 1 {
+		endingTotal = max(1, p.intCfg("ending_dur"))
+	}
+	p.timers["ending"] = endingTotal
+	p.values["ending_total"] = float64(endingTotal)
+}
+
+func (p *Procedural) stepAuroraLocked() {
+	if p.timers["brighten"] <= 0 {
+		p.values["brighten_gain"] = 0
+	}
+	if p.timers["shift"] <= 0 {
+		p.values["shift_push"] = 0
+		p.values["shift_seed"] = 0
+	}
+	if p.timers["intro"] <= 0 {
+		delete(p.values, "intro_total")
+	}
+	if p.timers["ending"] <= 0 {
+		delete(p.values, "ending_total")
+	}
+	if p.timers["intro"] > 0 || p.timers["ending"] > 0 {
+		return
+	}
+	if p.timers["brighten"] <= 0 && p.cfg["brighten_p"] > 0 && p.rng.Float64() < p.cfg["brighten_p"] {
+		p.startAuroraBrightenLocked("started")
+	}
+	if p.timers["shift"] <= 0 && p.cfg["shift_p"] > 0 && p.rng.Float64() < p.cfg["shift_p"] {
+		p.startAuroraShiftLocked("started")
+	}
+	if p.timers["fade"] <= 0 && p.cfg["fade_p"] > 0 && p.rng.Float64() < p.cfg["fade_p"] {
+		p.startAuroraFadeLocked("started")
 	}
 }

--- a/sim/procedural_test.go
+++ b/sim/procedural_test.go
@@ -32,6 +32,16 @@ func TestStarfieldSchema(t *testing.T) {
 	}
 }
 
+func TestAuroraSchema(t *testing.T) {
+	schema := AuroraSchema()
+	if schema.Name != "aurora" {
+		t.Fatalf("schema name = %q, want aurora", schema.Name)
+	}
+	if len(schema.Knobs) == 0 {
+		t.Fatal("expected aurora schema knobs")
+	}
+}
+
 func TestProceduralSnowSnapshotRestore(t *testing.T) {
 	p := NewProcedural("snow", 160, 80, 42, nil)
 	if !p.TriggerEvent("gust") {
@@ -101,5 +111,31 @@ func TestProceduralStarfieldSnapshotRestore(t *testing.T) {
 	again := restored.Snapshot()
 	if again.Timers["shooting-star"] != snap.Timers["shooting-star"] {
 		t.Fatalf("restored shooting-star timer = %d, want %d", again.Timers["shooting-star"], snap.Timers["shooting-star"])
+	}
+}
+
+func TestProceduralAuroraSnapshotRestore(t *testing.T) {
+	p := NewProcedural("aurora", 160, 80, 77, nil)
+	if !p.TriggerEvent("shift") {
+		t.Fatal("expected shift trigger to succeed")
+	}
+	p.Step()
+
+	snap := p.Snapshot()
+	if snap.Timers["shift"] <= 0 {
+		t.Fatal("expected shift timer in snapshot")
+	}
+	if snap.Values["shift_push"] == 0 {
+		t.Fatal("expected shift push value in snapshot")
+	}
+
+	restored := NewProcedural("aurora", 160, 80, 7, nil)
+	restored.RestoreSnapshot(snap)
+	again := restored.Snapshot()
+	if again.Timers["shift"] != snap.Timers["shift"] {
+		t.Fatalf("restored shift timer = %d, want %d", again.Timers["shift"], snap.Timers["shift"])
+	}
+	if again.Values["shift_push"] != snap.Values["shift_push"] {
+		t.Fatalf("restored shift push = %f, want %f", again.Values["shift_push"], snap.Values["shift_push"])
 	}
 }


### PR DESCRIPTION
## Summary
- add the aurora procedural effect schema, runtime wiring, and snapshot/restore coverage
- implement a browser-side aurora renderer with brighten, shift, fade, intro, and ending behavior
- add aurora presets and dev-route/schema tests so /dev/aurora works end to end

## Validation
- go test ./...
- 
ode --check cmd/ambience/web/sim.js
- powershell -ExecutionPolicy Bypass -File scripts/dev-deploy.ps1 -Component all
- powershell -ExecutionPolicy Bypass -File scripts/dev-loop.ps1 -Once
- visual check on [ambience.dev.romaine.life/dev/aurora](https://ambience.dev.romaine.life/dev/aurora)

Refs #30