### PR TITLE
Add the beach dev effect prototype

### DIFF
--- a/cmd/ambience/dev_random_test.go
+++ b/cmd/ambience/dev_random_test.go
@@ -19,6 +19,7 @@ func TestRandomizedDevConfigStaysWithinSchemaBounds(t *testing.T) {
 		sim.StarfieldSchema(),
 		sim.AuroraSchema(),
 		sim.WheatFieldSchema(),
+		sim.BeachSchema(),
 	}
 
 	for i, schema := range schemas {
@@ -58,6 +59,7 @@ func TestRandomizedDevConfigChangesAtLeastOneKnob(t *testing.T) {
 		sim.StarfieldSchema(),
 		sim.AuroraSchema(),
 		sim.WheatFieldSchema(),
+		sim.BeachSchema(),
 	}
 
 	for i, schema := range schemas {

--- a/cmd/ambience/dev_sessions_test.go
+++ b/cmd/ambience/dev_sessions_test.go
@@ -14,6 +14,7 @@ func TestDevPageEffectFromPath(t *testing.T) {
 		{path: "/dev", want: "rain", wantOK: true},
 		{path: "/dev/", want: "rain", wantOK: true},
 		{path: "/dev/aurora", want: "aurora", wantOK: true},
+		{path: "/dev/beach", want: "beach", wantOK: true},
 		{path: "/dev/dust", want: "dust", wantOK: true},
 		{path: "/dev/autumn-leaves", want: "autumn-leaves", wantOK: true},
 		{path: "/dev/fireflies", want: "fireflies", wantOK: true},
@@ -43,6 +44,7 @@ func TestEffectFromSchemaPath(t *testing.T) {
 	}{
 		{path: "/effects/rain/schema", want: "rain", wantOK: true},
 		{path: "/effects/aurora/schema", want: "aurora", wantOK: true},
+		{path: "/effects/beach/schema", want: "beach", wantOK: true},
 		{path: "/effects/autumn-leaves/schema", want: "autumn-leaves", wantOK: true},
 		{path: "/effects/dust/schema", want: "dust", wantOK: true},
 		{path: "/effects/fireflies/schema", want: "fireflies", wantOK: true},
@@ -116,6 +118,17 @@ func TestNewDevSessionAuroraSnapshotType(t *testing.T) {
 	snap := session.snapshot()
 	if snap.Type != "aurora" {
 		t.Fatalf("snapshot type = %q, want aurora", snap.Type)
+	}
+}
+
+func TestNewDevSessionBeachSnapshotType(t *testing.T) {
+	session, err := newDevSession("beach")
+	if err != nil {
+		t.Fatalf("newDevSession: %v", err)
+	}
+	snap := session.snapshot()
+	if snap.Type != "beach" {
+		t.Fatalf("snapshot type = %q, want beach", snap.Type)
 	}
 }
 

--- a/cmd/ambience/effects.go
+++ b/cmd/ambience/effects.go
@@ -96,6 +96,11 @@ var effectRegistry = map[string]effectDefinition{
 		Schema:     sim.WheatFieldSchema,
 		NewRuntime: newWheatFieldRuntime,
 	},
+	"beach": {
+		Type:       "beach",
+		Schema:     sim.BeachSchema,
+		NewRuntime: newBeachRuntime,
+	},
 }
 
 func lookupEffectDefinition(effectType string) (effectDefinition, bool) {
@@ -254,6 +259,10 @@ func newAuroraRuntime(w, h int, seed int64, cfg json.RawMessage) (effectRuntime,
 
 func newWheatFieldRuntime(w, h int, seed int64, cfg json.RawMessage) (effectRuntime, error) {
 	return newProceduralRuntime("wheat-field", w, h, seed, cfg)
+}
+
+func newBeachRuntime(w, h int, seed int64, cfg json.RawMessage) (effectRuntime, error) {
+	return newProceduralRuntime("beach", w, h, seed, cfg)
 }
 
 func (r *rainRuntime) Type() string { return "rain" }
@@ -674,6 +683,8 @@ func (p *proceduralRuntime) Schema() sim.EffectSchema {
 		return sim.AuroraSchema()
 	case "wheat-field":
 		return sim.WheatFieldSchema()
+	case "beach":
+		return sim.BeachSchema()
 	default:
 		return sim.EffectSchema{}
 	}

--- a/cmd/ambience/web/sim.js
+++ b/cmd/ambience/web/sim.js
@@ -1841,6 +1841,35 @@
 			calm_dur: 72,
 			calm_mult: 0.4,
 		},
+		beach: {
+			intro_dur: 55,
+			intro_tide: 0.18,
+			ending_dur: 65,
+			ending_linger: 18,
+			ending_wet: 0.1,
+			shoreline: 0.58,
+			tide_amp: 6,
+			wave_amp: 2.4,
+			wave_freq: 0.18,
+			speed: 0.1,
+			slope: 0.16,
+			foam: 0.36,
+			shimmer: 0.22,
+			hue: 198,
+			hue_sp: 16,
+			sat: 0.5,
+			lmin: 0.28,
+			lmax: 0.82,
+			high_tide_p: 0,
+			low_tide_p: 0,
+			foam_burst_p: 0,
+			high_tide_dur: 60,
+			high_tide_push: 1.4,
+			low_tide_dur: 58,
+			low_tide_pull: 1.2,
+			foam_burst_dur: 34,
+			foam_burst_mult: 1.9,
+		},
 		starfield: {
 			intro_dur: 50,
 			intro_density: 0.08,
@@ -1944,6 +1973,32 @@
 				if (c.gust_mult <= 0) c.gust_mult = base.gust_mult;
 				if (c.calm_dur <= 0) c.calm_dur = base.calm_dur;
 				if (c.calm_mult <= 0) c.calm_mult = base.calm_mult;
+				break;
+			case 'beach':
+				if (c.intro_dur <= 0) c.intro_dur = base.intro_dur;
+				c.intro_tide = clamp01(c.intro_tide);
+				if (c.ending_dur <= 0) c.ending_dur = base.ending_dur;
+				if (c.ending_linger < 0) c.ending_linger = 0;
+				c.ending_wet = clamp01(c.ending_wet);
+				if (c.shoreline <= 0) c.shoreline = base.shoreline;
+				if (c.tide_amp <= 0) c.tide_amp = base.tide_amp;
+				if (c.wave_amp <= 0) c.wave_amp = base.wave_amp;
+				if (c.wave_freq <= 0) c.wave_freq = base.wave_freq;
+				if (c.speed <= 0) c.speed = base.speed;
+				if (c.foam <= 0) c.foam = base.foam;
+				if (c.shimmer <= 0) c.shimmer = base.shimmer;
+				if (c.hue === 0) c.hue = base.hue;
+				if (c.hue_sp < 0) c.hue_sp = 0;
+				if (c.sat <= 0) c.sat = base.sat;
+				if (c.lmin <= 0) c.lmin = base.lmin;
+				if (c.lmax <= 0) c.lmax = base.lmax;
+				if (c.lmax < c.lmin) [c.lmin, c.lmax] = [c.lmax, c.lmin];
+				if (c.high_tide_dur <= 0) c.high_tide_dur = base.high_tide_dur;
+				if (c.high_tide_push <= 0) c.high_tide_push = base.high_tide_push;
+				if (c.low_tide_dur <= 0) c.low_tide_dur = base.low_tide_dur;
+				if (c.low_tide_pull <= 0) c.low_tide_pull = base.low_tide_pull;
+				if (c.foam_burst_dur <= 0) c.foam_burst_dur = base.foam_burst_dur;
+				if (c.foam_burst_mult <= 0) c.foam_burst_mult = base.foam_burst_mult;
 				break;
 			case 'aurora':
 				if (c.intro_dur <= 0) c.intro_dur = base.intro_dur;
@@ -2082,6 +2137,8 @@
 			switch (this.kind) {
 				case 'wheat-field':
 					return this._triggerWheatField(name);
+				case 'beach':
+					return this._triggerBeach(name);
 				case 'aurora':
 					return this._triggerAurora(name);
 				case 'starfield':
@@ -2116,12 +2173,22 @@
 			if (this.kind === 'wheat-field' && (!this.timers.gust || this.timers.gust <= 0)) {
 				this.values.gust_push = 0;
 			}
+			if (this.kind === 'beach') {
+				if ((!this.timers['high-tide'] || this.timers['high-tide'] <= 0) && (!this.timers['low-tide'] || this.timers['low-tide'] <= 0)) {
+					this.values.tide_bias = 0;
+				}
+				if (!this.timers['foam-burst'] || this.timers['foam-burst'] <= 0) {
+					this.values.foam_gain = 1;
+				}
+			}
 		}
 
 		render(ctx, canvasW, canvasH, opts) {
 			switch (this.kind) {
 				case 'wheat-field':
 					return this._renderWheatField(ctx, canvasW, canvasH, opts);
+				case 'beach':
+					return this._renderBeach(ctx, canvasW, canvasH, opts);
 				case 'aurora':
 					return this._renderAurora(ctx, canvasW, canvasH, opts);
 				case 'starfield':
@@ -2245,6 +2312,47 @@
 					this.timers.gust = 0;
 					this.timers.calm = 0;
 					this.values.gust_push = 0;
+					this.timers.ending = Math.max(1, Math.round(this.cfg.ending_dur + Math.max(0, this.cfg.ending_linger)));
+					this.values.ending_total = this.timers.ending;
+					return true;
+			}
+			return false;
+		}
+
+		_triggerBeach(name) {
+			const rng = this._eventRng(name.length + 61);
+			switch (name) {
+				case 'high-tide':
+					this.timers['high-tide'] = jitterInt(rng, this.cfg.high_tide_dur, 0.3);
+					this.timers['low-tide'] = 0;
+					this.values.tide_bias = this.cfg.high_tide_push * (0.65 + rng() * 0.55);
+					return true;
+				case 'low-tide':
+					this.timers['low-tide'] = jitterInt(rng, this.cfg.low_tide_dur, 0.3);
+					this.timers['high-tide'] = 0;
+					this.values.tide_bias = -this.cfg.low_tide_pull * (0.65 + rng() * 0.55);
+					return true;
+				case 'foam-burst':
+					this.timers['foam-burst'] = jitterInt(rng, this.cfg.foam_burst_dur, 0.3);
+					this.values.foam_gain = this.cfg.foam_burst_mult * (0.85 + rng() * 0.35);
+					return true;
+				case 'intro':
+					this.timers['high-tide'] = 0;
+					this.timers['low-tide'] = 0;
+					this.timers['foam-burst'] = 0;
+					this.timers.ending = 0;
+					this.values.tide_bias = 0;
+					this.values.foam_gain = 1;
+					this.timers.intro = Math.max(1, Math.round(this.cfg.intro_dur));
+					this.values.intro_total = this.timers.intro;
+					return true;
+				case 'ending':
+					this.timers.intro = 0;
+					this.timers['high-tide'] = 0;
+					this.timers['low-tide'] = 0;
+					this.timers['foam-burst'] = 0;
+					this.values.tide_bias = 0;
+					this.values.foam_gain = 1;
 					this.timers.ending = Math.max(1, Math.round(this.cfg.ending_dur + Math.max(0, this.cfg.ending_linger)));
 					this.values.ending_total = this.timers.ending;
 					return true;
@@ -2403,6 +2511,21 @@
 				const total = this.values.ending_total || (this.cfg.ending_dur + this.cfg.ending_linger);
 				const progress = this._phaseProgress(total, this.timers.ending);
 				level *= 1 - (1 - this.cfg.ending_sway) * progress;
+			}
+			return Math.max(0.05, level);
+		}
+
+		_tideLevelBeach() {
+			let level = 1;
+			if (this.timers.intro > 0) {
+				const total = this.values.intro_total || this.cfg.intro_dur;
+				const progress = this._phaseProgress(total, this.timers.intro);
+				level *= this.cfg.intro_tide + (1 - this.cfg.intro_tide) * progress;
+			}
+			if (this.timers.ending > 0) {
+				const total = this.values.ending_total || (this.cfg.ending_dur + this.cfg.ending_linger);
+				const progress = this._phaseProgress(total, this.timers.ending);
+				level *= 1 - (1 - this.cfg.ending_wet) * progress;
 			}
 			return Math.max(0.05, level);
 		}
@@ -2712,6 +2835,164 @@
 			}
 		}
 
+		_renderBeach(ctx, canvasW, canvasH, opts) {
+			opts = opts || {};
+			if (opts.transparent) {
+				ctx.clearRect(0, 0, canvasW, canvasH);
+			} else {
+				const sky = ctx.createLinearGradient(0, 0, 0, canvasH);
+				sky.addColorStop(0, '#f4b17a');
+				sky.addColorStop(0.38, '#f8d6a9');
+				sky.addColorStop(0.68, '#cfe3e6');
+				sky.addColorStop(1, '#8bb4c4');
+				ctx.fillStyle = sky;
+				ctx.fillRect(0, 0, canvasW, canvasH);
+			}
+
+			const sx = canvasW / this.w;
+			const sy = canvasH / this.h;
+			const ceilSx = Math.ceil(sx);
+			const ceilSy = Math.ceil(sy);
+			const horizon = Math.max(8, Math.floor(this.h * 0.34));
+			const tideLevel = this._tideLevelBeach();
+			const tideBias = this.values.tide_bias || 0;
+			const foamGain = this.values.foam_gain || 1;
+			const tidePhase = this.tick * this.cfg.speed * 0.08;
+			const baseShore = this.h * this.cfg.shoreline + Math.sin(tidePhase) * this.cfg.tide_amp * tideLevel * 0.34 + tideBias * 1.6;
+
+			const sunX = canvasW * (0.16 + this._hash(24000) * 0.18);
+			const sunY = canvasH * (0.18 + this._hash(24001) * 0.08);
+			const sunR = Math.max(22, Math.min(canvasW, canvasH) * 0.085);
+			const sun = ctx.createRadialGradient(sunX, sunY, 0, sunX, sunY, sunR * 2.8);
+			sun.addColorStop(0, 'rgba(255, 239, 187, 0.38)');
+			sun.addColorStop(0.34, 'rgba(255, 224, 168, 0.2)');
+			sun.addColorStop(1, 'rgba(255, 224, 168, 0)');
+			ctx.fillStyle = sun;
+			ctx.fillRect(0, 0, canvasW, canvasH);
+
+			const haze = ctx.createLinearGradient(0, canvasH * 0.18, 0, canvasH * 0.6);
+			haze.addColorStop(0, 'rgba(255, 246, 224, 0)');
+			haze.addColorStop(1, 'rgba(255, 246, 224, 0.14)');
+			ctx.fillStyle = haze;
+			ctx.fillRect(0, canvasH * 0.16, canvasW, canvasH * 0.44);
+
+			const waterTop = hslToRGB((this.cfg.hue - 12 + 360) % 360, clamp01(this.cfg.sat * 0.72), clamp01(this.cfg.lmax * 0.74));
+			const waterMid = hslToRGB(this.cfg.hue, this.cfg.sat, clamp01(this.cfg.lmin + (this.cfg.lmax - this.cfg.lmin) * 0.44));
+			const waterDeep = hslToRGB((this.cfg.hue + 6) % 360, clamp01(this.cfg.sat * 1.06), clamp01(this.cfg.lmin * 0.8));
+			const waterGrad = ctx.createLinearGradient(0, Math.floor(horizon * sy), 0, canvasH);
+			waterGrad.addColorStop(0, `rgb(${waterTop.r},${waterTop.g},${waterTop.b})`);
+			waterGrad.addColorStop(0.46, `rgb(${waterMid.r},${waterMid.g},${waterMid.b})`);
+			waterGrad.addColorStop(1, `rgb(${waterDeep.r},${waterDeep.g},${waterDeep.b})`);
+			ctx.fillStyle = waterGrad;
+			ctx.fillRect(0, Math.floor(horizon * sy), canvasW, canvasH - Math.floor(horizon * sy));
+
+			const horizonGlow = ctx.createLinearGradient(0, Math.floor((horizon - 1) * sy), 0, Math.floor((horizon + 4) * sy));
+			horizonGlow.addColorStop(0, 'rgba(255, 247, 221, 0.35)');
+			horizonGlow.addColorStop(1, 'rgba(255, 247, 221, 0)');
+			ctx.fillStyle = horizonGlow;
+			ctx.fillRect(0, Math.floor((horizon - 1) * sy), canvasW, Math.ceil(7 * sy));
+
+			for (let band = 0; band < 3; band++) {
+				const y = Math.floor((horizon + 2 + band * 3 + Math.sin(tidePhase * 1.8 + band) * 1.2) * sy);
+				ctx.fillStyle = `rgba(${waterTop.r},${waterTop.g},${waterTop.b},${0.08 + band * 0.03})`;
+				ctx.fillRect(0, y, canvasW, Math.max(1, Math.ceil(sy)));
+			}
+
+			const shoreRows = new Array(this.w);
+			for (let x = 0; x < this.w; x++) {
+				const nx = x / Math.max(1, this.w - 1);
+				const slopeOffset = (nx - 0.5) * this.cfg.slope * this.h * 0.34;
+				const wave = Math.sin(x * this.cfg.wave_freq + tidePhase * 2.2);
+				const backwash = Math.sin(x * this.cfg.wave_freq * 0.46 - tidePhase * 1.6 + 0.8);
+				const chop = Math.sin(x * this.cfg.wave_freq * 1.85 + tidePhase * 3.1 + this._hash(24100 + x) * 3);
+				const shore = baseShore + slopeOffset + wave * this.cfg.wave_amp * (0.14 + tideLevel * 0.1) + backwash * this.cfg.wave_amp * 0.08 + chop * this.cfg.wave_amp * 0.03;
+				shoreRows[x] = Math.max(horizon + 3, Math.min(this.h - 4, shore));
+			}
+			for (let pass = 0; pass < 2; pass++) {
+				for (let x = 1; x < this.w - 1; x++) {
+					shoreRows[x] = (shoreRows[x - 1] + shoreRows[x] * 2 + shoreRows[x + 1]) / 4;
+				}
+			}
+
+			const sandTop = hslToRGB(39, 0.54, 0.8);
+			const sandMid = hslToRGB(36, 0.48, 0.68);
+			const sandLow = hslToRGB(33, 0.42, 0.54);
+			const drawSandPath = () => {
+				ctx.beginPath();
+				ctx.moveTo(0, canvasH);
+				for (let x = 0; x < this.w; x++) {
+					ctx.lineTo(Math.floor(x * sx), Math.floor(shoreRows[x] * sy));
+				}
+				ctx.lineTo(canvasW, canvasH);
+				ctx.closePath();
+			};
+			drawSandPath();
+			const sandGrad = ctx.createLinearGradient(0, Math.floor(horizon * sy), 0, canvasH);
+			sandGrad.addColorStop(0, `rgb(${sandTop.r},${sandTop.g},${sandTop.b})`);
+			sandGrad.addColorStop(0.55, `rgb(${sandMid.r},${sandMid.g},${sandMid.b})`);
+			sandGrad.addColorStop(1, `rgb(${sandLow.r},${sandLow.g},${sandLow.b})`);
+			ctx.fillStyle = sandGrad;
+			ctx.fill();
+
+			const duneColor = hslToRGB(31, 0.32, 0.42);
+			const dunePoints = [];
+			for (let i = 0; i <= 6; i++) {
+				dunePoints.push(Math.floor(this.h * 0.74) + Math.floor(this._hash(24200 + i) * 5) + Math.floor(Math.sin(i * 1.08 + this._hash(24300 + i) * 2) * 2));
+			}
+			ctx.fillStyle = `rgba(${duneColor.r},${duneColor.g},${duneColor.b},0.16)`;
+			ctx.beginPath();
+			ctx.moveTo(0, canvasH);
+			for (let x = 0; x < this.w; x++) {
+				const pos = (x / Math.max(1, this.w - 1)) * 6;
+				const idx = Math.min(5, Math.floor(pos));
+				const frac = pos - idx;
+				const eased = frac * frac * (3 - 2 * frac);
+				const y = dunePoints[idx] + (dunePoints[idx + 1] - dunePoints[idx]) * eased;
+				ctx.lineTo(Math.floor(x * sx), Math.floor(y * sy));
+			}
+			ctx.lineTo(canvasW, canvasH);
+			ctx.closePath();
+			ctx.fill();
+
+			const wetColor = hslToRGB(34, 0.34, 0.34 + clamp01(0.22 + tideLevel * 0.36) * 0.12);
+			const foamColor = hslToRGB((this.cfg.hue - 8 + 360) % 360, clamp01(this.cfg.sat * 0.18), clamp01(this.cfg.lmax * 1.02));
+			const shimmerColor = hslToRGB((this.cfg.hue - 12 + 360) % 360, clamp01(this.cfg.sat * 0.5), clamp01(this.cfg.lmax * 0.96));
+			const shimmerLevel = clamp01(this.cfg.shimmer * (0.6 + tideLevel * 0.5));
+
+			for (let x = 0; x < this.w; x++) {
+				const shore = shoreRows[x];
+				const surfRow = Math.round(shore);
+				const wetBand = Math.max(2, Math.round(2 + tideLevel * 3 + Math.max(0, foamGain - 1) * 1.4));
+				const foamBand = Math.max(1, Math.round(1 + this.cfg.foam * 2.8 + Math.max(0, foamGain - 1) * 1.4));
+
+				for (let row = surfRow; row < Math.min(this.h, surfRow + wetBand); row++) {
+					const fade = 1 - (row - shore) / Math.max(1, wetBand);
+					this._fillCell(ctx, sx, sy, ceilSx, ceilSy, x, row, 1, 1, `rgb(${wetColor.r},${wetColor.g},${wetColor.b})`, clamp01(0.14 + fade * 0.32));
+				}
+
+				for (let i = 0; i < foamBand; i++) {
+					const row = surfRow - i;
+					const pulse = 0.55 + 0.45 * Math.sin(this.tick * 0.05 + x * 0.18 + i * 0.9);
+					const alpha = clamp01((0.12 + this.cfg.foam * 0.42) * foamGain * (0.5 + 0.5 * pulse));
+					this._fillCell(ctx, sx, sy, ceilSx, ceilSy, x, row, 1, 1, `rgb(${foamColor.r},${foamColor.g},${foamColor.b})`, alpha);
+				}
+
+				if ((x + this.tick) % 2 === 0) {
+					const depth = 0.18 + this._hash(24400 + x) * 0.56;
+					const row = Math.max(horizon + 1, Math.floor(horizon + (shore - horizon) * depth));
+					const width = 1 + Math.floor(this._hash(24500 + x) * 3);
+					const blink = 0.35 + 0.65 * Math.pow(0.5 + 0.5 * Math.sin(this.tick * 0.03 + x * 0.12), 2);
+					this._fillCell(ctx, sx, sy, ceilSx, ceilSy, x, row, width, 1, `rgb(${shimmerColor.r},${shimmerColor.g},${shimmerColor.b})`, clamp01((0.08 + shimmerLevel * 0.34) * blink));
+				}
+
+				if ((x + Math.floor(this.tick / 3)) % 7 === 0) {
+					const pebbleRow = Math.min(this.h - 2, surfRow + wetBand + 1 + Math.floor(this._hash(24600 + x) * 8));
+					const pebble = hslToRGB(34 + this._hash(24700 + x) * 10, 0.2, 0.4 + this._hash(24800 + x) * 0.12);
+					this._fillCell(ctx, sx, sy, ceilSx, ceilSy, x, pebbleRow, 1, 1, `rgb(${pebble.r},${pebble.g},${pebble.b})`, 0.22);
+				}
+			}
+		}
+
 		_renderAurora(ctx, canvasW, canvasH, opts) {
 			opts = opts || {};
 			if (opts.transparent) {
@@ -2846,6 +3127,12 @@
 		}
 	}
 
+	class Beach extends ProceduralScene {
+		constructor(w, h, cfg, seed) {
+			super('beach', w, h, cfg, seed);
+		}
+	}
+
 	class Aurora extends ProceduralScene {
 		constructor(w, h, cfg, seed) {
 			super('aurora', w, h, cfg, seed);
@@ -2904,7 +3191,7 @@
 	// server's snapshot payload — the client looks up the constructor here
 	// by name so new effects just register themselves and work without
 	// client-side changes.
-	const effects = { rain: Rain, dust: Dust, fireflies: Fireflies, waterfall: Waterfall, 'wheat-field': WheatField, aurora: Aurora, snow: Snow, 'autumn-leaves': AutumnLeaves, starfield: Starfield };
+	const effects = { rain: Rain, dust: Dust, fireflies: Fireflies, waterfall: Waterfall, 'wheat-field': WheatField, beach: Beach, aurora: Aurora, snow: Snow, 'autumn-leaves': AutumnLeaves, starfield: Starfield };
 	const presets = {
 		'wheat-field': [
 			{
@@ -2988,6 +3275,90 @@
 					gust_p: 0.0016,
 					gust_mult: 2.45,
 					gust_dur: 66,
+				},
+			},
+		],
+		beach: [
+			{
+				key: 'still-shore',
+				label: 'still shore',
+				config: {
+					shoreline: 0.56,
+					tide_amp: 3.2,
+					wave_amp: 1.3,
+					wave_freq: 0.14,
+					speed: 0.05,
+					slope: 0.08,
+					foam: 0.24,
+					shimmer: 0.18,
+					hue: 196,
+					hue_sp: 10,
+					sat: 0.42,
+					lmin: 0.26,
+					lmax: 0.78,
+				},
+			},
+			{
+				key: 'gentle-tide',
+				label: 'gentle tide',
+				config: {
+					shoreline: 0.58,
+					tide_amp: 6,
+					wave_amp: 2.4,
+					wave_freq: 0.18,
+					speed: 0.1,
+					slope: 0.16,
+					foam: 0.36,
+					shimmer: 0.22,
+					hue: 198,
+					hue_sp: 16,
+					sat: 0.5,
+					lmin: 0.28,
+					lmax: 0.82,
+					high_tide_p: 0.0008,
+					low_tide_p: 0.0006,
+				},
+			},
+			{
+				key: 'foamy-edge',
+				label: 'foamy edge',
+				config: {
+					shoreline: 0.6,
+					tide_amp: 7.4,
+					wave_amp: 3.1,
+					wave_freq: 0.21,
+					speed: 0.12,
+					slope: 0.2,
+					foam: 0.5,
+					shimmer: 0.18,
+					hue: 194,
+					hue_sp: 18,
+					sat: 0.54,
+					lmin: 0.3,
+					lmax: 0.84,
+					high_tide_p: 0.0012,
+					foam_burst_p: 0.0013,
+					foam_burst_mult: 2.2,
+				},
+			},
+			{
+				key: 'wide-beach',
+				label: 'wide beach',
+				config: {
+					shoreline: 0.52,
+					tide_amp: 4.8,
+					wave_amp: 1.8,
+					wave_freq: 0.12,
+					speed: 0.08,
+					slope: -0.1,
+					foam: 0.3,
+					shimmer: 0.28,
+					hue: 202,
+					hue_sp: 14,
+					sat: 0.44,
+					lmin: 0.24,
+					lmax: 0.78,
+					low_tide_p: 0.0011,
 				},
 			},
 		],
@@ -3502,5 +3873,5 @@
 		],
 	};
 
-	global.AmbienceSim = { Rain, Dust, Fireflies, Waterfall, WheatField, Aurora, AutumnLeaves, Snow, Starfield, subscribe, applyDefaults, hslToRGB, effects, presets };
+	global.AmbienceSim = { Rain, Dust, Fireflies, Waterfall, WheatField, Beach, Aurora, AutumnLeaves, Snow, Starfield, subscribe, applyDefaults, hslToRGB, effects, presets };
 })(window);

--- a/sim/procedural.go
+++ b/sim/procedural.go
@@ -180,6 +180,36 @@ var wheatFieldDefaults = ProceduralConfig{
 	"calm_mult":     0.40,
 }
 
+var beachDefaults = ProceduralConfig{
+	"intro_dur":       55,
+	"intro_tide":      0.18,
+	"ending_dur":      65,
+	"ending_linger":   18,
+	"ending_wet":      0.10,
+	"shoreline":       0.58,
+	"tide_amp":        6.0,
+	"wave_amp":        2.4,
+	"wave_freq":       0.18,
+	"speed":           0.10,
+	"slope":           0.16,
+	"foam":            0.36,
+	"shimmer":         0.22,
+	"hue":             198,
+	"hue_sp":          16,
+	"sat":             0.50,
+	"lmin":            0.28,
+	"lmax":            0.82,
+	"high_tide_p":     0.0,
+	"low_tide_p":      0.0,
+	"foam_burst_p":    0.0,
+	"high_tide_dur":   60,
+	"high_tide_push":  1.40,
+	"low_tide_dur":    58,
+	"low_tide_pull":   1.20,
+	"foam_burst_dur":  34,
+	"foam_burst_mult": 1.90,
+}
+
 func SnowSchema() EffectSchema {
 	return EffectSchema{
 		Name: "snow",
@@ -458,6 +488,68 @@ func WheatFieldSchema() EffectSchema {
 	}
 }
 
+func BeachSchema() EffectSchema {
+	return EffectSchema{
+		Name: "beach",
+		Knobs: []Knob{
+			{Key: "intro_dur", Label: "intro dur", Slot: SlotSpawn, Group: "introduction", Type: KnobInt, Min: 10, Max: 220, Step: 5, Default: 55, Trigger: "intro",
+				Description: "Ticks spent establishing the first advancing tide rhythm from a calmer shoreline."},
+			{Key: "intro_tide", Label: "intro tide", Slot: SlotSpawn, Group: "introduction", Type: KnobFloat, Min: 0.05, Max: 0.5, Step: 0.01, Default: 0.18,
+				Description: "Starting fraction of the full tide motion before the shoreline settles into rhythm."},
+			{Key: "ending_dur", Label: "ending dur", Slot: SlotEnd, Group: "ending", Type: KnobInt, Min: 10, Max: 220, Step: 5, Default: 65, Trigger: "ending",
+				Description: "Ticks spent easing the waterline back out toward a calmer shore."},
+			{Key: "ending_linger", Label: "ending linger", Slot: SlotEnd, Group: "ending", Type: KnobInt, Min: 0, Max: 140, Step: 5, Default: 18,
+				Description: "Extra quiet ticks for wet sand and foam remnants to fade after the retreat."},
+			{Key: "ending_wet", Label: "ending wet", Slot: SlotEnd, Group: "ending", Type: KnobFloat, Min: 0.02, Max: 0.35, Step: 0.01, Default: 0.10,
+				Description: "Residual shoreline motion and wet-sand presence near the end of the outro."},
+			{Key: "shoreline", Label: "shoreline", Slot: SlotLever, Group: "shore", Type: KnobFloat, Min: 0.42, Max: 0.76, Step: 0.01, Default: 0.58,
+				Description: "Base shoreline height in the frame."},
+			{Key: "tide_amp", Label: "tide amp", Slot: SlotLever, Group: "shore", Type: KnobFloat, Min: 1, Max: 14, Step: 0.5, Default: 6,
+				Description: "How far the tide line advances and retreats."},
+			{Key: "wave_amp", Label: "wave amp", Slot: SlotLever, Group: "shore", Type: KnobFloat, Min: 0.5, Max: 6, Step: 0.1, Default: 2.4,
+				Description: "Height of the small shoreline ripples layered on top of the tide."},
+			{Key: "wave_freq", Label: "wave freq", Slot: SlotLever, Group: "shore", Type: KnobFloat, Min: 0.05, Max: 0.35, Step: 0.01, Default: 0.18,
+				Description: "Horizontal frequency of the shoreline wiggle."},
+			{Key: "speed", Label: "tide speed", Slot: SlotLever, Group: "shore", Type: KnobFloat, Min: 0.02, Max: 0.3, Step: 0.01, Default: 0.10,
+				Description: "How quickly the tide rhythm moves in and out."},
+			{Key: "slope", Label: "shore slope", Slot: SlotLever, Group: "shore", Type: KnobFloat, Min: -0.35, Max: 0.35, Step: 0.01, Default: 0.16,
+				Description: "Diagonal slant of the shoreline across the frame."},
+			{Key: "foam", Label: "foam", Slot: SlotLever, Group: "shore", Type: KnobFloat, Min: 0.05, Max: 0.8, Step: 0.01, Default: 0.36,
+				Description: "Brightness and thickness of the foam edge at the waterline."},
+			{Key: "shimmer", Label: "shimmer", Slot: SlotLever, Group: "shore", Type: KnobFloat, Min: 0.02, Max: 0.6, Step: 0.01, Default: 0.22,
+				Description: "Strength of the water-surface shimmer away from the foam line."},
+			{Key: "hue", Label: "water hue", Slot: SlotLever, Group: "color", Type: KnobFloat, Min: 180, Max: 220, Step: 1, Default: 198,
+				Description: "Base water hue. Lower values lean teal; higher values lean deep blue."},
+			{Key: "hue_sp", Label: "hue spread", Slot: SlotLever, Group: "color", Type: KnobFloat, Min: 0, Max: 28, Step: 1, Default: 16,
+				Description: "Variation across water and foam accents."},
+			{Key: "sat", Label: "saturation", Slot: SlotLever, Group: "color", Type: KnobFloat, Min: 0.1, Max: 0.9, Step: 0.01, Default: 0.50,
+				Description: "Overall water color saturation."},
+			{Key: "lmin", Label: "light min", Slot: SlotLever, Group: "color", Type: KnobFloat, Min: 0.1, Max: 0.6, Step: 0.01, Default: 0.28,
+				Description: "Minimum lightness used for deeper water and wet sand."},
+			{Key: "lmax", Label: "light max", Slot: SlotLever, Group: "color", Type: KnobFloat, Min: 0.4, Max: 0.95, Step: 0.01, Default: 0.82,
+				Description: "Maximum lightness used for foam and bright shore reflections."},
+			{Key: "high_tide_p", Label: "high tide", Slot: SlotEvent, Type: KnobFloat, Min: 0, Max: 0.02, Step: 0.0005, Default: 0, Trigger: "high-tide",
+				Description: "Per-tick chance of the shoreline pushing farther inland for a while."},
+			{Key: "low_tide_p", Label: "low tide", Slot: SlotEvent, Type: KnobFloat, Min: 0, Max: 0.02, Step: 0.0005, Default: 0, Trigger: "low-tide",
+				Description: "Per-tick chance of the shoreline pulling farther back down the beach."},
+			{Key: "foam_burst_p", Label: "foam burst", Slot: SlotEvent, Type: KnobFloat, Min: 0, Max: 0.02, Step: 0.0005, Default: 0, Trigger: "foam-burst",
+				Description: "Per-tick chance of a brighter foamy wash crossing the edge."},
+			{Key: "high_tide_dur", Label: "high dur", Slot: SlotEventMod, Group: "high-tide", Type: KnobInt, Min: 10, Max: 220, Step: 5, Default: 60,
+				Description: "Duration of the stronger high-tide push."},
+			{Key: "high_tide_push", Label: "high push", Slot: SlotEventMod, Group: "high-tide", Type: KnobFloat, Min: 0.2, Max: 3, Step: 0.05, Default: 1.4,
+				Description: "Additional inward shoreline offset during high tide."},
+			{Key: "low_tide_dur", Label: "low dur", Slot: SlotEventMod, Group: "low-tide", Type: KnobInt, Min: 10, Max: 220, Step: 5, Default: 58,
+				Description: "Duration of the lower-tide retreat."},
+			{Key: "low_tide_pull", Label: "low pull", Slot: SlotEventMod, Group: "low-tide", Type: KnobFloat, Min: 0.2, Max: 3, Step: 0.05, Default: 1.2,
+				Description: "Additional outward shoreline offset during low tide."},
+			{Key: "foam_burst_dur", Label: "foam dur", Slot: SlotEventMod, Group: "foam-burst", Type: KnobInt, Min: 8, Max: 120, Step: 2, Default: 34,
+				Description: "Duration of a brighter foamy edge."},
+			{Key: "foam_burst_mult", Label: "foam x", Slot: SlotEventMod, Group: "foam-burst", Type: KnobFloat, Min: 1.05, Max: 3, Step: 0.05, Default: 1.9,
+				Description: "Brightness multiplier applied during a foam burst."},
+		},
+	}
+}
+
 func cloneProceduralConfig(src ProceduralConfig) ProceduralConfig {
 	if src == nil {
 		return ProceduralConfig{}
@@ -508,6 +600,8 @@ func proceduralDefaults(kind string) ProceduralConfig {
 		return cloneProceduralConfig(auroraDefaults)
 	case "wheat-field":
 		return cloneProceduralConfig(wheatFieldDefaults)
+	case "beach":
+		return cloneProceduralConfig(beachDefaults)
 	default:
 		return ProceduralConfig{}
 	}
@@ -819,6 +913,75 @@ func mergeProceduralDefaults(kind string, cfg ProceduralConfig) ProceduralConfig
 		if out["calm_mult"] <= 0 {
 			out["calm_mult"] = wheatFieldDefaults["calm_mult"]
 		}
+	case "beach":
+		if out["intro_dur"] <= 0 {
+			out["intro_dur"] = beachDefaults["intro_dur"]
+		}
+		out["intro_tide"] = clamp01(out["intro_tide"])
+		if out["ending_dur"] <= 0 {
+			out["ending_dur"] = beachDefaults["ending_dur"]
+		}
+		if out["ending_linger"] < 0 {
+			out["ending_linger"] = 0
+		}
+		out["ending_wet"] = clamp01(out["ending_wet"])
+		if out["shoreline"] <= 0 {
+			out["shoreline"] = beachDefaults["shoreline"]
+		}
+		if out["tide_amp"] <= 0 {
+			out["tide_amp"] = beachDefaults["tide_amp"]
+		}
+		if out["wave_amp"] <= 0 {
+			out["wave_amp"] = beachDefaults["wave_amp"]
+		}
+		if out["wave_freq"] <= 0 {
+			out["wave_freq"] = beachDefaults["wave_freq"]
+		}
+		if out["speed"] <= 0 {
+			out["speed"] = beachDefaults["speed"]
+		}
+		if out["foam"] <= 0 {
+			out["foam"] = beachDefaults["foam"]
+		}
+		if out["shimmer"] <= 0 {
+			out["shimmer"] = beachDefaults["shimmer"]
+		}
+		if out["hue"] == 0 {
+			out["hue"] = beachDefaults["hue"]
+		}
+		if out["hue_sp"] < 0 {
+			out["hue_sp"] = 0
+		}
+		if out["sat"] <= 0 {
+			out["sat"] = beachDefaults["sat"]
+		}
+		if out["lmin"] <= 0 {
+			out["lmin"] = beachDefaults["lmin"]
+		}
+		if out["lmax"] <= 0 {
+			out["lmax"] = beachDefaults["lmax"]
+		}
+		if out["lmax"] < out["lmin"] {
+			out["lmin"], out["lmax"] = out["lmax"], out["lmin"]
+		}
+		if out["high_tide_dur"] <= 0 {
+			out["high_tide_dur"] = beachDefaults["high_tide_dur"]
+		}
+		if out["high_tide_push"] <= 0 {
+			out["high_tide_push"] = beachDefaults["high_tide_push"]
+		}
+		if out["low_tide_dur"] <= 0 {
+			out["low_tide_dur"] = beachDefaults["low_tide_dur"]
+		}
+		if out["low_tide_pull"] <= 0 {
+			out["low_tide_pull"] = beachDefaults["low_tide_pull"]
+		}
+		if out["foam_burst_dur"] <= 0 {
+			out["foam_burst_dur"] = beachDefaults["foam_burst_dur"]
+		}
+		if out["foam_burst_mult"] <= 0 {
+			out["foam_burst_mult"] = beachDefaults["foam_burst_mult"]
+		}
 	}
 	return out
 }
@@ -1033,6 +1196,24 @@ func (p *Procedural) TriggerEvent(name string) bool {
 			return false
 		}
 		return true
+	case "beach":
+		switch name {
+		case "high-tide":
+			p.startBeachHighTideLocked("triggered")
+		case "low-tide":
+			p.startBeachLowTideLocked("triggered")
+		case "foam-burst":
+			p.startBeachFoamBurstLocked("triggered")
+		case "intro":
+			p.startBeachIntroLocked()
+			p.appendLog("intro", fmt.Sprintf("started (dur=%d, tide=%.2f)", p.timers["intro"], p.cfg["intro_tide"]))
+		case "ending":
+			p.startBeachEndingLocked()
+			p.appendLog("ending", fmt.Sprintf("started (fade=%d, linger=%d)", p.intCfg("ending_dur"), p.intCfg("ending_linger")))
+		default:
+			return false
+		}
+		return true
 	default:
 		return false
 	}
@@ -1078,6 +1259,8 @@ func (p *Procedural) Step() {
 		p.stepAuroraLocked()
 	case "wheat-field":
 		p.stepWheatFieldLocked()
+	case "beach":
+		p.stepBeachLocked()
 	}
 }
 
