### PR TITLE
Add the wheat field dev effect prototype

### DIFF
--- a/cmd/ambience/dev_random_test.go
+++ b/cmd/ambience/dev_random_test.go
@@ -14,6 +14,11 @@ func TestRandomizedDevConfigStaysWithinSchemaBounds(t *testing.T) {
 		sim.DustSchema(),
 		sim.FirefliesSchema(),
 		sim.WaterfallSchema(),
+		sim.SnowSchema(),
+		sim.AutumnLeavesSchema(),
+		sim.StarfieldSchema(),
+		sim.AuroraSchema(),
+		sim.WheatFieldSchema(),
 	}
 
 	for i, schema := range schemas {
@@ -48,6 +53,11 @@ func TestRandomizedDevConfigChangesAtLeastOneKnob(t *testing.T) {
 		sim.DustSchema(),
 		sim.FirefliesSchema(),
 		sim.WaterfallSchema(),
+		sim.SnowSchema(),
+		sim.AutumnLeavesSchema(),
+		sim.StarfieldSchema(),
+		sim.AuroraSchema(),
+		sim.WheatFieldSchema(),
 	}
 
 	for i, schema := range schemas {

--- a/cmd/ambience/dev_sessions_test.go
+++ b/cmd/ambience/dev_sessions_test.go
@@ -20,6 +20,7 @@ func TestDevPageEffectFromPath(t *testing.T) {
 		{path: "/dev/snow", want: "snow", wantOK: true},
 		{path: "/dev/starfield", want: "starfield", wantOK: true},
 		{path: "/dev/waterfall", want: "waterfall", wantOK: true},
+		{path: "/dev/wheat-field", want: "wheat-field", wantOK: true},
 		{path: "/dev/unknown", wantOK: false},
 		{path: "/dev/fireflies/extra", wantOK: false},
 	}
@@ -48,6 +49,7 @@ func TestEffectFromSchemaPath(t *testing.T) {
 		{path: "/effects/snow/schema", want: "snow", wantOK: true},
 		{path: "/effects/starfield/schema", want: "starfield", wantOK: true},
 		{path: "/effects/waterfall/schema", want: "waterfall", wantOK: true},
+		{path: "/effects/wheat-field/schema", want: "wheat-field", wantOK: true},
 		{path: "/effects/unknown/schema", wantOK: false},
 		{path: "/effects/fireflies/not-schema", wantOK: false},
 	}
@@ -114,6 +116,17 @@ func TestNewDevSessionAuroraSnapshotType(t *testing.T) {
 	snap := session.snapshot()
 	if snap.Type != "aurora" {
 		t.Fatalf("snapshot type = %q, want aurora", snap.Type)
+	}
+}
+
+func TestNewDevSessionWheatFieldSnapshotType(t *testing.T) {
+	session, err := newDevSession("wheat-field")
+	if err != nil {
+		t.Fatalf("newDevSession: %v", err)
+	}
+	snap := session.snapshot()
+	if snap.Type != "wheat-field" {
+		t.Fatalf("snapshot type = %q, want wheat-field", snap.Type)
 	}
 }
 

--- a/cmd/ambience/effects.go
+++ b/cmd/ambience/effects.go
@@ -91,6 +91,11 @@ var effectRegistry = map[string]effectDefinition{
 		Schema:     sim.AuroraSchema,
 		NewRuntime: newAuroraRuntime,
 	},
+	"wheat-field": {
+		Type:       "wheat-field",
+		Schema:     sim.WheatFieldSchema,
+		NewRuntime: newWheatFieldRuntime,
+	},
 }
 
 func lookupEffectDefinition(effectType string) (effectDefinition, bool) {
@@ -245,6 +250,10 @@ func newStarfieldRuntime(w, h int, seed int64, cfg json.RawMessage) (effectRunti
 
 func newAuroraRuntime(w, h int, seed int64, cfg json.RawMessage) (effectRuntime, error) {
 	return newProceduralRuntime("aurora", w, h, seed, cfg)
+}
+
+func newWheatFieldRuntime(w, h int, seed int64, cfg json.RawMessage) (effectRuntime, error) {
+	return newProceduralRuntime("wheat-field", w, h, seed, cfg)
 }
 
 func (r *rainRuntime) Type() string { return "rain" }
@@ -663,6 +672,8 @@ func (p *proceduralRuntime) Schema() sim.EffectSchema {
 		return sim.StarfieldSchema()
 	case "aurora":
 		return sim.AuroraSchema()
+	case "wheat-field":
+		return sim.WheatFieldSchema()
 	default:
 		return sim.EffectSchema{}
 	}

--- a/cmd/ambience/web/sim.js
+++ b/cmd/ambience/web/sim.js
@@ -1815,6 +1815,32 @@
 			fade_dur: 58,
 			fade_mult: 0.6,
 		},
+		'wheat-field': {
+			intro_dur: 60,
+			intro_breeze: 0.16,
+			ending_dur: 70,
+			ending_linger: 20,
+			ending_sway: 0.08,
+			density: 0.48,
+			speed: 0.12,
+			drift: 0.16,
+			sway: 0.68,
+			wave_freq: 0.18,
+			field_top: 0.62,
+			stalk_h: 18,
+			layers: 3,
+			hue: 46,
+			hue_sp: 18,
+			sat: 0.64,
+			lmin: 0.3,
+			lmax: 0.76,
+			gust_p: 0,
+			calm_p: 0,
+			gust_dur: 50,
+			gust_mult: 1.85,
+			calm_dur: 72,
+			calm_mult: 0.4,
+		},
 		starfield: {
 			intro_dur: 50,
 			intro_density: 0.08,
@@ -1895,6 +1921,30 @@
 		const base = PROCEDURAL_DEFAULTS[kind] || {};
 		const c = Object.assign({}, base, cfg || {});
 		switch (kind) {
+			case 'wheat-field':
+				if (c.intro_dur <= 0) c.intro_dur = base.intro_dur;
+				c.intro_breeze = clamp01(c.intro_breeze);
+				if (c.ending_dur <= 0) c.ending_dur = base.ending_dur;
+				if (c.ending_linger < 0) c.ending_linger = 0;
+				c.ending_sway = clamp01(c.ending_sway);
+				if (c.density <= 0) c.density = base.density;
+				if (c.speed <= 0) c.speed = base.speed;
+				if (c.sway <= 0) c.sway = base.sway;
+				if (c.wave_freq <= 0) c.wave_freq = base.wave_freq;
+				if (c.field_top <= 0) c.field_top = base.field_top;
+				if (c.stalk_h <= 0) c.stalk_h = base.stalk_h;
+				if (c.layers < 1) c.layers = base.layers;
+				if (c.hue === 0) c.hue = base.hue;
+				if (c.hue_sp < 0) c.hue_sp = 0;
+				if (c.sat <= 0) c.sat = base.sat;
+				if (c.lmin <= 0) c.lmin = base.lmin;
+				if (c.lmax <= 0) c.lmax = base.lmax;
+				if (c.lmax < c.lmin) [c.lmin, c.lmax] = [c.lmax, c.lmin];
+				if (c.gust_dur <= 0) c.gust_dur = base.gust_dur;
+				if (c.gust_mult <= 0) c.gust_mult = base.gust_mult;
+				if (c.calm_dur <= 0) c.calm_dur = base.calm_dur;
+				if (c.calm_mult <= 0) c.calm_mult = base.calm_mult;
+				break;
 			case 'aurora':
 				if (c.intro_dur <= 0) c.intro_dur = base.intro_dur;
 				c.intro_glow = clamp01(c.intro_glow);
@@ -2030,6 +2080,8 @@
 
 		triggerEvent(name) {
 			switch (this.kind) {
+				case 'wheat-field':
+					return this._triggerWheatField(name);
 				case 'aurora':
 					return this._triggerAurora(name);
 				case 'starfield':
@@ -2061,10 +2113,15 @@
 					this.values.shift_seed = 0;
 				}
 			}
+			if (this.kind === 'wheat-field' && (!this.timers.gust || this.timers.gust <= 0)) {
+				this.values.gust_push = 0;
+			}
 		}
 
 		render(ctx, canvasW, canvasH, opts) {
 			switch (this.kind) {
+				case 'wheat-field':
+					return this._renderWheatField(ctx, canvasW, canvasH, opts);
 				case 'aurora':
 					return this._renderAurora(ctx, canvasW, canvasH, opts);
 				case 'starfield':
@@ -2158,6 +2215,36 @@
 					this.timers.swirl = 0;
 					this.values.gust_push = 0;
 					this.values.swirl_spin = 0;
+					this.timers.ending = Math.max(1, Math.round(this.cfg.ending_dur + Math.max(0, this.cfg.ending_linger)));
+					this.values.ending_total = this.timers.ending;
+					return true;
+			}
+			return false;
+		}
+
+		_triggerWheatField(name) {
+			const rng = this._eventRng(name.length + 47);
+			switch (name) {
+				case 'gust':
+					this.timers.gust = jitterInt(rng, this.cfg.gust_dur, 0.3);
+					this.values.gust_push = (rng() < 0.35 ? -1 : 1) * this.cfg.gust_mult * (0.55 + rng() * 0.55);
+					return true;
+				case 'calm':
+					this.timers.calm = jitterInt(rng, this.cfg.calm_dur, 0.3);
+					return true;
+				case 'intro':
+					this.timers.gust = 0;
+					this.timers.calm = 0;
+					this.timers.ending = 0;
+					this.values.gust_push = 0;
+					this.timers.intro = Math.max(1, Math.round(this.cfg.intro_dur));
+					this.values.intro_total = this.timers.intro;
+					return true;
+				case 'ending':
+					this.timers.intro = 0;
+					this.timers.gust = 0;
+					this.timers.calm = 0;
+					this.values.gust_push = 0;
 					this.timers.ending = Math.max(1, Math.round(this.cfg.ending_dur + Math.max(0, this.cfg.ending_linger)));
 					this.values.ending_total = this.timers.ending;
 					return true;
@@ -2301,6 +2388,23 @@
 				level *= 1 - (1 - this.cfg.ending_glow) * progress;
 			}
 			return Math.max(0.02, level);
+		}
+
+		_motionLevelWheatField() {
+			let level = this.cfg.sway;
+			if (this.timers.gust > 0) level *= 1 + Math.abs(this.values.gust_push || this.cfg.gust_mult) * 0.35;
+			if (this.timers.calm > 0) level *= this.cfg.calm_mult;
+			if (this.timers.intro > 0) {
+				const total = this.values.intro_total || this.cfg.intro_dur;
+				const progress = this._phaseProgress(total, this.timers.intro);
+				level *= this.cfg.intro_breeze + (1 - this.cfg.intro_breeze) * progress;
+			}
+			if (this.timers.ending > 0) {
+				const total = this.values.ending_total || (this.cfg.ending_dur + this.cfg.ending_linger);
+				const progress = this._phaseProgress(total, this.timers.ending);
+				level *= 1 - (1 - this.cfg.ending_sway) * progress;
+			}
+			return Math.max(0.05, level);
 		}
 
 		_renderSnow(ctx, canvasW, canvasH, opts) {
@@ -2513,6 +2617,101 @@
 			}
 		}
 
+		_renderWheatField(ctx, canvasW, canvasH, opts) {
+			opts = opts || {};
+			if (opts.transparent) {
+				ctx.clearRect(0, 0, canvasW, canvasH);
+			} else {
+				const sky = ctx.createLinearGradient(0, 0, 0, canvasH);
+				sky.addColorStop(0, '#16213f');
+				sky.addColorStop(0.56, '#556785');
+				sky.addColorStop(1, '#d2ad66');
+				ctx.fillStyle = sky;
+				ctx.fillRect(0, 0, canvasW, canvasH);
+			}
+
+			const sx = canvasW / this.w;
+			const sy = canvasH / this.h;
+			const ceilSx = Math.ceil(sx);
+			const ceilSy = Math.ceil(sy);
+			const motion = this._motionLevelWheatField();
+			const density = Math.max(0.08, this.cfg.density);
+			const layers = Math.max(1, Math.round(this.cfg.layers));
+			const gustPush = this.values.gust_push || 0;
+			const fieldBase = Math.floor(this.h * this.cfg.field_top);
+
+			const sunX = canvasW * (0.16 + this._hash(21000) * 0.18);
+			const sunY = canvasH * (0.2 + this._hash(21001) * 0.06);
+			const sunR = Math.max(18, Math.min(canvasW, canvasH) * 0.06);
+			const sun = ctx.createRadialGradient(sunX, sunY, 0, sunX, sunY, sunR * 2.8);
+			sun.addColorStop(0, 'rgba(255, 228, 153, 0.2)');
+			sun.addColorStop(1, 'rgba(255, 228, 153, 0)');
+			ctx.fillStyle = sun;
+			ctx.fillRect(0, 0, canvasW, canvasH);
+
+			const hillColor = hslToRGB(38, 0.18, 0.3);
+			const hillPoints = [];
+			for (let i = 0; i <= 8; i++) {
+				hillPoints.push(Math.floor(this.h * 0.56) - Math.floor(this._hash(21100 + i) * 5) - Math.floor((0.5 + 0.5 * Math.sin(i * 0.9 + this._hash(21200 + i) * 3)) * 5));
+			}
+			ctx.fillStyle = `rgb(${hillColor.r},${hillColor.g},${hillColor.b})`;
+			ctx.beginPath();
+			ctx.moveTo(0, canvasH);
+			for (let x = 0; x < this.w; x++) {
+				const pos = (x / Math.max(1, this.w - 1)) * 8;
+				const idx = Math.min(7, Math.floor(pos));
+				const frac = pos - idx;
+				const eased = frac * frac * (3 - 2 * frac);
+				const y = hillPoints[idx] + (hillPoints[idx + 1] - hillPoints[idx]) * eased;
+				ctx.lineTo(Math.floor(x * sx), Math.floor(y * sy));
+			}
+			ctx.lineTo(canvasW, canvasH);
+			ctx.closePath();
+			ctx.fill();
+
+			const groundGrad = ctx.createLinearGradient(0, Math.floor(fieldBase * sy), 0, canvasH);
+			groundGrad.addColorStop(0, '#b28d45');
+			groundGrad.addColorStop(0.45, '#be9c56');
+			groundGrad.addColorStop(1, '#8e6e32');
+			ctx.fillStyle = groundGrad;
+			ctx.fillRect(0, Math.floor(fieldBase * sy), canvasW, canvasH - Math.floor(fieldBase * sy));
+
+			for (let layer = 0; layer < layers; layer++) {
+				const layerRatio = layers === 1 ? 1 : layer / (layers - 1);
+				const amp = motion * (2.4 + layerRatio * 4.8);
+				const speed = this.cfg.speed * (0.4 + layerRatio * 0.65);
+				const drift = this.cfg.drift * (0.25 + layerRatio * 0.75) + gustPush * 0.04 * (0.5 + layerRatio * 0.5);
+				const topBase = fieldBase - this.cfg.stalk_h * (0.28 + layerRatio * 0.46);
+				const tipChance = clamp01(density * (0.4 + layerRatio * 0.22));
+				for (let x = 0; x < this.w;) {
+					const clumpSeed = layer * 4000 + x;
+					const width = Math.max(1, Math.min(4, Math.round(1 + this._hash(21700 + clumpSeed) * (1.2 + layerRatio * 2.4))));
+					const sampleX = Math.min(this.w - 1, x + width * 0.5);
+					const idx = layer * 2000 + sampleX;
+					const wave = Math.sin(sampleX * this.cfg.wave_freq * (0.85 + layerRatio * 0.25) + this.tick * speed + layer * 1.7);
+					const subWave = Math.sin(sampleX * this.cfg.wave_freq * 0.42 - this.tick * speed * 0.62 + layer * 2.3);
+					const lean = wave * amp + subWave * amp * 0.32 + Math.sin(this.tick * 0.012 + sampleX * 0.05) * drift * 3.2;
+					const top = Math.max(0, Math.min(this.h - 2, topBase + lean + this._hash(21300 + idx) * 2));
+					const depth = Math.max(6, Math.round(this.cfg.stalk_h * (0.48 + layerRatio * 0.42)));
+					const hue = ((this.cfg.hue + (this._hash(21400 + idx) * 2 - 1) * this.cfg.hue_sp) % 360 + 360) % 360;
+					const light = clamp01(this.cfg.lmin + (this.cfg.lmax - this.cfg.lmin) * (0.18 + layerRatio * 0.6));
+					const alpha = clamp01(0.34 + layerRatio * 0.24);
+					const color = hslToRGB(hue, this.cfg.sat, light);
+					this._fillCell(ctx, sx, sy, ceilSx, ceilSy, x, Math.round(top), width, depth, `rgb(${color.r},${color.g},${color.b})`, alpha);
+					const shadow = hslToRGB(hue, clamp01(this.cfg.sat * 0.72), clamp01(light * 0.76));
+					this._fillCell(ctx, sx, sy, ceilSx, ceilSy, x, Math.round(top), width, Math.max(1, Math.round(depth * 0.28)), `rgb(${shadow.r},${shadow.g},${shadow.b})`, clamp01(alpha * 0.55));
+
+					if (this._hash(21500 + idx) < tipChance) {
+						const tipHeight = 1 + Math.floor(this._hash(21600 + idx) * (1 + layerRatio * 3));
+						const tipX = Math.max(0, Math.min(this.w - 1, Math.round(x + width * 0.5 + lean * 0.18)));
+						const accent = hslToRGB((hue + 4) % 360, clamp01(this.cfg.sat * 0.82), clamp01(light * 1.08));
+						this._fillCell(ctx, sx, sy, ceilSx, ceilSy, tipX, Math.round(top) - tipHeight + 1, 1, tipHeight, `rgb(${accent.r},${accent.g},${accent.b})`, clamp01(alpha * 0.9));
+					}
+					x += width;
+				}
+			}
+		}
+
 		_renderAurora(ctx, canvasW, canvasH, opts) {
 			opts = opts || {};
 			if (opts.transparent) {
@@ -2641,6 +2840,12 @@
 		}
 	}
 
+	class WheatField extends ProceduralScene {
+		constructor(w, h, cfg, seed) {
+			super('wheat-field', w, h, cfg, seed);
+		}
+	}
+
 	class Aurora extends ProceduralScene {
 		constructor(w, h, cfg, seed) {
 			super('aurora', w, h, cfg, seed);
@@ -2699,8 +2904,93 @@
 	// server's snapshot payload — the client looks up the constructor here
 	// by name so new effects just register themselves and work without
 	// client-side changes.
-	const effects = { rain: Rain, dust: Dust, fireflies: Fireflies, waterfall: Waterfall, aurora: Aurora, snow: Snow, 'autumn-leaves': AutumnLeaves, starfield: Starfield };
+	const effects = { rain: Rain, dust: Dust, fireflies: Fireflies, waterfall: Waterfall, 'wheat-field': WheatField, aurora: Aurora, snow: Snow, 'autumn-leaves': AutumnLeaves, starfield: Starfield };
 	const presets = {
+		'wheat-field': [
+			{
+				key: 'still-evening',
+				label: 'still evening',
+				config: {
+					density: 0.4,
+					speed: 0.07,
+					drift: 0.05,
+					sway: 0.34,
+					wave_freq: 0.14,
+					field_top: 0.64,
+					stalk_h: 17,
+					layers: 2,
+					hue: 42,
+					hue_sp: 12,
+					sat: 0.56,
+					lmin: 0.28,
+					lmax: 0.7,
+					calm_p: 0.001,
+				},
+			},
+			{
+				key: 'gentle-breeze',
+				label: 'gentle breeze',
+				config: {
+					density: 0.48,
+					speed: 0.12,
+					drift: 0.14,
+					sway: 0.68,
+					wave_freq: 0.18,
+					field_top: 0.62,
+					stalk_h: 18,
+					layers: 3,
+					hue: 46,
+					hue_sp: 18,
+					sat: 0.64,
+					lmin: 0.3,
+					lmax: 0.76,
+					gust_p: 0.0008,
+				},
+			},
+			{
+				key: 'rolling-field',
+				label: 'rolling field',
+				config: {
+					density: 0.56,
+					speed: 0.16,
+					drift: 0.2,
+					sway: 0.88,
+					wave_freq: 0.16,
+					field_top: 0.6,
+					stalk_h: 20,
+					layers: 3,
+					hue: 48,
+					hue_sp: 20,
+					sat: 0.68,
+					lmin: 0.3,
+					lmax: 0.8,
+					gust_p: 0.0012,
+					gust_mult: 2.15,
+				},
+			},
+			{
+				key: 'windy-harvest',
+				label: 'windy harvest',
+				config: {
+					density: 0.62,
+					speed: 0.2,
+					drift: 0.28,
+					sway: 1.02,
+					wave_freq: 0.21,
+					field_top: 0.59,
+					stalk_h: 22,
+					layers: 4,
+					hue: 44,
+					hue_sp: 24,
+					sat: 0.72,
+					lmin: 0.32,
+					lmax: 0.84,
+					gust_p: 0.0016,
+					gust_mult: 2.45,
+					gust_dur: 66,
+				},
+			},
+		],
 		aurora: [
 			{
 				key: 'green-veil',
@@ -3212,5 +3502,5 @@
 		],
 	};
 
-	global.AmbienceSim = { Rain, Dust, Fireflies, Waterfall, Aurora, AutumnLeaves, Snow, Starfield, subscribe, applyDefaults, hslToRGB, effects, presets };
+	global.AmbienceSim = { Rain, Dust, Fireflies, Waterfall, WheatField, Aurora, AutumnLeaves, Snow, Starfield, subscribe, applyDefaults, hslToRGB, effects, presets };
 })(window);

--- a/sim/procedural.go
+++ b/sim/procedural.go
@@ -153,6 +153,33 @@ var auroraDefaults = ProceduralConfig{
 	"fade_mult":     0.60,
 }
 
+var wheatFieldDefaults = ProceduralConfig{
+	"intro_dur":     60,
+	"intro_breeze":  0.16,
+	"ending_dur":    70,
+	"ending_linger": 20,
+	"ending_sway":   0.08,
+	"density":       0.48,
+	"speed":         0.12,
+	"drift":         0.16,
+	"sway":          0.68,
+	"wave_freq":     0.18,
+	"field_top":     0.62,
+	"stalk_h":       18,
+	"layers":        3,
+	"hue":           46,
+	"hue_sp":        18,
+	"sat":           0.64,
+	"lmin":          0.30,
+	"lmax":          0.76,
+	"gust_p":        0.0,
+	"calm_p":        0.0,
+	"gust_dur":      50,
+	"gust_mult":     1.85,
+	"calm_dur":      72,
+	"calm_mult":     0.40,
+}
+
 func SnowSchema() EffectSchema {
 	return EffectSchema{
 		Name: "snow",
@@ -375,6 +402,62 @@ func AuroraSchema() EffectSchema {
 	}
 }
 
+func WheatFieldSchema() EffectSchema {
+	return EffectSchema{
+		Name: "wheat-field",
+		Knobs: []Knob{
+			{Key: "intro_dur", Label: "intro dur", Slot: SlotSpawn, Group: "introduction", Type: KnobInt, Min: 10, Max: 240, Step: 5, Default: 60, Trigger: "intro",
+				Description: "Ticks spent spreading motion through the field from near-stillness into full waves."},
+			{Key: "intro_breeze", Label: "intro breeze", Slot: SlotSpawn, Group: "introduction", Type: KnobFloat, Min: 0.08, Max: 0.5, Step: 0.02, Default: 0.16,
+				Description: "Starting fraction of the full sway before the waves finish arriving."},
+			{Key: "ending_dur", Label: "ending dur", Slot: SlotEnd, Group: "ending", Type: KnobInt, Min: 10, Max: 240, Step: 5, Default: 70, Trigger: "ending",
+				Description: "Ticks spent damping the field back toward calm."},
+			{Key: "ending_linger", Label: "ending linger", Slot: SlotEnd, Group: "ending", Type: KnobInt, Min: 0, Max: 140, Step: 5, Default: 20,
+				Description: "Extra quiet ticks for the last residual motion to settle out."},
+			{Key: "ending_sway", Label: "ending sway", Slot: SlotEnd, Group: "ending", Type: KnobFloat, Min: 0.04, Max: 0.28, Step: 0.02, Default: 0.08,
+				Description: "Residual sway fraction that remains near the end of the outro."},
+			{Key: "density", Label: "density", Slot: SlotLever, Group: "field", Type: KnobFloat, Min: 0.24, Max: 0.92, Step: 0.02, Default: 0.48,
+				Description: "How densely the field is packed with visible stalk highlights."},
+			{Key: "speed", Label: "wave speed", Slot: SlotLever, Group: "field", Type: KnobFloat, Min: 0.02, Max: 0.4, Step: 0.01, Default: 0.12,
+				Description: "How quickly the broad waves travel through the field."},
+			{Key: "drift", Label: "drift", Slot: SlotLever, Group: "field", Type: KnobFloat, Min: -0.5, Max: 0.5, Step: 0.01, Default: 0.16,
+				Description: "Preferred direction of the wave travel. Positive values push right."},
+			{Key: "sway", Label: "sway", Slot: SlotLever, Group: "field", Type: KnobFloat, Min: 0.25, Max: 1.35, Step: 0.02, Default: 0.68,
+				Description: "How far the stalk tips lean and recover."},
+			{Key: "wave_freq", Label: "wave freq", Slot: SlotLever, Group: "field", Type: KnobFloat, Min: 0.06, Max: 0.35, Step: 0.01, Default: 0.18,
+				Description: "Horizontal frequency of the passing field waves."},
+			{Key: "field_top", Label: "field top", Slot: SlotLever, Group: "field", Type: KnobFloat, Min: 0.54, Max: 0.74, Step: 0.01, Default: 0.62,
+				Description: "Where the top of the wheat band sits in the frame."},
+			{Key: "stalk_h", Label: "stalk height", Slot: SlotLever, Group: "field", Type: KnobFloat, Min: 8, Max: 28, Step: 1, Default: 18,
+				Description: "Apparent height of the stalks rising above the field base."},
+			{Key: "layers", Label: "layers", Slot: SlotLever, Group: "field", Type: KnobInt, Min: 1, Max: 4, Step: 1, Default: 3,
+				Description: "Number of depth layers used to build the field."},
+			{Key: "hue", Label: "hue", Slot: SlotLever, Group: "color", Type: KnobFloat, Min: 38, Max: 66, Step: 1, Default: 46,
+				Description: "Base wheat hue. Lower values warm toward amber; higher values lean green-gold."},
+			{Key: "hue_sp", Label: "hue spread", Slot: SlotLever, Group: "color", Type: KnobFloat, Min: 0, Max: 32, Step: 1, Default: 18,
+				Description: "Variation across stalk highlights and shadow bands."},
+			{Key: "sat", Label: "saturation", Slot: SlotLever, Group: "color", Type: KnobFloat, Min: 0.32, Max: 0.95, Step: 0.01, Default: 0.64,
+				Description: "Overall color saturation of the field."},
+			{Key: "lmin", Label: "light min", Slot: SlotLever, Group: "color", Type: KnobFloat, Min: 0.18, Max: 0.55, Step: 0.01, Default: 0.30,
+				Description: "Minimum lightness used for deeper shadowed wheat."},
+			{Key: "lmax", Label: "light max", Slot: SlotLever, Group: "color", Type: KnobFloat, Min: 0.55, Max: 0.92, Step: 0.01, Default: 0.76,
+				Description: "Maximum lightness used for sunstruck stalk tips."},
+			{Key: "gust_p", Label: "gust", Slot: SlotEvent, Type: KnobFloat, Min: 0, Max: 0.02, Step: 0.0005, Default: 0, Trigger: "gust",
+				Description: "Per-tick chance of a stronger wind wave crossing the field."},
+			{Key: "calm_p", Label: "calm", Slot: SlotEvent, Type: KnobFloat, Min: 0, Max: 0.02, Step: 0.0005, Default: 0, Trigger: "calm",
+				Description: "Per-tick chance of the field settling into a quieter, lighter sway."},
+			{Key: "gust_dur", Label: "gust dur", Slot: SlotEventMod, Group: "gust", Type: KnobInt, Min: 10, Max: 220, Step: 5, Default: 50,
+				Description: "Typical duration of a stronger wind pulse."},
+			{Key: "gust_mult", Label: "gust x", Slot: SlotEventMod, Group: "gust", Type: KnobFloat, Min: 1.05, Max: 4, Step: 0.05, Default: 1.85,
+				Description: "Sway multiplier applied during a gust."},
+			{Key: "calm_dur", Label: "calm dur", Slot: SlotEventMod, Group: "calm", Type: KnobInt, Min: 10, Max: 220, Step: 5, Default: 72,
+				Description: "Duration of the quieter low-amplitude window."},
+			{Key: "calm_mult", Label: "calm x", Slot: SlotEventMod, Group: "calm", Type: KnobFloat, Min: 0.05, Max: 1, Step: 0.05, Default: 0.4,
+				Description: "Sway multiplier applied while calm is active."},
+		},
+	}
+}
+
 func cloneProceduralConfig(src ProceduralConfig) ProceduralConfig {
 	if src == nil {
 		return ProceduralConfig{}
@@ -423,6 +506,8 @@ func proceduralDefaults(kind string) ProceduralConfig {
 		return cloneProceduralConfig(starfieldDefaults)
 	case "aurora":
 		return cloneProceduralConfig(auroraDefaults)
+	case "wheat-field":
+		return cloneProceduralConfig(wheatFieldDefaults)
 	default:
 		return ProceduralConfig{}
 	}
@@ -671,6 +756,69 @@ func mergeProceduralDefaults(kind string, cfg ProceduralConfig) ProceduralConfig
 		if out["fade_mult"] <= 0 {
 			out["fade_mult"] = auroraDefaults["fade_mult"]
 		}
+	case "wheat-field":
+		if out["intro_dur"] <= 0 {
+			out["intro_dur"] = wheatFieldDefaults["intro_dur"]
+		}
+		out["intro_breeze"] = clamp01(out["intro_breeze"])
+		if out["ending_dur"] <= 0 {
+			out["ending_dur"] = wheatFieldDefaults["ending_dur"]
+		}
+		if out["ending_linger"] < 0 {
+			out["ending_linger"] = 0
+		}
+		out["ending_sway"] = clamp01(out["ending_sway"])
+		if out["density"] <= 0 {
+			out["density"] = wheatFieldDefaults["density"]
+		}
+		if out["speed"] <= 0 {
+			out["speed"] = wheatFieldDefaults["speed"]
+		}
+		if out["sway"] <= 0 {
+			out["sway"] = wheatFieldDefaults["sway"]
+		}
+		if out["wave_freq"] <= 0 {
+			out["wave_freq"] = wheatFieldDefaults["wave_freq"]
+		}
+		if out["field_top"] <= 0 {
+			out["field_top"] = wheatFieldDefaults["field_top"]
+		}
+		if out["stalk_h"] <= 0 {
+			out["stalk_h"] = wheatFieldDefaults["stalk_h"]
+		}
+		if out["layers"] < 1 {
+			out["layers"] = wheatFieldDefaults["layers"]
+		}
+		if out["hue"] == 0 {
+			out["hue"] = wheatFieldDefaults["hue"]
+		}
+		if out["hue_sp"] < 0 {
+			out["hue_sp"] = 0
+		}
+		if out["sat"] <= 0 {
+			out["sat"] = wheatFieldDefaults["sat"]
+		}
+		if out["lmin"] <= 0 {
+			out["lmin"] = wheatFieldDefaults["lmin"]
+		}
+		if out["lmax"] <= 0 {
+			out["lmax"] = wheatFieldDefaults["lmax"]
+		}
+		if out["lmax"] < out["lmin"] {
+			out["lmin"], out["lmax"] = out["lmax"], out["lmin"]
+		}
+		if out["gust_dur"] <= 0 {
+			out["gust_dur"] = wheatFieldDefaults["gust_dur"]
+		}
+		if out["gust_mult"] <= 0 {
+			out["gust_mult"] = wheatFieldDefaults["gust_mult"]
+		}
+		if out["calm_dur"] <= 0 {
+			out["calm_dur"] = wheatFieldDefaults["calm_dur"]
+		}
+		if out["calm_mult"] <= 0 {
+			out["calm_mult"] = wheatFieldDefaults["calm_mult"]
+		}
 	}
 	return out
 }
@@ -869,6 +1017,22 @@ func (p *Procedural) TriggerEvent(name string) bool {
 			return false
 		}
 		return true
+	case "wheat-field":
+		switch name {
+		case "gust":
+			p.startWheatFieldGustLocked("triggered")
+		case "calm":
+			p.startWheatFieldCalmLocked("triggered")
+		case "intro":
+			p.startWheatFieldIntroLocked()
+			p.appendLog("intro", fmt.Sprintf("started (dur=%d, breeze=%.2f)", p.timers["intro"], p.cfg["intro_breeze"]))
+		case "ending":
+			p.startWheatFieldEndingLocked()
+			p.appendLog("ending", fmt.Sprintf("started (fade=%d, linger=%d)", p.intCfg("ending_dur"), p.intCfg("ending_linger")))
+		default:
+			return false
+		}
+		return true
 	default:
 		return false
 	}
@@ -912,6 +1076,8 @@ func (p *Procedural) Step() {
 		p.stepStarfieldLocked()
 	case "aurora":
 		p.stepAuroraLocked()
+	case "wheat-field":
+		p.stepWheatFieldLocked()
 	}
 }
 
@@ -1187,5 +1353,63 @@ func (p *Procedural) stepAuroraLocked() {
 	}
 	if p.timers["fade"] <= 0 && p.cfg["fade_p"] > 0 && p.rng.Float64() < p.cfg["fade_p"] {
 		p.startAuroraFadeLocked("started")
+	}
+}
+
+func (p *Procedural) startWheatFieldGustLocked(verb string) {
+	p.timers["gust"] = jitterInt(p.rng, p.intCfg("gust_dur"), 0.3)
+	sign := 1.0
+	if p.rng.Float64() < 0.35 {
+		sign = -1
+	}
+	p.values["gust_push"] = sign * p.cfg["gust_mult"] * (0.55 + p.rng.Float64()*0.55)
+	p.appendLog("gust", fmt.Sprintf("%s (dur=%d, push=%+.2f)", verb, p.timers["gust"], p.values["gust_push"]))
+}
+
+func (p *Procedural) startWheatFieldCalmLocked(verb string) {
+	p.timers["calm"] = jitterInt(p.rng, p.intCfg("calm_dur"), 0.3)
+	p.appendLog("calm", fmt.Sprintf("%s (dur=%d, x%.2f)", verb, p.timers["calm"], p.cfg["calm_mult"]))
+}
+
+func (p *Procedural) startWheatFieldIntroLocked() {
+	p.timers["gust"] = 0
+	p.timers["calm"] = 0
+	p.timers["ending"] = 0
+	p.values["gust_push"] = 0
+	p.timers["intro"] = p.intCfg("intro_dur")
+	p.values["intro_total"] = float64(p.timers["intro"])
+}
+
+func (p *Procedural) startWheatFieldEndingLocked() {
+	p.timers["intro"] = 0
+	p.timers["gust"] = 0
+	p.timers["calm"] = 0
+	p.values["gust_push"] = 0
+	endingTotal := p.intCfg("ending_dur") + max(0, p.intCfg("ending_linger"))
+	if endingTotal < 1 {
+		endingTotal = max(1, p.intCfg("ending_dur"))
+	}
+	p.timers["ending"] = endingTotal
+	p.values["ending_total"] = float64(endingTotal)
+}
+
+func (p *Procedural) stepWheatFieldLocked() {
+	if p.timers["gust"] <= 0 {
+		p.values["gust_push"] = 0
+	}
+	if p.timers["intro"] <= 0 {
+		delete(p.values, "intro_total")
+	}
+	if p.timers["ending"] <= 0 {
+		delete(p.values, "ending_total")
+	}
+	if p.timers["intro"] > 0 || p.timers["ending"] > 0 {
+		return
+	}
+	if p.timers["gust"] <= 0 && p.cfg["gust_p"] > 0 && p.rng.Float64() < p.cfg["gust_p"] {
+		p.startWheatFieldGustLocked("started")
+	}
+	if p.timers["calm"] <= 0 && p.cfg["calm_p"] > 0 && p.rng.Float64() < p.cfg["calm_p"] {
+		p.startWheatFieldCalmLocked("started")
 	}
 }

--- a/sim/procedural_test.go
+++ b/sim/procedural_test.go
@@ -42,6 +42,16 @@ func TestAuroraSchema(t *testing.T) {
 	}
 }
 
