### PR TITLE
Add the rowboat dev effect prototype

### DIFF
--- a/cmd/ambience/dev_random_test.go
+++ b/cmd/ambience/dev_random_test.go
@@ -23,6 +23,7 @@ func TestRandomizedDevConfigStaysWithinSchemaBounds(t *testing.T) {
 		sim.CampfireSchema(),
 		sim.WindmillSchema(),
 		sim.LighthouseSchema(),
+		sim.RowboatSchema(),
 	}
 
 	for i, schema := range schemas {
@@ -66,6 +67,7 @@ func TestRandomizedDevConfigChangesAtLeastOneKnob(t *testing.T) {
 		sim.CampfireSchema(),
 		sim.WindmillSchema(),
 		sim.LighthouseSchema(),
+		sim.RowboatSchema(),
 	}
 
 	for i, schema := range schemas {

--- a/cmd/ambience/dev_sessions_test.go
+++ b/cmd/ambience/dev_sessions_test.go
@@ -20,6 +20,7 @@ func TestDevPageEffectFromPath(t *testing.T) {
 		{path: "/dev/autumn-leaves", want: "autumn-leaves", wantOK: true},
 		{path: "/dev/fireflies", want: "fireflies", wantOK: true},
 		{path: "/dev/lighthouse", want: "lighthouse", wantOK: true},
+		{path: "/dev/rowboat", want: "rowboat", wantOK: true},
 		{path: "/dev/snow", want: "snow", wantOK: true},
 		{path: "/dev/starfield", want: "starfield", wantOK: true},
 		{path: "/dev/waterfall", want: "waterfall", wantOK: true},
@@ -53,6 +54,7 @@ func TestEffectFromSchemaPath(t *testing.T) {
 		{path: "/effects/dust/schema", want: "dust", wantOK: true},
 		{path: "/effects/fireflies/schema", want: "fireflies", wantOK: true},
 		{path: "/effects/lighthouse/schema", want: "lighthouse", wantOK: true},
+		{path: "/effects/rowboat/schema", want: "rowboat", wantOK: true},
 		{path: "/effects/snow/schema", want: "snow", wantOK: true},
 		{path: "/effects/starfield/schema", want: "starfield", wantOK: true},
 		{path: "/effects/waterfall/schema", want: "waterfall", wantOK: true},
@@ -168,6 +170,17 @@ func TestNewDevSessionLighthouseSnapshotType(t *testing.T) {
 	snap := session.snapshot()
 	if snap.Type != "lighthouse" {
 		t.Fatalf("snapshot type = %q, want lighthouse", snap.Type)
+	}
+}
+
+func TestNewDevSessionRowboatSnapshotType(t *testing.T) {
+	session, err := newDevSession("rowboat")
+	if err != nil {
+		t.Fatalf("newDevSession: %v", err)
+	}
+	snap := session.snapshot()
+	if snap.Type != "rowboat" {
+		t.Fatalf("snapshot type = %q, want rowboat", snap.Type)
 	}
 }
 

--- a/cmd/ambience/effects.go
+++ b/cmd/ambience/effects.go
@@ -116,6 +116,11 @@ var effectRegistry = map[string]effectDefinition{
 		Schema:     sim.LighthouseSchema,
 		NewRuntime: newLighthouseRuntime,
 	},
+	"rowboat": {
+		Type:       "rowboat",
+		Schema:     sim.RowboatSchema,
+		NewRuntime: newRowboatRuntime,
+	},
 }
 
 func lookupEffectDefinition(effectType string) (effectDefinition, bool) {
@@ -290,6 +295,10 @@ func newWindmillRuntime(w, h int, seed int64, cfg json.RawMessage) (effectRuntim
 
 func newLighthouseRuntime(w, h int, seed int64, cfg json.RawMessage) (effectRuntime, error) {
 	return newProceduralRuntime("lighthouse", w, h, seed, cfg)
+}
+
+func newRowboatRuntime(w, h int, seed int64, cfg json.RawMessage) (effectRuntime, error) {
+	return newProceduralRuntime("rowboat", w, h, seed, cfg)
 }
 
 func (r *rainRuntime) Type() string { return "rain" }
@@ -718,6 +727,8 @@ func (p *proceduralRuntime) Schema() sim.EffectSchema {
 		return sim.WindmillSchema()
 	case "lighthouse":
 		return sim.LighthouseSchema()
+	case "rowboat":
+		return sim.RowboatSchema()
 	default:
 		return sim.EffectSchema{}
 	}

--- a/cmd/ambience/web/sim.js
+++ b/cmd/ambience/web/sim.js
@@ -1949,6 +1949,36 @@
 			calm_dur: 64,
 			calm_mult: 0.55,
 		},
+		rowboat: {
+			intro_dur: 50,
+			intro_drift: 0.18,
+			ending_dur: 65,
+			ending_linger: 18,
+			ending_ripple: 0.08,
+			waterline: 0.58,
+			drift_speed: 0.08,
+			bob_amp: 1.2,
+			wave_amp: 1.6,
+			wave_freq: 0.16,
+			ripple: 0.24,
+			reflection: 0.22,
+			boat_len: 14,
+			boat_height: 3.5,
+			hue: 206,
+			hue_sp: 16,
+			sat: 0.36,
+			lmin: 0.16,
+			lmax: 0.82,
+			wake_p: 0,
+			drift_p: 0,
+			calm_p: 0,
+			wake_dur: 40,
+			wake_mult: 1.85,
+			drift_dur: 58,
+			drift_push: 1.3,
+			calm_dur: 72,
+			calm_mult: 0.5,
+		},
 		starfield: {
 			intro_dur: 50,
 			intro_density: 0.08,
@@ -2154,6 +2184,34 @@
 				if (c.calm_dur <= 0) c.calm_dur = base.calm_dur;
 				if (c.calm_mult <= 0) c.calm_mult = base.calm_mult;
 				break;
+			case 'rowboat':
+				if (c.intro_dur <= 0) c.intro_dur = base.intro_dur;
+				c.intro_drift = clamp01(c.intro_drift);
+				if (c.ending_dur <= 0) c.ending_dur = base.ending_dur;
+				if (c.ending_linger < 0) c.ending_linger = 0;
+				c.ending_ripple = clamp01(c.ending_ripple);
+				if (c.waterline <= 0) c.waterline = base.waterline;
+				if (c.drift_speed <= 0) c.drift_speed = base.drift_speed;
+				if (c.bob_amp <= 0) c.bob_amp = base.bob_amp;
+				if (c.wave_amp <= 0) c.wave_amp = base.wave_amp;
+				if (c.wave_freq <= 0) c.wave_freq = base.wave_freq;
+				if (c.ripple <= 0) c.ripple = base.ripple;
+				if (c.reflection <= 0) c.reflection = base.reflection;
+				if (c.boat_len <= 0) c.boat_len = base.boat_len;
+				if (c.boat_height <= 0) c.boat_height = base.boat_height;
+				if (c.hue === 0) c.hue = base.hue;
+				if (c.hue_sp < 0) c.hue_sp = 0;
+				if (c.sat <= 0) c.sat = base.sat;
+				if (c.lmin <= 0) c.lmin = base.lmin;
+				if (c.lmax <= 0) c.lmax = base.lmax;
+				if (c.lmax < c.lmin) [c.lmin, c.lmax] = [c.lmax, c.lmin];
+				if (c.wake_dur <= 0) c.wake_dur = base.wake_dur;
+				if (c.wake_mult <= 0) c.wake_mult = base.wake_mult;
+				if (c.drift_dur <= 0) c.drift_dur = base.drift_dur;
+				if (c.drift_push <= 0) c.drift_push = base.drift_push;
+				if (c.calm_dur <= 0) c.calm_dur = base.calm_dur;
+				if (c.calm_mult <= 0) c.calm_mult = base.calm_mult;
+				break;
 			case 'aurora':
 				if (c.intro_dur <= 0) c.intro_dur = base.intro_dur;
 				c.intro_glow = clamp01(c.intro_glow);
@@ -2299,6 +2357,8 @@
 					return this._triggerWindmill(name);
 				case 'lighthouse':
 					return this._triggerLighthouse(name);
+				case 'rowboat':
+					return this._triggerRowboat(name);
 				case 'aurora':
 					return this._triggerAurora(name);
 				case 'starfield':
@@ -2355,6 +2415,14 @@
 					this.values.fog_gain = 1;
 				}
 			}
+			if (this.kind === 'rowboat') {
+				if (!this.timers.wake || this.timers.wake <= 0) {
+					this.values.wake_gain = 1;
+				}
+				if (!this.timers.drift || this.timers.drift <= 0) {
+					this.values.drift_push = 0;
+				}
+			}
 		}
 
 		render(ctx, canvasW, canvasH, opts) {
@@ -2369,6 +2437,8 @@
 					return this._renderWindmill(ctx, canvasW, canvasH, opts);
 				case 'lighthouse':
 					return this._renderLighthouse(ctx, canvasW, canvasH, opts);
+				case 'rowboat':
+					return this._renderRowboat(ctx, canvasW, canvasH, opts);
 				case 'aurora':
 					return this._renderAurora(ctx, canvasW, canvasH, opts);
 				case 'starfield':
@@ -2641,6 +2711,44 @@
 			return false;
 		}
 
+		_triggerRowboat(name) {
+			const rng = this._eventRng(name.length + 83);
+			switch (name) {
+				case 'wake':
+					this.timers.wake = jitterInt(rng, this.cfg.wake_dur, 0.3);
+					this.values.wake_gain = this.cfg.wake_mult * (0.8 + rng() * 0.45);
+					return true;
+				case 'drift':
+					this.timers.drift = jitterInt(rng, this.cfg.drift_dur, 0.3);
+					this.values.drift_push = (rng() < 0.5 ? -1 : 1) * this.cfg.drift_push * (0.65 + rng() * 0.55);
+					return true;
+				case 'calm':
+					this.timers.calm = jitterInt(rng, this.cfg.calm_dur, 0.3);
+					return true;
+				case 'intro':
+					this.timers.wake = 0;
+					this.timers.drift = 0;
+					this.timers.calm = 0;
+					this.timers.ending = 0;
+					this.values.wake_gain = 1;
+					this.values.drift_push = 0;
+					this.timers.intro = Math.max(1, Math.round(this.cfg.intro_dur));
+					this.values.intro_total = this.timers.intro;
+					return true;
+				case 'ending':
+					this.timers.intro = 0;
+					this.timers.wake = 0;
+					this.timers.drift = 0;
+					this.timers.calm = 0;
+					this.values.wake_gain = 1;
+					this.values.drift_push = 0;
+					this.timers.ending = Math.max(1, Math.round(this.cfg.ending_dur + Math.max(0, this.cfg.ending_linger)));
+					this.values.ending_total = this.timers.ending;
+					return true;
+			}
+			return false;
+		}
+
 		_triggerAurora(name) {
 			const rng = this._eventRng(name.length + 53);
 			switch (name) {
@@ -2860,6 +2968,26 @@
 				level *= 1 - (1 - this.cfg.ending_beam) * progress;
 			}
 			return Math.max(0.05, level);
+		}
+
+		_rippleLevelRowboat() {
+			let level = 1;
+			if (this.timers.wake > 0) level *= this.values.wake_gain || this.cfg.wake_mult;
+			if (this.timers.calm > 0) level *= this.cfg.calm_mult;
+			if (this.timers.intro > 0) {
+				const total = this.values.intro_total || this.cfg.intro_dur;
+				const progress = this._phaseProgress(total, this.timers.intro);
+				level *= this.cfg.intro_drift + (1 - this.cfg.intro_drift) * progress;
+			}
+			if (this.timers.ending > 0) {
+				const total = this.values.ending_total || (this.cfg.ending_dur + this.cfg.ending_linger);
+				const progress = this._phaseProgress(total, this.timers.ending);
+				level *= 1 - (1 - this.cfg.ending_ripple) * progress;
+			}
+			if (this.timers.drift > 0) {
+				level *= 1 + Math.abs(this.values.drift_push || this.cfg.drift_push) * 0.22;
+			}
+			return Math.max(0.04, level);
 		}
 
 		_renderSnow(ctx, canvasW, canvasH, opts) {
@@ -3657,6 +3785,177 @@
 			}
 		}
 
+		_renderRowboat(ctx, canvasW, canvasH, opts) {
+			opts = opts || {};
+			if (opts.transparent) {
+				ctx.clearRect(0, 0, canvasW, canvasH);
+			} else {
+				const skyTop = hslToRGB((this.cfg.hue - 12 + 360) % 360, clamp01(this.cfg.sat * 0.45), clamp01(this.cfg.lmin + 0.02));
+				const skyMid = hslToRGB((this.cfg.hue - this.cfg.hue_sp * 0.22 + 360) % 360, clamp01(this.cfg.sat * 0.58), clamp01(this.cfg.lmin + (this.cfg.lmax - this.cfg.lmin) * 0.34));
+				const skyLow = hslToRGB((this.cfg.hue + this.cfg.hue_sp * 0.18) % 360, clamp01(this.cfg.sat * 0.72), clamp01(this.cfg.lmin + (this.cfg.lmax - this.cfg.lmin) * 0.62));
+				const sky = ctx.createLinearGradient(0, 0, 0, canvasH);
+				sky.addColorStop(0, `rgb(${skyTop.r},${skyTop.g},${skyTop.b})`);
+				sky.addColorStop(0.58, `rgb(${skyMid.r},${skyMid.g},${skyMid.b})`);
+				sky.addColorStop(1, `rgb(${skyLow.r},${skyLow.g},${skyLow.b})`);
+				ctx.fillStyle = sky;
+				ctx.fillRect(0, 0, canvasW, canvasH);
+			}
+
+			const sx = canvasW / this.w;
+			const sy = canvasH / this.h;
+			const ceilSx = Math.ceil(sx);
+			const ceilSy = Math.ceil(sy);
+			const waterline = Math.max(12, Math.min(this.h - 10, Math.floor(this.h * this.cfg.waterline)));
+			const motion = this._rippleLevelRowboat();
+			const driftPush = this.values.drift_push || 0;
+			const phase = this.tick * this.cfg.drift_speed * 0.08;
+
+			const glowX = canvasW * 0.74;
+			const glowY = canvasH * 0.24;
+			const glowR = Math.max(20, Math.min(canvasW, canvasH) * 0.09);
+			const glow = ctx.createRadialGradient(glowX, glowY, 0, glowX, glowY, glowR * 2.8);
+			glow.addColorStop(0, 'rgba(255, 223, 174, 0.22)');
+			glow.addColorStop(1, 'rgba(255, 223, 174, 0)');
+			ctx.fillStyle = glow;
+			ctx.fillRect(0, 0, canvasW, canvasH);
+
+			const ridgeBase = waterline - Math.max(5, Math.round(this.h * 0.12));
+			const shorelineY = Math.max(ridgeBase + 2, waterline - Math.max(2, Math.round(this.h * 0.04)));
+			const ridgePoints = [];
+			const ridgeSegments = 7;
+			for (let i = 0; i <= ridgeSegments; i++) {
+				const ridgeWave = Math.sin(i * 0.9 + this._hash(25100 + i) * 2.4) * 2.8;
+				ridgePoints.push(Math.round(ridgeBase - Math.abs(ridgeWave) - this._hash(25200 + i) * 3));
+			}
+			const ridgeColor = hslToRGB((this.cfg.hue + 54) % 360, clamp01(this.cfg.sat * 0.24), clamp01(this.cfg.lmin * 0.7));
+			ctx.fillStyle = `rgb(${ridgeColor.r},${ridgeColor.g},${ridgeColor.b})`;
+			ctx.beginPath();
+			ctx.moveTo(0, Math.floor(shorelineY * sy));
+			for (let x = 0; x < this.w; x++) {
+				const pos = (x / Math.max(1, this.w - 1)) * ridgeSegments;
+				const idx = Math.min(ridgeSegments - 1, Math.floor(pos));
+				const frac = pos - idx;
+				const eased = frac * frac * (3 - 2 * frac);
+				const ridgeY = ridgePoints[idx] + (ridgePoints[idx + 1] - ridgePoints[idx]) * eased;
+				ctx.lineTo(Math.floor(x * sx), Math.floor(ridgeY * sy));
+			}
+			ctx.lineTo(canvasW, Math.floor(shorelineY * sy));
+			ctx.closePath();
+			ctx.fill();
+
+			const treelineColor = hslToRGB((this.cfg.hue + 72) % 360, clamp01(this.cfg.sat * 0.2), clamp01(this.cfg.lmin * 0.52));
+			for (let i = 0; i < 11; i++) {
+				const col = Math.floor((i + 0.4) * this.w / 11 + (this._hash(25300 + i) - 0.5) * 6);
+				const top = Math.round(ridgeBase - 1 - this._hash(25400 + i) * 4);
+				const height = 2 + Math.floor(this._hash(25500 + i) * 3);
+				for (let row = 0; row < height; row++) {
+					this._fillCell(ctx, sx, sy, ceilSx, ceilSy, col, top + row, 1, 1, `rgb(${treelineColor.r},${treelineColor.g},${treelineColor.b})`, 0.92);
+				}
+			}
+
+			for (let y = waterline; y < this.h; y++) {
+				const depth = (y - waterline) / Math.max(1, this.h - waterline);
+				const hue = ((this.cfg.hue + depth * this.cfg.hue_sp * 0.22) % 360 + 360) % 360;
+				const sat = clamp01(this.cfg.sat * (0.8 - depth * 0.22));
+				const light = clamp01(this.cfg.lmin + (this.cfg.lmax - this.cfg.lmin) * (0.36 - depth * 0.18));
+				const color = hslToRGB(hue, sat, light);
+				this._fillCell(ctx, sx, sy, ceilSx, ceilSy, 0, y, this.w, 1, `rgb(${color.r},${color.g},${color.b})`, 1);
+			}
+
+			const mist = ctx.createLinearGradient(0, Math.floor((shorelineY - 3) * sy), 0, Math.floor((waterline + 8) * sy));
+			mist.addColorStop(0, 'rgba(255, 240, 220, 0.14)');
+			mist.addColorStop(1, 'rgba(255, 240, 220, 0)');
+			ctx.fillStyle = mist;
+			ctx.fillRect(0, Math.floor((shorelineY - 3) * sy), canvasW, Math.ceil((waterline - shorelineY + 11) * sy));
+
+			const surfaceColor = hslToRGB((this.cfg.hue - 6 + 360) % 360, clamp01(this.cfg.sat * 0.34), clamp01(this.cfg.lmax * 0.92));
+			for (let x = 0; x < this.w; x++) {
+				const wave = Math.sin(x * this.cfg.wave_freq + phase) * this.cfg.wave_amp;
+				const subWave = Math.sin(x * this.cfg.wave_freq * 0.42 - phase * 1.7) * this.cfg.wave_amp * 0.36;
+				const row = waterline + Math.round((wave + subWave) * motion * 0.22);
+				const twinkle = 0.45 + 0.55 * Math.pow(0.5 + 0.5 * Math.sin(this.tick * 0.03 + x * 0.11), 2);
+				const alpha = clamp01((0.05 + this.cfg.reflection * 0.16) * twinkle);
+				this._fillCell(ctx, sx, sy, ceilSx, ceilSy, x, row, 1, 1, `rgb(${surfaceColor.r},${surfaceColor.g},${surfaceColor.b})`, alpha);
+				if ((x + this.tick) % 6 === 0) {
+					this._fillCell(ctx, sx, sy, ceilSx, ceilSy, x, row + 2, 1, 1, `rgb(${surfaceColor.r},${surfaceColor.g},${surfaceColor.b})`, alpha * 0.45);
+				}
+			}
+
+			const boatLen = Math.max(7, Math.round(this.cfg.boat_len));
+			const boatHeight = Math.max(2, Math.round(this.cfg.boat_height));
+			const boatX = Math.max(Math.floor(boatLen * 0.6), Math.min(this.w - Math.ceil(boatLen * 0.6), Math.round(this.w * 0.34 + Math.sin(phase * 1.6 + 0.8) * (2.4 + motion * 1.6) + driftPush * 1.8)));
+			const bob = Math.sin(phase * 2.4 + 0.6) * this.cfg.bob_amp * motion * 0.52 + Math.sin(phase * 0.95 + 1.3) * 0.35;
+			const hullBaseY = waterline - Math.round(bob * 0.55);
+			const tilt = Math.sin(phase * 1.9 + 0.4) * motion * 0.9 + driftPush * 0.2;
+			const hullColor = hslToRGB(24, 0.34, 0.22);
+			const railColor = hslToRGB(31, 0.26, 0.36);
+			const seatColor = hslToRGB(28, 0.18, 0.16);
+			const hullRows = [];
+
+			for (let row = 0; row < boatHeight; row++) {
+				const t = boatHeight === 1 ? 0.5 : row / (boatHeight - 1);
+				const arch = 1 - Math.abs(t * 2 - 1);
+				const width = Math.max(4, Math.round(boatLen * (0.54 + arch * 0.42)));
+				const y = hullBaseY - (boatHeight - 1 - row);
+				const offset = Math.round((t - 0.5) * tilt * 1.8);
+				const startX = Math.round(boatX - width / 2 + offset);
+				hullRows.push({ startX, width, y });
+				this._fillCell(ctx, sx, sy, ceilSx, ceilSy, startX, y, width, 1, `rgb(${hullColor.r},${hullColor.g},${hullColor.b})`, clamp01(0.78 + t * 0.2));
+			}
+
+			const topHull = hullRows[0];
+			if (topHull && topHull.width > 3) {
+				this._fillCell(ctx, sx, sy, ceilSx, ceilSy, topHull.startX + 1, topHull.y, topHull.width - 2, 1, `rgb(${railColor.r},${railColor.g},${railColor.b})`, 0.72);
+			}
+			const seatWidth = Math.max(2, Math.round(boatLen * 0.22));
+			this._fillCell(ctx, sx, sy, ceilSx, ceilSy, Math.round(boatX - seatWidth / 2), hullBaseY - Math.max(1, Math.floor(boatHeight / 2)), seatWidth, 1, `rgb(${seatColor.r},${seatColor.g},${seatColor.b})`, 0.82);
+			this._fillCell(ctx, sx, sy, ceilSx, ceilSy, Math.round(boatX - boatLen * 0.46), hullBaseY - 1, 1, 1, `rgb(${railColor.r},${railColor.g},${railColor.b})`, 0.82);
+			this._fillCell(ctx, sx, sy, ceilSx, ceilSy, Math.round(boatX + boatLen * 0.44), hullBaseY - 1, 1, 1, `rgb(${railColor.r},${railColor.g},${railColor.b})`, 0.82);
+
+			const shadowColor = hslToRGB((this.cfg.hue + 10) % 360, clamp01(this.cfg.sat * 0.28), clamp01(this.cfg.lmin * 0.9));
+			this._fillCell(ctx, sx, sy, ceilSx, ceilSy, Math.round(boatX - boatLen * 0.5), waterline, boatLen, 1, `rgb(${shadowColor.r},${shadowColor.g},${shadowColor.b})`, 0.26);
+
+			const reflectionColor = hslToRGB((this.cfg.hue + 8) % 360, clamp01(this.cfg.sat * 0.28), clamp01(this.cfg.lmax * 0.58));
+			const reflectionLevel = clamp01(this.cfg.reflection * (0.3 + motion * 0.22));
+			for (let i = 0; i < hullRows.length; i++) {
+				const row = hullRows[i];
+				const distance = hullBaseY - row.y + 1;
+				const wobble = Math.round(Math.sin(this.tick * 0.08 + i * 0.8 + row.startX * 0.03) * (0.5 + motion * 0.45));
+				const reflY = hullBaseY + distance + Math.round(Math.sin(row.startX * this.cfg.wave_freq + phase) * motion * 0.35);
+				const reflWidth = Math.max(2, row.width - 1 - Math.floor(distance / 2));
+				const alpha = clamp01(reflectionLevel * (0.4 - distance * 0.045));
+				this._fillCell(ctx, sx, sy, ceilSx, ceilSy, row.startX + wobble, reflY, reflWidth, 1, `rgb(${reflectionColor.r},${reflectionColor.g},${reflectionColor.b})`, alpha);
+			}
+
+			const rippleColor = hslToRGB((this.cfg.hue - 10 + 360) % 360, clamp01(this.cfg.sat * 0.32), clamp01(this.cfg.lmax * 0.98));
+			const wakeGain = this.timers.wake > 0 ? (this.values.wake_gain || this.cfg.wake_mult) : 1;
+			const rippleBands = 4 + Math.round(this.cfg.ripple * 7);
+			for (let band = 0; band < rippleBands; band++) {
+				const centerX = Math.round(boatX + boatLen * 0.18 + band * (1.2 + wakeGain * 0.28));
+				const half = Math.max(3, Math.round(boatLen * (0.24 + band * 0.14 + wakeGain * 0.03)));
+				const centerY = waterline + Math.round(0.8 + band * 0.75 + Math.abs(Math.sin(phase * 4.2 + band * 0.9)) * 1.1);
+				for (let dx = -half; dx <= half; dx++) {
+					if ((dx + band + this.tick) % 2 !== 0) continue;
+					const edge = 1 - Math.abs(dx) / Math.max(1, half);
+					const waveY = centerY + Math.round(Math.sin(dx * 0.22 + this.tick * 0.08 + band * 0.7) * 0.7);
+					const alpha = clamp01((0.08 + this.cfg.ripple * 0.24 * motion) * Math.pow(edge, 0.45));
+					this._fillCell(ctx, sx, sy, ceilSx, ceilSy, centerX + dx, waveY, 1, 1, `rgb(${rippleColor.r},${rippleColor.g},${rippleColor.b})`, alpha);
+				}
+			}
+
+			for (let band = 0; band < 3; band++) {
+				const half = Math.max(2, Math.round(boatLen * (0.16 + band * 0.08)));
+				const centerX = Math.round(boatX - boatLen * 0.2 - band * 1.2);
+				const centerY = waterline + Math.round(band * 0.85 + Math.abs(Math.sin(phase * 3.6 + band)) * 0.9);
+				for (let dx = -half; dx <= half; dx++) {
+					if ((dx + band) % 2 !== 0) continue;
+					const edge = 1 - Math.abs(dx) / Math.max(1, half);
+					const alpha = clamp01((0.03 + this.cfg.ripple * 0.12 * motion) * Math.pow(edge, 0.65));
+					this._fillCell(ctx, sx, sy, ceilSx, ceilSy, centerX + dx, centerY + Math.round(Math.sin(dx * 0.3 + this.tick * 0.06) * 0.5), 1, 1, `rgb(${rippleColor.r},${rippleColor.g},${rippleColor.b})`, alpha);
+				}
+			}
+		}
+
 		_renderAurora(ctx, canvasW, canvasH, opts) {
 			opts = opts || {};
 			if (opts.transparent) {
@@ -3815,6 +4114,12 @@
 		}
 	}
 
+	class Rowboat extends ProceduralScene {
+		constructor(w, h, cfg, seed) {
+			super('rowboat', w, h, cfg, seed);
+		}
+	}
+
 	class Aurora extends ProceduralScene {
 		constructor(w, h, cfg, seed) {
 			super('aurora', w, h, cfg, seed);
@@ -3873,7 +4178,7 @@
 	// server's snapshot payload — the client looks up the constructor here
 	// by name so new effects just register themselves and work without
 	// client-side changes.
-	const effects = { rain: Rain, dust: Dust, fireflies: Fireflies, waterfall: Waterfall, 'wheat-field': WheatField, beach: Beach, campfire: Campfire, windmill: Windmill, lighthouse: Lighthouse, aurora: Aurora, snow: Snow, 'autumn-leaves': AutumnLeaves, starfield: Starfield };
+	const effects = { rain: Rain, dust: Dust, fireflies: Fireflies, waterfall: Waterfall, 'wheat-field': WheatField, beach: Beach, campfire: Campfire, windmill: Windmill, lighthouse: Lighthouse, rowboat: Rowboat, aurora: Aurora, snow: Snow, 'autumn-leaves': AutumnLeaves, starfield: Starfield };
 	const presets = {
 		'wheat-field': [
 			{
@@ -4289,6 +4594,97 @@
 					bright_pass_p: 0.0014,
 					bright_pass_mult: 2.1,
 					calm_p: 0.0009,
+				},
+			},
+		],
+		rowboat: [
+			{
+				key: 'still-lake',
+				label: 'still lake',
+				config: {
+					intro_drift: 0.12,
+					ending_ripple: 0.12,
+					waterline: 0.57,
+					drift_speed: 0.05,
+					bob_amp: 0.7,
+					wave_amp: 0.9,
+					wave_freq: 0.12,
+					ripple: 0.12,
+					reflection: 0.28,
+					boat_len: 13,
+					boat_height: 3.5,
+					hue: 202,
+					hue_sp: 10,
+					sat: 0.26,
+					lmin: 0.16,
+					lmax: 0.74,
+					calm_p: 0.0011,
+				},
+			},
+			{
+				key: 'gentle-drift',
+				label: 'gentle drift',
+				config: {
+					waterline: 0.58,
+					drift_speed: 0.08,
+					bob_amp: 1.2,
+					wave_amp: 1.6,
+					wave_freq: 0.16,
+					ripple: 0.24,
+					reflection: 0.22,
+					boat_len: 14,
+					boat_height: 3.5,
+					hue: 206,
+					hue_sp: 16,
+					sat: 0.36,
+					lmin: 0.16,
+					lmax: 0.82,
+					drift_p: 0.0009,
+				},
+			},
+			{
+				key: 'evening-ripples',
+				label: 'evening ripples',
+				config: {
+					waterline: 0.6,
+					drift_speed: 0.1,
+					bob_amp: 1.4,
+					wave_amp: 1.9,
+					wave_freq: 0.18,
+					ripple: 0.34,
+					reflection: 0.24,
+					boat_len: 14.5,
+					boat_height: 4,
+					hue: 212,
+					hue_sp: 18,
+					sat: 0.4,
+					lmin: 0.18,
+					lmax: 0.86,
+					wake_p: 0.001,
+				},
+			},
+			{
+				key: 'wind-touched-water',
+				label: 'wind-touched water',
+				config: {
+					waterline: 0.56,
+					drift_speed: 0.12,
+					bob_amp: 1.8,
+					wave_amp: 2.5,
+					wave_freq: 0.2,
+					ripple: 0.42,
+					reflection: 0.18,
+					boat_len: 15,
+					boat_height: 4,
+					hue: 198,
+					hue_sp: 20,
+					sat: 0.46,
+					lmin: 0.18,
+					lmax: 0.8,
+					wake_p: 0.0012,
+					wake_mult: 2.1,
+					drift_p: 0.0014,
+					drift_push: 1.55,
 				},
 			},
 		],
@@ -4803,5 +5199,5 @@
 		],
 	};
 
-	global.AmbienceSim = { Rain, Dust, Fireflies, Waterfall, WheatField, Beach, Campfire, Windmill, Lighthouse, Aurora, AutumnLeaves, Snow, Starfield, subscribe, applyDefaults, hslToRGB, effects, presets };
+	global.AmbienceSim = { Rain, Dust, Fireflies, Waterfall, WheatField, Beach, Campfire, Windmill, Lighthouse, Rowboat, Aurora, AutumnLeaves, Snow, Starfield, subscribe, applyDefaults, hslToRGB, effects, presets };
 })(window);

