### PR TITLE
Add the windmill dev effect prototype

### DIFF
--- a/cmd/ambience/dev_random_test.go
+++ b/cmd/ambience/dev_random_test.go
@@ -21,6 +21,7 @@ func TestRandomizedDevConfigStaysWithinSchemaBounds(t *testing.T) {
 		sim.WheatFieldSchema(),
 		sim.BeachSchema(),
 		sim.CampfireSchema(),
+		sim.WindmillSchema(),
 	}
 
 	for i, schema := range schemas {
@@ -62,6 +63,7 @@ func TestRandomizedDevConfigChangesAtLeastOneKnob(t *testing.T) {
 		sim.WheatFieldSchema(),
 		sim.BeachSchema(),
 		sim.CampfireSchema(),
+		sim.WindmillSchema(),
 	}
 
 	for i, schema := range schemas {

--- a/cmd/ambience/dev_sessions_test.go
+++ b/cmd/ambience/dev_sessions_test.go
@@ -22,6 +22,7 @@ func TestDevPageEffectFromPath(t *testing.T) {
 		{path: "/dev/snow", want: "snow", wantOK: true},
 		{path: "/dev/starfield", want: "starfield", wantOK: true},
 		{path: "/dev/waterfall", want: "waterfall", wantOK: true},
+		{path: "/dev/windmill", want: "windmill", wantOK: true},
 		{path: "/dev/wheat-field", want: "wheat-field", wantOK: true},
 		{path: "/dev/unknown", wantOK: false},
 		{path: "/dev/fireflies/extra", wantOK: false},
@@ -53,6 +54,7 @@ func TestEffectFromSchemaPath(t *testing.T) {
 		{path: "/effects/snow/schema", want: "snow", wantOK: true},
 		{path: "/effects/starfield/schema", want: "starfield", wantOK: true},
 		{path: "/effects/waterfall/schema", want: "waterfall", wantOK: true},
+		{path: "/effects/windmill/schema", want: "windmill", wantOK: true},
 		{path: "/effects/wheat-field/schema", want: "wheat-field", wantOK: true},
 		{path: "/effects/unknown/schema", wantOK: false},
 		{path: "/effects/fireflies/not-schema", wantOK: false},
@@ -142,6 +144,17 @@ func TestNewDevSessionCampfireSnapshotType(t *testing.T) {
 	snap := session.snapshot()
 	if snap.Type != "campfire" {
 		t.Fatalf("snapshot type = %q, want campfire", snap.Type)
+	}
+}
+
+func TestNewDevSessionWindmillSnapshotType(t *testing.T) {
+	session, err := newDevSession("windmill")
+	if err != nil {
+		t.Fatalf("newDevSession: %v", err)
+	}
+	snap := session.snapshot()
+	if snap.Type != "windmill" {
+		t.Fatalf("snapshot type = %q, want windmill", snap.Type)
 	}
 }
 

--- a/cmd/ambience/effects.go
+++ b/cmd/ambience/effects.go
@@ -106,6 +106,11 @@ var effectRegistry = map[string]effectDefinition{
 		Schema:     sim.CampfireSchema,
 		NewRuntime: newCampfireRuntime,
 	},
+	"windmill": {
+		Type:       "windmill",
+		Schema:     sim.WindmillSchema,
+		NewRuntime: newWindmillRuntime,
+	},
 }
 
 func lookupEffectDefinition(effectType string) (effectDefinition, bool) {
@@ -272,6 +277,10 @@ func newBeachRuntime(w, h int, seed int64, cfg json.RawMessage) (effectRuntime, 
 
 func newCampfireRuntime(w, h int, seed int64, cfg json.RawMessage) (effectRuntime, error) {
 	return newProceduralRuntime("campfire", w, h, seed, cfg)
+}
+
+func newWindmillRuntime(w, h int, seed int64, cfg json.RawMessage) (effectRuntime, error) {
+	return newProceduralRuntime("windmill", w, h, seed, cfg)
 }
 
 func (r *rainRuntime) Type() string { return "rain" }
@@ -696,6 +705,8 @@ func (p *proceduralRuntime) Schema() sim.EffectSchema {
 		return sim.BeachSchema()
 	case "campfire":
 		return sim.CampfireSchema()
+	case "windmill":
+		return sim.WindmillSchema()
 	default:
 		return sim.EffectSchema{}
 	}

--- a/cmd/ambience/web/sim.js
+++ b/cmd/ambience/web/sim.js
@@ -1895,6 +1895,31 @@
 			lull_dur: 68,
 			lull_mult: 0.55,
 		},
+		windmill: {
+			intro_dur: 45,
+			intro_turn: 0.12,
+			ending_dur: 60,
+			ending_linger: 20,
+			ending_turn: 0.05,
+			turn_speed: 0.08,
+			blade_len: 14,
+			blade_width: 1.8,
+			tower_height: 20,
+			tower_width: 6,
+			horizon: 0.72,
+			glow: 0.18,
+			hue: 28,
+			hue_sp: 18,
+			sat: 0.42,
+			lmin: 0.18,
+			lmax: 0.82,
+			gust_p: 0,
+			lull_p: 0,
+			gust_dur: 50,
+			gust_mult: 1.9,
+			lull_dur: 72,
+			lull_mult: 0.45,
+		},
 		starfield: {
 			intro_dur: 50,
 			intro_density: 0.08,
@@ -2049,6 +2074,30 @@
 				if (c.lull_dur <= 0) c.lull_dur = base.lull_dur;
 				if (c.lull_mult <= 0) c.lull_mult = base.lull_mult;
 				break;
+			case 'windmill':
+				if (c.intro_dur <= 0) c.intro_dur = base.intro_dur;
+				c.intro_turn = clamp01(c.intro_turn);
+				if (c.ending_dur <= 0) c.ending_dur = base.ending_dur;
+				if (c.ending_linger < 0) c.ending_linger = 0;
+				c.ending_turn = clamp01(c.ending_turn);
+				if (c.turn_speed <= 0) c.turn_speed = base.turn_speed;
+				if (c.blade_len <= 0) c.blade_len = base.blade_len;
+				if (c.blade_width <= 0) c.blade_width = base.blade_width;
+				if (c.tower_height <= 0) c.tower_height = base.tower_height;
+				if (c.tower_width <= 0) c.tower_width = base.tower_width;
+				if (c.horizon <= 0) c.horizon = base.horizon;
+				if (c.glow <= 0) c.glow = base.glow;
+				if (c.hue === 0) c.hue = base.hue;
+				if (c.hue_sp < 0) c.hue_sp = 0;
+				if (c.sat <= 0) c.sat = base.sat;
+				if (c.lmin <= 0) c.lmin = base.lmin;
+				if (c.lmax <= 0) c.lmax = base.lmax;
+				if (c.lmax < c.lmin) [c.lmin, c.lmax] = [c.lmax, c.lmin];
+				if (c.gust_dur <= 0) c.gust_dur = base.gust_dur;
+				if (c.gust_mult <= 0) c.gust_mult = base.gust_mult;
+				if (c.lull_dur <= 0) c.lull_dur = base.lull_dur;
+				if (c.lull_mult <= 0) c.lull_mult = base.lull_mult;
+				break;
 			case 'aurora':
 				if (c.intro_dur <= 0) c.intro_dur = base.intro_dur;
 				c.intro_glow = clamp01(c.intro_glow);
@@ -2190,6 +2239,8 @@
 					return this._triggerBeach(name);
 				case 'campfire':
 					return this._triggerCampfire(name);
+				case 'windmill':
+					return this._triggerWindmill(name);
 				case 'aurora':
 					return this._triggerAurora(name);
 				case 'starfield':
@@ -2235,6 +2286,9 @@
 			if (this.kind === 'campfire' && (!this.timers.crackle || this.timers.crackle <= 0)) {
 				this.values.crackle_gain = 1;
 			}
+			if (this.kind === 'windmill' && (!this.timers.gust || this.timers.gust <= 0)) {
+				this.values.gust_gain = 1;
+			}
 		}
 
 		render(ctx, canvasW, canvasH, opts) {
@@ -2245,6 +2299,8 @@
 					return this._renderBeach(ctx, canvasW, canvasH, opts);
 				case 'campfire':
 					return this._renderCampfire(ctx, canvasW, canvasH, opts);
+				case 'windmill':
+					return this._renderWindmill(ctx, canvasW, canvasH, opts);
 				case 'aurora':
 					return this._renderAurora(ctx, canvasW, canvasH, opts);
 				case 'starfield':
@@ -2446,6 +2502,36 @@
 			return false;
 		}
 
+		_triggerWindmill(name) {
+			const rng = this._eventRng(name.length + 71);
+			switch (name) {
+				case 'gust':
+					this.timers.gust = jitterInt(rng, this.cfg.gust_dur, 0.3);
+					this.values.gust_gain = this.cfg.gust_mult * (0.75 + rng() * 0.45);
+					return true;
+				case 'lull':
+					this.timers.lull = jitterInt(rng, this.cfg.lull_dur, 0.3);
+					return true;
+				case 'intro':
+					this.timers.gust = 0;
+					this.timers.lull = 0;
+					this.timers.ending = 0;
+					this.values.gust_gain = 1;
+					this.timers.intro = Math.max(1, Math.round(this.cfg.intro_dur));
+					this.values.intro_total = this.timers.intro;
+					return true;
+				case 'ending':
+					this.timers.intro = 0;
+					this.timers.gust = 0;
+					this.timers.lull = 0;
+					this.values.gust_gain = 1;
+					this.timers.ending = Math.max(1, Math.round(this.cfg.ending_dur + Math.max(0, this.cfg.ending_linger)));
+					this.values.ending_total = this.timers.ending;
+					return true;
+			}
+			return false;
+		}
+
 		_triggerAurora(name) {
 			const rng = this._eventRng(name.length + 53);
 			switch (name) {
@@ -2631,6 +2717,23 @@
 				level *= 1 - (1 - this.cfg.ending_glow) * progress;
 			}
 			return Math.max(0.05, level);
+		}
+
+		_rotationLevelWindmill() {
+			let level = 1;
+			if (this.timers.gust > 0) level *= this.values.gust_gain || this.cfg.gust_mult;
+			if (this.timers.lull > 0) level *= this.cfg.lull_mult;
+			if (this.timers.intro > 0) {
+				const total = this.values.intro_total || this.cfg.intro_dur;
+				const progress = this._phaseProgress(total, this.timers.intro);
+				level *= this.cfg.intro_turn + (1 - this.cfg.intro_turn) * progress;
+			}
+			if (this.timers.ending > 0) {
+				const total = this.values.ending_total || (this.cfg.ending_dur + this.cfg.ending_linger);
+				const progress = this._phaseProgress(total, this.timers.ending);
+				level *= 1 - (1 - this.cfg.ending_turn) * progress;
+			}
+			return Math.max(0.03, level);
 		}
 
 		_renderSnow(ctx, canvasW, canvasH, opts) {
@@ -2935,6 +3038,106 @@
 					}
 					x += width;
 				}
+			}
+		}
+
+		_renderWindmill(ctx, canvasW, canvasH, opts) {
+			opts = opts || {};
+			if (opts.transparent) {
+				ctx.clearRect(0, 0, canvasW, canvasH);
+			} else {
+				const skyTop = hslToRGB((this.cfg.hue + 210) % 360, clamp01(this.cfg.sat * 0.5), clamp01(this.cfg.lmin * 0.95));
+				const skyMid = hslToRGB((this.cfg.hue + 248) % 360, clamp01(this.cfg.sat * 0.42), clamp01(this.cfg.lmin + (this.cfg.lmax - this.cfg.lmin) * 0.32));
+				const skyLow = hslToRGB(this.cfg.hue, clamp01(this.cfg.sat * 0.82), clamp01(this.cfg.lmin + (this.cfg.lmax - this.cfg.lmin) * 0.78));
+				const sky = ctx.createLinearGradient(0, 0, 0, canvasH);
+				sky.addColorStop(0, `rgb(${skyTop.r},${skyTop.g},${skyTop.b})`);
+				sky.addColorStop(0.58, `rgb(${skyMid.r},${skyMid.g},${skyMid.b})`);
+				sky.addColorStop(1, `rgb(${skyLow.r},${skyLow.g},${skyLow.b})`);
+				ctx.fillStyle = sky;
+				ctx.fillRect(0, 0, canvasW, canvasH);
+			}
+
+			const sx = canvasW / this.w;
+			const sy = canvasH / this.h;
+			const ceilSx = Math.ceil(sx);
+			const ceilSy = Math.ceil(sy);
+			const horizon = Math.max(8, Math.min(this.h - 8, Math.floor(this.h * this.cfg.horizon)));
+			const centerX = Math.floor(this.w * 0.58);
+			const rotationLevel = this._rotationLevelWindmill();
+			const angle = this.tick * this.cfg.turn_speed * rotationLevel + Math.PI * 0.08;
+			const towerH = Math.max(10, Math.round(this.cfg.tower_height));
+			const towerW = Math.max(3, Math.round(this.cfg.tower_width));
+			const bladeLen = Math.max(5, Math.round(this.cfg.blade_len));
+			const bladeWidth = Math.max(1, this.cfg.blade_width);
+
+			const horizonGlow = ctx.createLinearGradient(0, Math.floor((horizon - 3) * sy), 0, Math.floor((horizon + 7) * sy));
+			horizonGlow.addColorStop(0, `rgba(255, 214, 163, ${0.04 + this.cfg.glow * 0.12})`);
+			horizonGlow.addColorStop(1, 'rgba(255, 214, 163, 0)');
+			ctx.fillStyle = horizonGlow;
+			ctx.fillRect(0, Math.floor((horizon - 3) * sy), canvasW, Math.ceil(12 * sy));
+
+			const hillRows = new Array(this.w);
+			for (let x = 0; x < this.w; x++) {
+				const broad = Math.sin(x * 0.045 + 0.4) * 1.2 + Math.sin(x * 0.012 + 1.3) * 2.1;
+				const mound = Math.exp(-Math.pow((x - centerX) / 18, 2)) * 6.2 + Math.exp(-Math.pow((x - this.w * 0.18) / 24, 2)) * 2.1;
+				hillRows[x] = Math.round(horizon + broad - mound);
+			}
+
+			const hillColor = hslToRGB((this.cfg.hue + 205) % 360, clamp01(this.cfg.sat * 0.16), 0.08);
+			ctx.fillStyle = `rgb(${hillColor.r},${hillColor.g},${hillColor.b})`;
+			ctx.beginPath();
+			ctx.moveTo(0, canvasH);
+			for (let x = 0; x < this.w; x++) {
+				ctx.lineTo(Math.floor(x * sx), Math.floor(hillRows[x] * sy));
+			}
+			ctx.lineTo(canvasW, canvasH);
+			ctx.closePath();
+			ctx.fill();
+
+			const baseY = hillRows[Math.max(0, Math.min(this.w - 1, centerX))];
+			const hubY = baseY - towerH + 2;
+			const millColor = hslToRGB((this.cfg.hue + 208) % 360, clamp01(this.cfg.sat * 0.08), 0.1);
+			for (let y = hubY; y <= baseY; y++) {
+				const ratio = (y - hubY) / Math.max(1, baseY - hubY);
+				const half = Math.max(1, Math.round((towerW * (0.38 + ratio * 0.62)) * 0.5));
+				for (let dx = -half; dx <= half; dx++) {
+					this._fillCell(ctx, sx, sy, ceilSx, ceilSy, centerX + dx, y, 1, 1, `rgb(${millColor.r},${millColor.g},${millColor.b})`, 1);
+				}
+			}
+
+			for (let dx = -Math.max(2, Math.round(towerW * 0.42)); dx <= Math.max(2, Math.round(towerW * 0.42)); dx++) {
+				const roofY = hubY - 2 + Math.abs(dx) * 0.4;
+				this._fillCell(ctx, sx, sy, ceilSx, ceilSy, centerX + dx, Math.round(roofY), 1, 1, `rgb(${millColor.r},${millColor.g},${millColor.b})`, 1);
+			}
+
+			const windowGlow = hslToRGB(42, 0.72, clamp01(0.38 + this.cfg.glow * 0.5));
+			const windowY = Math.round(hubY + towerH * 0.46);
+			this._fillCell(ctx, sx, sy, ceilSx, ceilSy, centerX, windowY, 1, 2, `rgb(${windowGlow.r},${windowGlow.g},${windowGlow.b})`, clamp01(0.18 + this.cfg.glow * 0.58));
+
+			const bladeColor = hslToRGB((this.cfg.hue + 210) % 360, clamp01(this.cfg.sat * 0.08), 0.13);
+			for (let blade = 0; blade < 4; blade++) {
+				const theta = angle + blade * Math.PI * 0.5;
+				const px = -Math.sin(theta);
+				const py = Math.cos(theta) * 0.88;
+				for (let r = 1; r <= bladeLen; r++) {
+					const fade = 1 - r / Math.max(1, bladeLen);
+					const bx = centerX + Math.cos(theta) * r;
+					const by = hubY + Math.sin(theta) * r * 0.88;
+					const half = Math.max(0, Math.round(bladeWidth * fade * 0.55));
+					for (let spread = -half; spread <= half; spread++) {
+						this._fillCell(ctx, sx, sy, ceilSx, ceilSy, Math.round(bx + px * spread * 0.7), Math.round(by + py * spread * 0.7), 1, 1, `rgb(${bladeColor.r},${bladeColor.g},${bladeColor.b})`, 1);
+					}
+				}
+			}
+
+			this._fillCell(ctx, sx, sy, ceilSx, ceilSy, centerX - 1, hubY - 1, 3, 3, `rgb(${millColor.r},${millColor.g},${millColor.b})`, 1);
+
+			const grassColor = hslToRGB((this.cfg.hue + 120) % 360, 0.16, 0.14);
+			for (let x = 0; x < this.w; x += 2) {
+				const top = hillRows[x];
+				if ((x + this.tick) % 5 !== 0) continue;
+				const sway = this.timers.gust > 0 ? (this.values.gust_gain || this.cfg.gust_mult) * 0.2 : this.timers.lull > 0 ? -this.cfg.lull_mult * 0.08 : 0.04;
+				this._fillCell(ctx, sx, sy, ceilSx, ceilSy, x + Math.round(Math.sin(this.tick * 0.05 + x * 0.1) * sway), top - 1, 1, 2, `rgb(${grassColor.r},${grassColor.g},${grassColor.b})`, 0.28);
 			}
 		}
 
@@ -3354,6 +3557,12 @@
 		}
 	}
 