@@ -1411,5 +1594,78 @@ func (p *Procedural) stepWheatFieldLocked() {
 	}
 	if p.timers["calm"] <= 0 && p.cfg["calm_p"] > 0 && p.rng.Float64() < p.cfg["calm_p"] {
 		p.startWheatFieldCalmLocked("started")
+	}
+}
+
+func (p *Procedural) startBeachHighTideLocked(verb string) {
+	p.timers["high-tide"] = jitterInt(p.rng, p.intCfg("high_tide_dur"), 0.3)
+	p.timers["low-tide"] = 0
+	p.values["tide_bias"] = p.cfg["high_tide_push"] * (0.65 + p.rng.Float64()*0.55)
+	p.appendLog("high-tide", fmt.Sprintf("%s (dur=%d, bias=+%.2f)", verb, p.timers["high-tide"], p.values["tide_bias"]))
+}
+
+func (p *Procedural) startBeachLowTideLocked(verb string) {
+	p.timers["low-tide"] = jitterInt(p.rng, p.intCfg("low_tide_dur"), 0.3)
+	p.timers["high-tide"] = 0
+	p.values["tide_bias"] = -p.cfg["low_tide_pull"] * (0.65 + p.rng.Float64()*0.55)
+	p.appendLog("low-tide", fmt.Sprintf("%s (dur=%d, bias=%.2f)", verb, p.timers["low-tide"], p.values["tide_bias"]))
+}
+
+func (p *Procedural) startBeachFoamBurstLocked(verb string) {
+	p.timers["foam-burst"] = jitterInt(p.rng, p.intCfg("foam_burst_dur"), 0.3)
+	p.values["foam_gain"] = p.cfg["foam_burst_mult"] * (0.85 + p.rng.Float64()*0.35)
+	p.appendLog("foam-burst", fmt.Sprintf("%s (dur=%d, x%.2f)", verb, p.timers["foam-burst"], p.values["foam_gain"]))
+}
+
+func (p *Procedural) startBeachIntroLocked() {
+	p.timers["high-tide"] = 0
+	p.timers["low-tide"] = 0
+	p.timers["foam-burst"] = 0
+	p.timers["ending"] = 0
+	p.values["tide_bias"] = 0
+	p.values["foam_gain"] = 1
+	p.timers["intro"] = p.intCfg("intro_dur")
+	p.values["intro_total"] = float64(p.timers["intro"])
+}
+
+func (p *Procedural) startBeachEndingLocked() {
+	p.timers["intro"] = 0
+	p.timers["high-tide"] = 0
+	p.timers["low-tide"] = 0
+	p.timers["foam-burst"] = 0
+	p.values["tide_bias"] = 0
+	p.values["foam_gain"] = 1
+	endingTotal := p.intCfg("ending_dur") + max(0, p.intCfg("ending_linger"))
+	if endingTotal < 1 {
+		endingTotal = max(1, p.intCfg("ending_dur"))
+	}
+	p.timers["ending"] = endingTotal
+	p.values["ending_total"] = float64(endingTotal)
+}
+
+func (p *Procedural) stepBeachLocked() {
+	if p.timers["high-tide"] <= 0 && p.timers["low-tide"] <= 0 {
+		p.values["tide_bias"] = 0
+	}
+	if p.timers["foam-burst"] <= 0 {
+		p.values["foam_gain"] = 1
+	}
+	if p.timers["intro"] <= 0 {
+		delete(p.values, "intro_total")
+	}
+	if p.timers["ending"] <= 0 {
+		delete(p.values, "ending_total")
+	}
+	if p.timers["intro"] > 0 || p.timers["ending"] > 0 {
+		return
+	}
+	if p.timers["high-tide"] <= 0 && p.timers["low-tide"] <= 0 && p.cfg["high_tide_p"] > 0 && p.rng.Float64() < p.cfg["high_tide_p"] {
+		p.startBeachHighTideLocked("started")
+	}
+	if p.timers["low-tide"] <= 0 && p.timers["high-tide"] <= 0 && p.cfg["low_tide_p"] > 0 && p.rng.Float64() < p.cfg["low_tide_p"] {
+		p.startBeachLowTideLocked("started")
+	}
+	if p.timers["foam-burst"] <= 0 && p.cfg["foam_burst_p"] > 0 && p.rng.Float64() < p.cfg["foam_burst_p"] {
+		p.startBeachFoamBurstLocked("started")
 	}
 }