--- a/sim/procedural.go
+++ b/sim/procedural.go
@@ -292,6 +292,37 @@ var lighthouseDefaults = ProceduralConfig{
 	"calm_mult":        0.55,
 }
 
+var rowboatDefaults = ProceduralConfig{
+	"intro_dur":     50,
+	"intro_drift":   0.18,
+	"ending_dur":    65,
+	"ending_linger": 18,
+	"ending_ripple": 0.08,
+	"waterline":     0.58,
+	"drift_speed":   0.08,
+	"bob_amp":       1.20,
+	"wave_amp":      1.60,
+	"wave_freq":     0.16,
+	"ripple":        0.24,
+	"reflection":    0.22,
+	"boat_len":      14.0,
+	"boat_height":   3.5,
+	"hue":           206,
+	"hue_sp":        16,
+	"sat":           0.36,
+	"lmin":          0.16,
+	"lmax":          0.82,
+	"wake_p":        0.0,
+	"drift_p":       0.0,
+	"calm_p":        0.0,
+	"wake_dur":      40,
+	"wake_mult":     1.85,
+	"drift_dur":     58,
+	"drift_push":    1.30,
+	"calm_dur":      72,
+	"calm_mult":     0.50,
+}
+
 func SnowSchema() EffectSchema {
 	return EffectSchema{
 		Name: "snow",
@@ -802,6 +833,70 @@ func LighthouseSchema() EffectSchema {
 	}
 }
 
+func RowboatSchema() EffectSchema {
+	return EffectSchema{
+		Name: "rowboat",
+		Knobs: []Knob{
+			{Key: "intro_dur", Label: "intro dur", Slot: SlotSpawn, Group: "introduction", Type: KnobInt, Min: 10, Max: 180, Step: 5, Default: 50, Trigger: "intro",
+				Description: "Ticks spent easing the boat and its first ripples into view."},
+			{Key: "intro_drift", Label: "intro drift", Slot: SlotSpawn, Group: "introduction", Type: KnobFloat, Min: 0.05, Max: 0.5, Step: 0.01, Default: 0.18,
+				Description: "Starting fraction of the final drift and bob motion before the scene settles."},
+			{Key: "ending_dur", Label: "ending dur", Slot: SlotEnd, Group: "ending", Type: KnobInt, Min: 10, Max: 220, Step: 5, Default: 65, Trigger: "ending",
+				Description: "Ticks spent flattening the ripples and easing the boat toward stillness."},
+			{Key: "ending_linger", Label: "ending linger", Slot: SlotEnd, Group: "ending", Type: KnobInt, Min: 0, Max: 160, Step: 5, Default: 18,
+				Description: "Extra quiet ticks after the visible motion has mostly faded."},
+			{Key: "ending_ripple", Label: "ending ripple", Slot: SlotEnd, Group: "ending", Type: KnobFloat, Min: 0.02, Max: 0.35, Step: 0.01, Default: 0.08,
+				Description: "Residual motion and ripple presence near the end of the outro."},
+			{Key: "waterline", Label: "waterline", Slot: SlotLever, Group: "lake", Type: KnobFloat, Min: 0.42, Max: 0.76, Step: 0.01, Default: 0.58,
+				Description: "Height of the lake surface in the frame."},
+			{Key: "drift_speed", Label: "drift speed", Slot: SlotLever, Group: "lake", Type: KnobFloat, Min: 0.02, Max: 0.2, Step: 0.01, Default: 0.08,
+				Description: "How quickly the boat drifts and the wave phase rolls underneath it."},
+			{Key: "bob_amp", Label: "bob amp", Slot: SlotLever, Group: "lake", Type: KnobFloat, Min: 0.2, Max: 3, Step: 0.1, Default: 1.2,
+				Description: "Vertical bobbing amplitude of the hull."},
+			{Key: "wave_amp", Label: "wave amp", Slot: SlotLever, Group: "lake", Type: KnobFloat, Min: 0.2, Max: 4, Step: 0.1, Default: 1.6,
+				Description: "Amplitude of the wider surface undulation behind the boat."},
+			{Key: "wave_freq", Label: "wave freq", Slot: SlotLever, Group: "lake", Type: KnobFloat, Min: 0.05, Max: 0.35, Step: 0.01, Default: 0.16,
+				Description: "Horizontal frequency of the lake surface wiggle."},
+			{Key: "ripple", Label: "ripple", Slot: SlotLever, Group: "lake", Type: KnobFloat, Min: 0.05, Max: 0.8, Step: 0.01, Default: 0.24,
+				Description: "Strength and number of the local ripples around the boat."},
+			{Key: "reflection", Label: "reflection", Slot: SlotLever, Group: "lake", Type: KnobFloat, Min: 0.05, Max: 0.6, Step: 0.01, Default: 0.22,
+				Description: "Visibility of the boat and ripple reflection in the water."},
+			{Key: "boat_len", Label: "boat len", Slot: SlotLever, Group: "boat", Type: KnobFloat, Min: 6, Max: 24, Step: 0.5, Default: 14,
+				Description: "Length of the rowboat hull."},
+			{Key: "boat_height", Label: "boat height", Slot: SlotLever, Group: "boat", Type: KnobFloat, Min: 1, Max: 8, Step: 0.5, Default: 3.5,
+				Description: "Height of the rowboat silhouette above the waterline."},
+			{Key: "hue", Label: "hue", Slot: SlotLever, Group: "color", Type: KnobFloat, Min: 180, Max: 230, Step: 1, Default: 206,
+				Description: "Base water and sky hue. Lower values lean teal; higher values lean deeper blue."},
+			{Key: "hue_sp", Label: "hue spread", Slot: SlotLever, Group: "color", Type: KnobFloat, Min: 0, Max: 24, Step: 1, Default: 16,
+				Description: "Variation between the upper sky, water, and reflected highlights."},
+			{Key: "sat", Label: "saturation", Slot: SlotLever, Group: "color", Type: KnobFloat, Min: 0.05, Max: 0.7, Step: 0.01, Default: 0.36,
+				Description: "Overall scene saturation."},
+			{Key: "lmin", Label: "light min", Slot: SlotLever, Group: "color", Type: KnobFloat, Min: 0.08, Max: 0.5, Step: 0.01, Default: 0.16,
+				Description: "Minimum lightness used for darker water and hull shadow."},
+			{Key: "lmax", Label: "light max", Slot: SlotLever, Group: "color", Type: KnobFloat, Min: 0.35, Max: 0.95, Step: 0.01, Default: 0.82,
+				Description: "Maximum lightness used for sky glow and water highlights."},
+			{Key: "wake_p", Label: "wake", Slot: SlotEvent, Type: KnobFloat, Min: 0, Max: 0.02, Step: 0.0005, Default: 0, Trigger: "wake",
+				Description: "Per-tick chance of a more pronounced wake rippling out behind the boat."},
+			{Key: "drift_p", Label: "drift", Slot: SlotEvent, Type: KnobFloat, Min: 0, Max: 0.02, Step: 0.0005, Default: 0, Trigger: "drift",
+				Description: "Per-tick chance of the boat being pushed gently farther to one side."},
+			{Key: "calm_p", Label: "calm", Slot: SlotEvent, Type: KnobFloat, Min: 0, Max: 0.02, Step: 0.0005, Default: 0, Trigger: "calm",
+				Description: "Per-tick chance of the lake briefly flattening into calmer motion."},
+			{Key: "wake_dur", Label: "wake dur", Slot: SlotEventMod, Group: "wake", Type: KnobInt, Min: 10, Max: 180, Step: 5, Default: 40,
+				Description: "Duration of the more pronounced wake window."},
+			{Key: "wake_mult", Label: "wake x", Slot: SlotEventMod, Group: "wake", Type: KnobFloat, Min: 1.05, Max: 3, Step: 0.05, Default: 1.85,
+				Description: "Ripple multiplier applied while wake is active."},
+			{Key: "drift_dur", Label: "drift dur", Slot: SlotEventMod, Group: "drift", Type: KnobInt, Min: 10, Max: 220, Step: 5, Default: 58,
+				Description: "Duration of the stronger side drift window."},
+			{Key: "drift_push", Label: "drift push", Slot: SlotEventMod, Group: "drift", Type: KnobFloat, Min: 0.2, Max: 3, Step: 0.05, Default: 1.3,
+				Description: "Additional sideways push applied during a drift event."},
+			{Key: "calm_dur", Label: "calm dur", Slot: SlotEventMod, Group: "calm", Type: KnobInt, Min: 10, Max: 220, Step: 5, Default: 72,
+				Description: "Duration of the calmer low-motion interval."},
+			{Key: "calm_mult", Label: "calm x", Slot: SlotEventMod, Group: "calm", Type: KnobFloat, Min: 0.1, Max: 1, Step: 0.05, Default: 0.5,
+				Description: "Motion and ripple multiplier applied while calm is active."},
+		},
+	}
+}
+
 func cloneProceduralConfig(src ProceduralConfig) ProceduralConfig {
 	if src == nil {
 		return ProceduralConfig{}
@@ -860,6 +955,8 @@ func proceduralDefaults(kind string) ProceduralConfig {
 		return cloneProceduralConfig(windmillDefaults)
 	case "lighthouse":
 		return cloneProceduralConfig(lighthouseDefaults)
+	case "rowboat":
+		return cloneProceduralConfig(rowboatDefaults)
 	default:
 		return ProceduralConfig{}
 	}
@@ -1438,6 +1535,81 @@ func mergeProceduralDefaults(kind string, cfg ProceduralConfig) ProceduralConfig
 		if out["calm_mult"] <= 0 {
 			out["calm_mult"] = lighthouseDefaults["calm_mult"]
 		}
+	case "rowboat":
+		if out["intro_dur"] <= 0 {
+			out["intro_dur"] = rowboatDefaults["intro_dur"]
+		}
+		out["intro_drift"] = clamp01(out["intro_drift"])
+		if out["ending_dur"] <= 0 {
+			out["ending_dur"] = rowboatDefaults["ending_dur"]
+		}
+		if out["ending_linger"] < 0 {
+			out["ending_linger"] = 0
+		}
+		out["ending_ripple"] = clamp01(out["ending_ripple"])
+		if out["waterline"] <= 0 {
+			out["waterline"] = rowboatDefaults["waterline"]
+		}
+		if out["drift_speed"] <= 0 {
+			out["drift_speed"] = rowboatDefaults["drift_speed"]
+		}
+		if out["bob_amp"] <= 0 {
+			out["bob_amp"] = rowboatDefaults["bob_amp"]
+		}
+		if out["wave_amp"] <= 0 {
+			out["wave_amp"] = rowboatDefaults["wave_amp"]
+		}
+		if out["wave_freq"] <= 0 {
+			out["wave_freq"] = rowboatDefaults["wave_freq"]
+		}
+		if out["ripple"] <= 0 {
+			out["ripple"] = rowboatDefaults["ripple"]
+		}
+		if out["reflection"] <= 0 {
+			out["reflection"] = rowboatDefaults["reflection"]
+		}
+		if out["boat_len"] <= 0 {
+			out["boat_len"] = rowboatDefaults["boat_len"]
+		}
+		if out["boat_height"] <= 0 {
+			out["boat_height"] = rowboatDefaults["boat_height"]
+		}
+		if out["hue"] == 0 {
+			out["hue"] = rowboatDefaults["hue"]
+		}
+		if out["hue_sp"] < 0 {
+			out["hue_sp"] = 0
+		}
+		if out["sat"] <= 0 {
+			out["sat"] = rowboatDefaults["sat"]
+		}
+		if out["lmin"] <= 0 {
+			out["lmin"] = rowboatDefaults["lmin"]
+		}
+		if out["lmax"] <= 0 {
+			out["lmax"] = rowboatDefaults["lmax"]
+		}
+		if out["lmax"] < out["lmin"] {
+			out["lmin"], out["lmax"] = out["lmax"], out["lmin"]
+		}
+		if out["wake_dur"] <= 0 {
+			out["wake_dur"] = rowboatDefaults["wake_dur"]
+		}
+		if out["wake_mult"] <= 0 {
+			out["wake_mult"] = rowboatDefaults["wake_mult"]
+		}
+		if out["drift_dur"] <= 0 {
+			out["drift_dur"] = rowboatDefaults["drift_dur"]
+		}
+		if out["drift_push"] <= 0 {
+			out["drift_push"] = rowboatDefaults["drift_push"]
+		}
+		if out["calm_dur"] <= 0 {
+			out["calm_dur"] = rowboatDefaults["calm_dur"]
+		}
+		if out["calm_mult"] <= 0 {
+			out["calm_mult"] = rowboatDefaults["calm_mult"]
+		}
 	}
 	return out
 }
@@ -1720,6 +1892,24 @@ func (p *Procedural) TriggerEvent(name string) bool {
 			return false
 		}
 		return true
+	case "rowboat":
+		switch name {
+		case "wake":
+			p.startRowboatWakeLocked("triggered")
+		case "drift":
+			p.startRowboatDriftLocked("triggered")
+		case "calm":
+			p.startRowboatCalmLocked("triggered")
+		case "intro":
+			p.startRowboatIntroLocked()
+			p.appendLog("intro", fmt.Sprintf("started (dur=%d, drift=%.2f)", p.timers["intro"], p.cfg["intro_drift"]))
+		case "ending":
+			p.startRowboatEndingLocked()
+			p.appendLog("ending", fmt.Sprintf("started (fade=%d, linger=%d)", p.intCfg("ending_dur"), p.intCfg("ending_linger")))
+		default:
+			return false
+		}
+		return true
 	default:
 		return false
 	}