+	class Windmill extends ProceduralScene {
+		constructor(w, h, cfg, seed) {
+			super('windmill', w, h, cfg, seed);
+		}
+	}
+
 	class Aurora extends ProceduralScene {
 		constructor(w, h, cfg, seed) {
 			super('aurora', w, h, cfg, seed);
@@ -3412,7 +3621,7 @@
 	// server's snapshot payload — the client looks up the constructor here
 	// by name so new effects just register themselves and work without
 	// client-side changes.
-	const effects = { rain: Rain, dust: Dust, fireflies: Fireflies, waterfall: Waterfall, 'wheat-field': WheatField, beach: Beach, campfire: Campfire, aurora: Aurora, snow: Snow, 'autumn-leaves': AutumnLeaves, starfield: Starfield };
+	const effects = { rain: Rain, dust: Dust, fireflies: Fireflies, waterfall: Waterfall, 'wheat-field': WheatField, beach: Beach, campfire: Campfire, windmill: Windmill, aurora: Aurora, snow: Snow, 'autumn-leaves': AutumnLeaves, starfield: Starfield };
 	const presets = {
 		'wheat-field': [
 			{
@@ -3662,6 +3871,88 @@
 					lmax: 0.8,
 					lull_p: 0.0014,
 					lull_mult: 0.42,
+				},
+			},
+		],
+		windmill: [
+			{
+				key: 'still-dusk',
+				label: 'still dusk',
+				config: {
+					intro_turn: 0.08,
+					ending_turn: 0.04,
+					turn_speed: 0.04,
+					blade_len: 12,
+					blade_width: 1.6,
+					tower_height: 19,
+					tower_width: 5.5,
+					horizon: 0.74,
+					glow: 0.22,
+					hue: 26,
+					hue_sp: 14,
+					sat: 0.38,
+					lmin: 0.16,
+					lmax: 0.78,
+				},
+			},
+			{
+				key: 'steady-turning',
+				label: 'steady turning',
+				config: {
+					turn_speed: 0.08,
+					blade_len: 14,
+					blade_width: 1.8,
+					tower_height: 20,
+					tower_width: 6,
+					horizon: 0.72,
+					glow: 0.18,
+					hue: 28,
+					hue_sp: 18,
+					sat: 0.42,
+					lmin: 0.18,
+					lmax: 0.82,
+					gust_p: 0.0006,
+				},
+			},
+			{
+				key: 'windy-hill',
+				label: 'windy hill',
+				config: {
+					turn_speed: 0.12,
+					blade_len: 15,
+					blade_width: 2.1,
+					tower_height: 21,
+					tower_width: 6.5,
+					horizon: 0.7,
+					glow: 0.14,
+					hue: 24,
+					hue_sp: 20,
+					sat: 0.4,
+					lmin: 0.16,
+					lmax: 0.8,
+					gust_p: 0.0014,
+					gust_mult: 2.2,
+					gust_dur: 62,
+				},
+			},
+			{
+				key: 'silhouette-mill',
+				label: 'silhouette mill',
+				config: {
+					turn_speed: 0.06,
+					blade_len: 16,
+					blade_width: 1.5,
+					tower_height: 23,
+					tower_width: 5,
+					horizon: 0.76,
+					glow: 0.1,
+					hue: 222,
+					hue_sp: 12,
+					sat: 0.22,
+					lmin: 0.12,
+					lmax: 0.68,
+					lull_p: 0.0012,
+					lull_mult: 0.38,
 				},
 			},
 		],
@@ -4176,5 +4467,5 @@
 		],
 	};
 