--- a/sim/procedural_test.go
+++ b/sim/procedural_test.go
@@ -52,6 +52,16 @@ func TestWheatFieldSchema(t *testing.T) {
 	}
 }
 
+func TestBeachSchema(t *testing.T) {
+	schema := BeachSchema()
+	if schema.Name != "beach" {
+		t.Fatalf("schema name = %q, want beach", schema.Name)
+	}
+	if len(schema.Knobs) == 0 {
+		t.Fatal("expected beach schema knobs")
+	}
+}
+
 func TestProceduralSnowSnapshotRestore(t *testing.T) {
 	p := NewProcedural("snow", 160, 80, 42, nil)
 	if !p.TriggerEvent("gust") {
@@ -173,5 +183,34 @@ func TestProceduralWheatFieldSnapshotRestore(t *testing.T) {
 	}
 	if again.Values["gust_push"] != snap.Values["gust_push"] {
 		t.Fatalf("restored gust push = %f, want %f", again.Values["gust_push"], snap.Values["gust_push"])
+	}
+}
+
+func TestProceduralBeachSnapshotRestore(t *testing.T) {
+	p := NewProcedural("beach", 160, 80, 91, nil)
+	if !p.TriggerEvent("foam-burst") {
+		t.Fatal("expected foam-burst trigger to succeed")
+	}
+	if !p.TriggerEvent("high-tide") {
+		t.Fatal("expected high-tide trigger to succeed")
+	}
+	p.Step()
+
+	snap := p.Snapshot()
+	if snap.Timers["foam-burst"] <= 0 {
+		t.Fatal("expected foam-burst timer in snapshot")
+	}
+	if snap.Timers["high-tide"] <= 0 {
+		t.Fatal("expected high-tide timer in snapshot")
+	}
+
+	restored := NewProcedural("beach", 160, 80, 7, nil)
+	restored.RestoreSnapshot(snap)
+	again := restored.Snapshot()
+	if again.Timers["foam-burst"] != snap.Timers["foam-burst"] {
+		t.Fatalf("restored foam-burst timer = %d, want %d", again.Timers["foam-burst"], snap.Timers["foam-burst"])
+	}
+	if again.Values["tide_bias"] != snap.Values["tide_bias"] {
+		t.Fatalf("restored tide bias = %f, want %f", again.Values["tide_bias"], snap.Values["tide_bias"])
 	}
 }


### PR DESCRIPTION
## Summary
- add the `beach` procedural dev effect schema, runtime registration, and snapshot coverage on the Go side
- add the browser-side `Beach` renderer, event handling, and presets to the procedural effect registry
- validate the shoreline composition on `ambience.dev.romaine.life/dev/beach` and tune it to stay readable under randomized configs

## Validation
- `node --check cmd/ambience/web/sim.js`
- `go test ./...`
- `powershell -ExecutionPolicy Bypass -File scripts/dev-deploy.ps1 -Component all`
- `powershell -ExecutionPolicy Bypass -File scripts/dev-loop.ps1 -Once`
- visual check on `https://ambience.dev.romaine.life/dev/beach`

Refs #26