@@ -1773,6 +1963,8 @@ func (p *Procedural) Step() {
 		p.stepWindmillLocked()
 	case "lighthouse":
 		p.stepLighthouseLocked()
+	case "rowboat":
+		p.stepRowboatLocked()
 	}
 }
 
@@ -2360,5 +2552,79 @@ func (p *Procedural) stepLighthouseLocked() {
 	}
 	if p.timers["calm"] <= 0 && p.timers["fog-thicken"] <= 0 && p.cfg["calm_p"] > 0 && p.rng.Float64() < p.cfg["calm_p"] {
 		p.startLighthouseCalmLocked("started")
+	}
+}
+
+func (p *Procedural) startRowboatWakeLocked(verb string) {
+	p.timers["wake"] = jitterInt(p.rng, p.intCfg("wake_dur"), 0.3)
+	p.values["wake_gain"] = p.cfg["wake_mult"] * (0.8 + p.rng.Float64()*0.45)
+	p.appendLog("wake", fmt.Sprintf("%s (dur=%d, x%.2f)", verb, p.timers["wake"], p.values["wake_gain"]))
+}
+
+func (p *Procedural) startRowboatDriftLocked(verb string) {
+	p.timers["drift"] = jitterInt(p.rng, p.intCfg("drift_dur"), 0.3)
+	sign := 1.0
+	if p.rng.Float64() < 0.5 {
+		sign = -1
+	}
+	p.values["drift_push"] = sign * p.cfg["drift_push"] * (0.65 + p.rng.Float64()*0.55)
+	p.appendLog("drift", fmt.Sprintf("%s (dur=%d, push=%+.2f)", verb, p.timers["drift"], p.values["drift_push"]))
+}
+
+func (p *Procedural) startRowboatCalmLocked(verb string) {
+	p.timers["calm"] = jitterInt(p.rng, p.intCfg("calm_dur"), 0.3)
+	p.appendLog("calm", fmt.Sprintf("%s (dur=%d, x%.2f)", verb, p.timers["calm"], p.cfg["calm_mult"]))
+}
+
+func (p *Procedural) startRowboatIntroLocked() {
+	p.timers["wake"] = 0
+	p.timers["drift"] = 0
+	p.timers["calm"] = 0
+	p.timers["ending"] = 0
+	p.values["wake_gain"] = 1
+	p.values["drift_push"] = 0
+	p.timers["intro"] = p.intCfg("intro_dur")
+	p.values["intro_total"] = float64(p.timers["intro"])
+}
+
+func (p *Procedural) startRowboatEndingLocked() {
+	p.timers["intro"] = 0
+	p.timers["wake"] = 0
+	p.timers["drift"] = 0
+	p.timers["calm"] = 0
+	p.values["wake_gain"] = 1
+	p.values["drift_push"] = 0
+	endingTotal := p.intCfg("ending_dur") + max(0, p.intCfg("ending_linger"))
+	if endingTotal < 1 {
+		endingTotal = max(1, p.intCfg("ending_dur"))
+	}
+	p.timers["ending"] = endingTotal
+	p.values["ending_total"] = float64(endingTotal)
+}
+
+func (p *Procedural) stepRowboatLocked() {
+	if p.timers["wake"] <= 0 {
+		p.values["wake_gain"] = 1
+	}
+	if p.timers["drift"] <= 0 {
+		p.values["drift_push"] = 0
+	}
+	if p.timers["intro"] <= 0 {
+		delete(p.values, "intro_total")
+	}
+	if p.timers["ending"] <= 0 {
+		delete(p.values, "ending_total")
+	}
+	if p.timers["intro"] > 0 || p.timers["ending"] > 0 {
+		return
+	}
+	if p.timers["wake"] <= 0 && p.cfg["wake_p"] > 0 && p.rng.Float64() < p.cfg["wake_p"] {
+		p.startRowboatWakeLocked("started")
+	}
+	if p.timers["drift"] <= 0 && p.cfg["drift_p"] > 0 && p.rng.Float64() < p.cfg["drift_p"] {
+		p.startRowboatDriftLocked("started")
+	}
+	if p.timers["calm"] <= 0 && p.cfg["calm_p"] > 0 && p.rng.Float64() < p.cfg["calm_p"] {
+		p.startRowboatCalmLocked("started")
 	}
 }