-	global.AmbienceSim = { Rain, Dust, Fireflies, Waterfall, WheatField, Beach, Campfire, Aurora, AutumnLeaves, Snow, Starfield, subscribe, applyDefaults, hslToRGB, effects, presets };
+	global.AmbienceSim = { Rain, Dust, Fireflies, Waterfall, WheatField, Beach, Campfire, Windmill, Aurora, AutumnLeaves, Snow, Starfield, subscribe, applyDefaults, hslToRGB, effects, presets };
 })(window);

--- a/sim/procedural.go
+++ b/sim/procedural.go
@@ -236,6 +236,32 @@ var campfireDefaults = ProceduralConfig{
 	"lull_mult":     0.55,
 }
 
+var windmillDefaults = ProceduralConfig{
+	"intro_dur":     45,
+	"intro_turn":    0.12,
+	"ending_dur":    60,
+	"ending_linger": 20,
+	"ending_turn":   0.05,
+	"turn_speed":    0.08,
+	"blade_len":     14.0,
+	"blade_width":   1.8,
+	"tower_height":  20.0,
+	"tower_width":   6.0,
+	"horizon":       0.72,
+	"glow":          0.18,
+	"hue":           28,
+	"hue_sp":        18,
+	"sat":           0.42,
+	"lmin":          0.18,
+	"lmax":          0.82,
+	"gust_p":        0.0,
+	"lull_p":        0.0,
+	"gust_dur":      50,
+	"gust_mult":     1.90,
+	"lull_dur":      72,
+	"lull_mult":     0.45,
+}
+
 func SnowSchema() EffectSchema {
 	return EffectSchema{
 		Name: "snow",
@@ -630,6 +656,60 @@ func CampfireSchema() EffectSchema {
 	}
 }
 
+func WindmillSchema() EffectSchema {
+	return EffectSchema{
+		Name: "windmill",
+		Knobs: []Knob{
+			{Key: "intro_dur", Label: "intro dur", Slot: SlotSpawn, Group: "introduction", Type: KnobInt, Min: 10, Max: 180, Step: 5, Default: 45, Trigger: "intro",
+				Description: "Ticks spent easing the blades from stillness into a readable turn."},
+			{Key: "intro_turn", Label: "intro turn", Slot: SlotSpawn, Group: "introduction", Type: KnobFloat, Min: 0.02, Max: 0.5, Step: 0.01, Default: 0.12,
+				Description: "Starting fraction of the final rotation speed before the mill settles into motion."},
+			{Key: "ending_dur", Label: "ending dur", Slot: SlotEnd, Group: "ending", Type: KnobInt, Min: 10, Max: 220, Step: 5, Default: 60, Trigger: "ending",
+				Description: "Ticks spent coasting the blades back down toward stillness."},
+			{Key: "ending_linger", Label: "ending linger", Slot: SlotEnd, Group: "ending", Type: KnobInt, Min: 0, Max: 160, Step: 5, Default: 20,
+				Description: "Extra quiet ticks after the blades have mostly stopped."},
+			{Key: "ending_turn", Label: "ending turn", Slot: SlotEnd, Group: "ending", Type: KnobFloat, Min: 0.01, Max: 0.35, Step: 0.01, Default: 0.05,
+				Description: "Residual blade motion near the end of the outro."},
+			{Key: "turn_speed", Label: "turn speed", Slot: SlotLever, Group: "mill", Type: KnobFloat, Min: 0.02, Max: 0.25, Step: 0.01, Default: 0.08,
+				Description: "Base blade rotation speed."},
+			{Key: "blade_len", Label: "blade len", Slot: SlotLever, Group: "mill", Type: KnobFloat, Min: 6, Max: 22, Step: 0.5, Default: 14,
+				Description: "Length of the windmill blades."},
+			{Key: "blade_width", Label: "blade width", Slot: SlotLever, Group: "mill", Type: KnobFloat, Min: 0.5, Max: 4, Step: 0.1, Default: 1.8,
+				Description: "Thickness of each blade arm."},
+			{Key: "tower_height", Label: "tower height", Slot: SlotLever, Group: "mill", Type: KnobFloat, Min: 10, Max: 30, Step: 0.5, Default: 20,
+				Description: "Height of the windmill tower above the hill."},
+			{Key: "tower_width", Label: "tower width", Slot: SlotLever, Group: "mill", Type: KnobFloat, Min: 3, Max: 10, Step: 0.5, Default: 6,
+				Description: "Width of the windmill tower silhouette."},
+			{Key: "horizon", Label: "horizon", Slot: SlotLever, Group: "mill", Type: KnobFloat, Min: 0.56, Max: 0.86, Step: 0.01, Default: 0.72,
+				Description: "Height of the ground line and hill in frame."},
+			{Key: "glow", Label: "glow", Slot: SlotLever, Group: "mill", Type: KnobFloat, Min: 0.02, Max: 0.5, Step: 0.01, Default: 0.18,
+				Description: "Strength of the dusk haze and tiny warm window glow."},
+			{Key: "hue", Label: "hue", Slot: SlotLever, Group: "color", Type: KnobFloat, Min: 10, Max: 240, Step: 1, Default: 28,
+				Description: "Base sky hue spanning cool night blues through warm dusk."},
+			{Key: "hue_sp", Label: "hue spread", Slot: SlotLever, Group: "color", Type: KnobFloat, Min: 0, Max: 28, Step: 1, Default: 18,
+				Description: "Variation between the upper sky and the horizon glow."},
+			{Key: "sat", Label: "saturation", Slot: SlotLever, Group: "color", Type: KnobFloat, Min: 0.05, Max: 0.7, Step: 0.01, Default: 0.42,
+				Description: "Overall sky and glow saturation."},
+			{Key: "lmin", Label: "light min", Slot: SlotLever, Group: "color", Type: KnobFloat, Min: 0.05, Max: 0.5, Step: 0.01, Default: 0.18,
+				Description: "Minimum lightness used for the upper sky and dark ground."},
+			{Key: "lmax", Label: "light max", Slot: SlotLever, Group: "color", Type: KnobFloat, Min: 0.25, Max: 0.95, Step: 0.01, Default: 0.82,
+				Description: "Maximum lightness used for the horizon and glow."},
+			{Key: "gust_p", Label: "gust", Slot: SlotEvent, Type: KnobFloat, Min: 0, Max: 0.02, Step: 0.0005, Default: 0, Trigger: "gust",
+				Description: "Per-tick chance of the blades briefly spinning faster."},
+			{Key: "lull_p", Label: "lull", Slot: SlotEvent, Type: KnobFloat, Min: 0, Max: 0.02, Step: 0.0005, Default: 0, Trigger: "lull",
+				Description: "Per-tick chance of the wind settling into a slower turn."},
+			{Key: "gust_dur", Label: "gust dur", Slot: SlotEventMod, Group: "gust", Type: KnobInt, Min: 10, Max: 220, Step: 5, Default: 50,
+				Description: "Duration of a faster-turning gust."},
+			{Key: "gust_mult", Label: "gust x", Slot: SlotEventMod, Group: "gust", Type: KnobFloat, Min: 1.05, Max: 3, Step: 0.05, Default: 1.9,
+				Description: "Rotation multiplier applied during a gust."},
+			{Key: "lull_dur", Label: "lull dur", Slot: SlotEventMod, Group: "lull", Type: KnobInt, Min: 10, Max: 220, Step: 5, Default: 72,
+				Description: "Duration of the calmer slower-turning window."},
+			{Key: "lull_mult", Label: "lull x", Slot: SlotEventMod, Group: "lull", Type: KnobFloat, Min: 0.1, Max: 1, Step: 0.05, Default: 0.45,
+				Description: "Rotation multiplier applied while lull is active."},
+		},
+	}
+}
+
 func cloneProceduralConfig(src ProceduralConfig) ProceduralConfig {
 	if src == nil {
 		return ProceduralConfig{}
@@ -684,6 +764,8 @@ func proceduralDefaults(kind string) ProceduralConfig {
 		return cloneProceduralConfig(beachDefaults)
 	case "campfire":
 		return cloneProceduralConfig(campfireDefaults)
+	case "windmill":
+		return cloneProceduralConfig(windmillDefaults)
 	default:
 		return ProceduralConfig{}
 	}
@@ -1127,6 +1209,69 @@ func mergeProceduralDefaults(kind string, cfg ProceduralConfig) ProceduralConfig
 		if out["lull_mult"] <= 0 {
 			out["lull_mult"] = campfireDefaults["lull_mult"]
 		}
+	case "windmill":
+		if out["intro_dur"] <= 0 {
+			out["intro_dur"] = windmillDefaults["intro_dur"]
+		}
+		out["intro_turn"] = clamp01(out["intro_turn"])
+		if out["ending_dur"] <= 0 {
+			out["ending_dur"] = windmillDefaults["ending_dur"]
+		}
+		if out["ending_linger"] < 0 {
+			out["ending_linger"] = 0
+		}
+		out["ending_turn"] = clamp01(out["ending_turn"])
+		if out["turn_speed"] <= 0 {
+			out["turn_speed"] = windmillDefaults["turn_speed"]
+		}
+		if out["blade_len"] <= 0 {
+			out["blade_len"] = windmillDefaults["blade_len"]
+		}
+		if out["blade_width"] <= 0 {
+			out["blade_width"] = windmillDefaults["blade_width"]
+		}
+		if out["tower_height"] <= 0 {
+			out["tower_height"] = windmillDefaults["tower_height"]
+		}
+		if out["tower_width"] <= 0 {
+			out["tower_width"] = windmillDefaults["tower_width"]
+		}
+		if out["horizon"] <= 0 {
+			out["horizon"] = windmillDefaults["horizon"]
+		}
+		if out["glow"] <= 0 {
+			out["glow"] = windmillDefaults["glow"]
+		}
+		if out["hue"] == 0 {
+			out["hue"] = windmillDefaults["hue"]
+		}
+		if out["hue_sp"] < 0 {
+			out["hue_sp"] = 0
+		}
+		if out["sat"] <= 0 {
+			out["sat"] = windmillDefaults["sat"]
+		}
+		if out["lmin"] <= 0 {
+			out["lmin"] = windmillDefaults["lmin"]
+		}
+		if out["lmax"] <= 0 {
+			out["lmax"] = windmillDefaults["lmax"]
+		}
+		if out["lmax"] < out["lmin"] {
+			out["lmin"], out["lmax"] = out["lmax"], out["lmin"]
+		}
+		if out["gust_dur"] <= 0 {
+			out["gust_dur"] = windmillDefaults["gust_dur"]
+		}
+		if out["gust_mult"] <= 0 {
+			out["gust_mult"] = windmillDefaults["gust_mult"]
+		}
+		if out["lull_dur"] <= 0 {
+			out["lull_dur"] = windmillDefaults["lull_dur"]
+		}
+		if out["lull_mult"] <= 0 {
+			out["lull_mult"] = windmillDefaults["lull_mult"]
+		}
 	}
 	return out
 }
@@ -1375,6 +1520,22 @@ func (p *Procedural) TriggerEvent(name string) bool {
 			return false
 		}
 		return true
+	case "windmill":
+		switch name {
+		case "gust":
+			p.startWindmillGustLocked("triggered")
+		case "lull":
+			p.startWindmillLullLocked("triggered")
+		case "intro":
+			p.startWindmillIntroLocked()
+			p.appendLog("intro", fmt.Sprintf("started (dur=%d, turn=%.2f)", p.timers["intro"], p.cfg["intro_turn"]))
+		case "ending":
+			p.startWindmillEndingLocked()
+			p.appendLog("ending", fmt.Sprintf("started (fade=%d, linger=%d)", p.intCfg("ending_dur"), p.intCfg("ending_linger")))
+		default:
+			return false
+		}
+		return true
 	default:
 		return false
 	}