+func TestWheatFieldSchema(t *testing.T) {
+	schema := WheatFieldSchema()
+	if schema.Name != "wheat-field" {
+		t.Fatalf("schema name = %q, want wheat-field", schema.Name)
+	}
+	if len(schema.Knobs) == 0 {
+		t.Fatal("expected wheat-field schema knobs")
+	}
+}
+
 func TestProceduralSnowSnapshotRestore(t *testing.T) {
 	p := NewProcedural("snow", 160, 80, 42, nil)
 	if !p.TriggerEvent("gust") {
@@ -137,5 +147,31 @@ func TestProceduralAuroraSnapshotRestore(t *testing.T) {
 	}
 	if again.Values["shift_push"] != snap.Values["shift_push"] {
 		t.Fatalf("restored shift push = %f, want %f", again.Values["shift_push"], snap.Values["shift_push"])
+	}
+}
+
+func TestProceduralWheatFieldSnapshotRestore(t *testing.T) {
+	p := NewProcedural("wheat-field", 160, 80, 88, nil)
+	if !p.TriggerEvent("gust") {
+		t.Fatal("expected gust trigger to succeed")
+	}
+	p.Step()
+
+	snap := p.Snapshot()
+	if snap.Timers["gust"] <= 0 {
+		t.Fatal("expected gust timer in snapshot")
+	}
+	if snap.Values["gust_push"] == 0 {
+		t.Fatal("expected gust push value in snapshot")
+	}
+
+	restored := NewProcedural("wheat-field", 160, 80, 7, nil)
+	restored.RestoreSnapshot(snap)
+	again := restored.Snapshot()
+	if again.Timers["gust"] != snap.Timers["gust"] {
+		t.Fatalf("restored gust timer = %d, want %d", again.Timers["gust"], snap.Timers["gust"])
+	}
+	if again.Values["gust_push"] != snap.Values["gust_push"] {
+		t.Fatalf("restored gust push = %f, want %f", again.Values["gust_push"], snap.Values["gust_push"])
 	}
 }


### PR DESCRIPTION
## Summary
- add the wheat-field procedural schema, runtime wiring, and snapshot/restore coverage
- implement a browser-side wheat field renderer with intro, gust, calm, and ending behavior
- add presets plus dev-route/schema and randomization coverage so /dev/wheat-field works end to end

## Validation
- go test ./...
- 
ode --check cmd/ambience/web/sim.js
- powershell -ExecutionPolicy Bypass -File scripts/dev-deploy.ps1 -Component all
- powershell -ExecutionPolicy Bypass -File scripts/dev-loop.ps1 -Once
- visual check on [ambience.dev.romaine.life/dev/wheat-field](https://ambience.dev.romaine.life/dev/wheat-field)

Refs #27