--- a/sim/procedural_test.go
+++ b/sim/procedural_test.go
@@ -92,6 +92,16 @@ func TestLighthouseSchema(t *testing.T) {
 	}
 }
 
+func TestRowboatSchema(t *testing.T) {
+	schema := RowboatSchema()
+	if schema.Name != "rowboat" {
+		t.Fatalf("schema name = %q, want rowboat", schema.Name)
+	}
+	if len(schema.Knobs) == 0 {
+		t.Fatal("expected rowboat schema knobs")
+	}
+}
+
 func TestProceduralSnowSnapshotRestore(t *testing.T) {
 	p := NewProcedural("snow", 160, 80, 42, nil)
 	if !p.TriggerEvent("gust") {
@@ -353,5 +363,46 @@ func TestProceduralLighthouseSnapshotRestore(t *testing.T) {
 	}
 	if again.Values["fog_gain"] != snap.Values["fog_gain"] {
 		t.Fatalf("restored fog gain = %f, want %f", again.Values["fog_gain"], snap.Values["fog_gain"])
+	}
+}
+
+func TestProceduralRowboatSnapshotRestore(t *testing.T) {
+	p := NewProcedural("rowboat", 160, 80, 66, nil)
+	if !p.TriggerEvent("wake") {
+		t.Fatal("expected wake trigger to succeed")
+	}
+	if !p.TriggerEvent("drift") {
+		t.Fatal("expected drift trigger to succeed")
+	}
+	p.Step()
+
+	snap := p.Snapshot()
+	if snap.Timers["wake"] <= 0 {
+		t.Fatal("expected wake timer in snapshot")
+	}
+	if snap.Timers["drift"] <= 0 {
+		t.Fatal("expected drift timer in snapshot")
+	}
+	if snap.Values["wake_gain"] <= 1 {
+		t.Fatal("expected wake gain value in snapshot")
+	}
+	if snap.Values["drift_push"] == 0 {
+		t.Fatal("expected drift push value in snapshot")
+	}
+
+	restored := NewProcedural("rowboat", 160, 80, 7, nil)
+	restored.RestoreSnapshot(snap)
+	again := restored.Snapshot()
+	if again.Timers["wake"] != snap.Timers["wake"] {
+		t.Fatalf("restored wake timer = %d, want %d", again.Timers["wake"], snap.Timers["wake"])
+	}
+	if again.Timers["drift"] != snap.Timers["drift"] {
+		t.Fatalf("restored drift timer = %d, want %d", again.Timers["drift"], snap.Timers["drift"])
+	}
+	if again.Values["wake_gain"] != snap.Values["wake_gain"] {
+		t.Fatalf("restored wake gain = %f, want %f", again.Values["wake_gain"], snap.Values["wake_gain"])
+	}
+	if again.Values["drift_push"] != snap.Values["drift_push"] {
+		t.Fatalf("restored drift push = %f, want %f", again.Values["drift_push"], snap.Values["drift_push"])
 	}
 }


### PR DESCRIPTION
## Summary
- add the `rowboat` procedural effect to the Go registry, schema surface, dev-session routing, and snapshot/restore coverage
- implement the browser-side rowboat renderer with wake, drift, calm, intro, and ending handling plus scenic presets for lake moods
- tune the live dev composition so the boat sits left of the control panel, reads as floating, and leaves a visible reflection/wake on the water

## Validation
- `node --check cmd/ambience/web/sim.js`
- `go test ./...`
- `powershell -ExecutionPolicy Bypass -File scripts/dev-deploy.ps1 -Component all`
- `powershell -ExecutionPolicy Bypass -File scripts/dev-loop.ps1 -Once`
- visual check on `https://ambience.dev.romaine.life/dev/rowboat`

Refs #22