@@ -1424,6 +1585,8 @@ func (p *Procedural) Step() {
 		p.stepBeachLocked()
 	case "campfire":
 		p.stepCampfireLocked()
+	case "windmill":
+		p.stepWindmillLocked()
 	}
 }
 
@@ -1884,5 +2047,59 @@ func (p *Procedural) stepCampfireLocked() {
 	}
 	if p.timers["lull"] <= 0 && p.cfg["lull_p"] > 0 && p.rng.Float64() < p.cfg["lull_p"] {
 		p.startCampfireLullLocked("started")
+	}
+}
+
+func (p *Procedural) startWindmillGustLocked(verb string) {
+	p.timers["gust"] = jitterInt(p.rng, p.intCfg("gust_dur"), 0.3)
+	p.values["gust_gain"] = p.cfg["gust_mult"] * (0.75 + p.rng.Float64()*0.45)
+	p.appendLog("gust", fmt.Sprintf("%s (dur=%d, x%.2f)", verb, p.timers["gust"], p.values["gust_gain"]))
+}
+
+func (p *Procedural) startWindmillLullLocked(verb string) {
+	p.timers["lull"] = jitterInt(p.rng, p.intCfg("lull_dur"), 0.3)
+	p.appendLog("lull", fmt.Sprintf("%s (dur=%d, x%.2f)", verb, p.timers["lull"], p.cfg["lull_mult"]))
+}
+
+func (p *Procedural) startWindmillIntroLocked() {
+	p.timers["gust"] = 0
+	p.timers["lull"] = 0
+	p.timers["ending"] = 0
+	p.values["gust_gain"] = 1
+	p.timers["intro"] = p.intCfg("intro_dur")
+	p.values["intro_total"] = float64(p.timers["intro"])
+}
+
+func (p *Procedural) startWindmillEndingLocked() {
+	p.timers["intro"] = 0
+	p.timers["gust"] = 0
+	p.timers["lull"] = 0
+	p.values["gust_gain"] = 1
+	endingTotal := p.intCfg("ending_dur") + max(0, p.intCfg("ending_linger"))
+	if endingTotal < 1 {
+		endingTotal = max(1, p.intCfg("ending_dur"))
+	}
+	p.timers["ending"] = endingTotal
+	p.values["ending_total"] = float64(endingTotal)
+}
+
+func (p *Procedural) stepWindmillLocked() {
+	if p.timers["gust"] <= 0 {
+		p.values["gust_gain"] = 1
+	}
+	if p.timers["intro"] <= 0 {
+		delete(p.values, "intro_total")
+	}
+	if p.timers["ending"] <= 0 {
+		delete(p.values, "ending_total")
+	}
+	if p.timers["intro"] > 0 || p.timers["ending"] > 0 {
+		return
+	}
+	if p.timers["gust"] <= 0 && p.cfg["gust_p"] > 0 && p.rng.Float64() < p.cfg["gust_p"] {
+		p.startWindmillGustLocked("started")
+	}
+	if p.timers["lull"] <= 0 && p.cfg["lull_p"] > 0 && p.rng.Float64() < p.cfg["lull_p"] {
+		p.startWindmillLullLocked("started")
 	}
 }

--- a/sim/procedural_test.go
+++ b/sim/procedural_test.go
@@ -72,6 +72,16 @@ func TestCampfireSchema(t *testing.T) {
 	}
 }
 
+func TestWindmillSchema(t *testing.T) {
+	schema := WindmillSchema()
+	if schema.Name != "windmill" {
+		t.Fatalf("schema name = %q, want windmill", schema.Name)
+	}
+	if len(schema.Knobs) == 0 {
+		t.Fatal("expected windmill schema knobs")
+	}
+}
+
 func TestProceduralSnowSnapshotRestore(t *testing.T) {
 	p := NewProcedural("snow", 160, 80, 42, nil)
 	if !p.TriggerEvent("gust") {
@@ -257,5 +267,40 @@ func TestProceduralCampfireSnapshotRestore(t *testing.T) {
 	}
 	if again.Values["crackle_gain"] != snap.Values["crackle_gain"] {
 		t.Fatalf("restored crackle gain = %f, want %f", again.Values["crackle_gain"], snap.Values["crackle_gain"])
+	}
+}
+
+func TestProceduralWindmillSnapshotRestore(t *testing.T) {
+	p := NewProcedural("windmill", 160, 80, 44, nil)
+	if !p.TriggerEvent("gust") {
+		t.Fatal("expected gust trigger to succeed")
+	}
+	if !p.TriggerEvent("lull") {
+		t.Fatal("expected lull trigger to succeed")
+	}
+	p.Step()
+
+	snap := p.Snapshot()
+	if snap.Timers["gust"] <= 0 {
+		t.Fatal("expected gust timer in snapshot")
+	}
+	if snap.Timers["lull"] <= 0 {
+		t.Fatal("expected lull timer in snapshot")
+	}
+	if snap.Values["gust_gain"] <= 1 {
+		t.Fatal("expected gust gain value in snapshot")
+	}
+
+	restored := NewProcedural("windmill", 160, 80, 7, nil)
+	restored.RestoreSnapshot(snap)
+	again := restored.Snapshot()
+	if again.Timers["gust"] != snap.Timers["gust"] {
+		t.Fatalf("restored gust timer = %d, want %d", again.Timers["gust"], snap.Timers["gust"])
+	}
+	if again.Timers["lull"] != snap.Timers["lull"] {
+		t.Fatalf("restored lull timer = %d, want %d", again.Timers["lull"], snap.Timers["lull"])
+	}
+	if again.Values["gust_gain"] != snap.Values["gust_gain"] {
+		t.Fatalf("restored gust gain = %f, want %f", again.Values["gust_gain"], snap.Values["gust_gain"])
 	}
 }


### PR DESCRIPTION
## Summary
- add the `windmill` procedural dev effect schema, runtime registration, and snapshot coverage on the Go side
- add the browser-side `Windmill` renderer, event handling, and presets to the procedural effect registry
- tune the dev composition so the windmill silhouette stays readable in `/dev/windmill` even with the control panel present

## Validation
- `node --check cmd/ambience/web/sim.js`
- `go test ./...`
- `powershell -ExecutionPolicy Bypass -File scripts/dev-deploy.ps1 -Component all`
- `powershell -ExecutionPolicy Bypass -File scripts/dev-loop.ps1 -Once`
- visual check on `https://ambience.dev.romaine.life/dev/windmill`

Refs #23
