### PR TITLE
Add the underwater dev effect prototype

### DIFF
--- a/cmd/ambience/dev_random_test.go
+++ b/cmd/ambience/dev_random_test.go
@@ -24,6 +24,7 @@ func TestRandomizedDevConfigStaysWithinSchemaBounds(t *testing.T) {
 		sim.WindmillSchema(),
 		sim.LighthouseSchema(),
 		sim.RowboatSchema(),
+		sim.UnderwaterSchema(),
 	}
 
 	for i, schema := range schemas {
@@ -68,6 +69,7 @@ func TestRandomizedDevConfigChangesAtLeastOneKnob(t *testing.T) {
 		sim.WindmillSchema(),
 		sim.LighthouseSchema(),
 		sim.RowboatSchema(),
+		sim.UnderwaterSchema(),
 	}
 
 	for i, schema := range schemas {

--- a/cmd/ambience/dev_sessions_test.go
+++ b/cmd/ambience/dev_sessions_test.go
@@ -23,6 +23,7 @@ func TestDevPageEffectFromPath(t *testing.T) {
 		{path: "/dev/rowboat", want: "rowboat", wantOK: true},
 		{path: "/dev/snow", want: "snow", wantOK: true},
 		{path: "/dev/starfield", want: "starfield", wantOK: true},
+		{path: "/dev/underwater", want: "underwater", wantOK: true},
 		{path: "/dev/waterfall", want: "waterfall", wantOK: true},
 		{path: "/dev/windmill", want: "windmill", wantOK: true},
 		{path: "/dev/wheat-field", want: "wheat-field", wantOK: true},
@@ -57,6 +58,7 @@ func TestEffectFromSchemaPath(t *testing.T) {
 		{path: "/effects/rowboat/schema", want: "rowboat", wantOK: true},
 		{path: "/effects/snow/schema", want: "snow", wantOK: true},
 		{path: "/effects/starfield/schema", want: "starfield", wantOK: true},
+		{path: "/effects/underwater/schema", want: "underwater", wantOK: true},
 		{path: "/effects/waterfall/schema", want: "waterfall", wantOK: true},
 		{path: "/effects/windmill/schema", want: "windmill", wantOK: true},
 		{path: "/effects/wheat-field/schema", want: "wheat-field", wantOK: true},
@@ -181,6 +183,17 @@ func TestNewDevSessionRowboatSnapshotType(t *testing.T) {
 	snap := session.snapshot()
 	if snap.Type != "rowboat" {
 		t.Fatalf("snapshot type = %q, want rowboat", snap.Type)
+	}
+}
+
+func TestNewDevSessionUnderwaterSnapshotType(t *testing.T) {
+	session, err := newDevSession("underwater")
+	if err != nil {
+		t.Fatalf("newDevSession: %v", err)
+	}
+	snap := session.snapshot()
+	if snap.Type != "underwater" {
+		t.Fatalf("snapshot type = %q, want underwater", snap.Type)
 	}
 }
 

--- a/cmd/ambience/effects.go
+++ b/cmd/ambience/effects.go
@@ -121,6 +121,11 @@ var effectRegistry = map[string]effectDefinition{
 		Schema:     sim.RowboatSchema,
 		NewRuntime: newRowboatRuntime,
 	},
+	"underwater": {
+		Type:       "underwater",
+		Schema:     sim.UnderwaterSchema,
+		NewRuntime: newUnderwaterRuntime,
+	},
 }
 
 func lookupEffectDefinition(effectType string) (effectDefinition, bool) {
@@ -299,6 +304,10 @@ func newLighthouseRuntime(w, h int, seed int64, cfg json.RawMessage) (effectRunt
 
 func newRowboatRuntime(w, h int, seed int64, cfg json.RawMessage) (effectRuntime, error) {
 	return newProceduralRuntime("rowboat", w, h, seed, cfg)
+}
+
+func newUnderwaterRuntime(w, h int, seed int64, cfg json.RawMessage) (effectRuntime, error) {
+	return newProceduralRuntime("underwater", w, h, seed, cfg)
 }
 
 func (r *rainRuntime) Type() string { return "rain" }
@@ -729,6 +738,8 @@ func (p *proceduralRuntime) Schema() sim.EffectSchema {
 		return sim.LighthouseSchema()
 	case "rowboat":
 		return sim.RowboatSchema()
+	case "underwater":
+		return sim.UnderwaterSchema()
 	default:
 		return sim.EffectSchema{}
 	}

--- a/cmd/ambience/web/sim.js
+++ b/cmd/ambience/web/sim.js
@@ -1979,6 +1979,35 @@
 			calm_dur: 72,
 			calm_mult: 0.5,
 		},
+		underwater: {
+			intro_dur: 55,
+			intro_reveal: 0.14,
+			ending_dur: 70,
+			ending_linger: 22,
+			ending_murk: 0.08,
+			density: 0.28,
+			rise_speed: 0.42,
+			drift: 0.1,
+			sway: 0.54,
+			weed_height: 20,
+			weed_count: 11,
+			caustics: 0.3,
+			depth: 0.56,
+			hue: 192,
+			hue_sp: 18,
+			sat: 0.42,
+			lmin: 0.12,
+			lmax: 0.82,
+			bubble_burst_p: 0,
+			current_shift_p: 0,
+			calm_p: 0,
+			bubble_burst_dur: 38,
+			bubble_burst_mult: 1.9,
+			current_shift_dur: 62,
+			current_shift_push: 1.2,
+			calm_dur: 74,
+			calm_mult: 0.55,
+		},
 		starfield: {
 			intro_dur: 50,
 			intro_density: 0.08,
@@ -2212,6 +2241,32 @@
 				if (c.calm_dur <= 0) c.calm_dur = base.calm_dur;
 				if (c.calm_mult <= 0) c.calm_mult = base.calm_mult;
 				break;
+			case 'underwater':
+				if (c.intro_dur <= 0) c.intro_dur = base.intro_dur;
+				c.intro_reveal = clamp01(c.intro_reveal);
+				if (c.ending_dur <= 0) c.ending_dur = base.ending_dur;
+				if (c.ending_linger < 0) c.ending_linger = 0;
+				c.ending_murk = clamp01(c.ending_murk);
+				if (c.density <= 0) c.density = base.density;
+				if (c.rise_speed <= 0) c.rise_speed = base.rise_speed;
+				if (c.sway <= 0) c.sway = base.sway;
+				if (c.weed_height <= 0) c.weed_height = base.weed_height;
+				if (c.weed_count < 1) c.weed_count = base.weed_count;
+				if (c.caustics <= 0) c.caustics = base.caustics;
+				if (c.depth <= 0) c.depth = base.depth;
+				if (c.hue === 0) c.hue = base.hue;
+				if (c.hue_sp < 0) c.hue_sp = 0;
+				if (c.sat <= 0) c.sat = base.sat;
+				if (c.lmin <= 0) c.lmin = base.lmin;
+				if (c.lmax <= 0) c.lmax = base.lmax;
+				if (c.lmax < c.lmin) [c.lmin, c.lmax] = [c.lmax, c.lmin];
+				if (c.bubble_burst_dur <= 0) c.bubble_burst_dur = base.bubble_burst_dur;
+				if (c.bubble_burst_mult <= 0) c.bubble_burst_mult = base.bubble_burst_mult;
+				if (c.current_shift_dur <= 0) c.current_shift_dur = base.current_shift_dur;
+				if (c.current_shift_push <= 0) c.current_shift_push = base.current_shift_push;
+				if (c.calm_dur <= 0) c.calm_dur = base.calm_dur;
+				if (c.calm_mult <= 0) c.calm_mult = base.calm_mult;
+				break;
 			case 'aurora':
 				if (c.intro_dur <= 0) c.intro_dur = base.intro_dur;
 				c.intro_glow = clamp01(c.intro_glow);
@@ -2359,6 +2414,8 @@
 					return this._triggerLighthouse(name);
 				case 'rowboat':
 					return this._triggerRowboat(name);
+				case 'underwater':
+					return this._triggerUnderwater(name);
 				case 'aurora':
 					return this._triggerAurora(name);
 				case 'starfield':
@@ -2423,6 +2480,14 @@
 					this.values.drift_push = 0;
 				}
 			}
+			if (this.kind === 'underwater') {
+				if (!this.timers['bubble-burst'] || this.timers['bubble-burst'] <= 0) {
+					this.values.bubble_gain = 1;
+				}
+				if (!this.timers['current-shift'] || this.timers['current-shift'] <= 0) {
+					this.values.current_push = 0;
+				}
+			}
 		}
 
 		render(ctx, canvasW, canvasH, opts) {
@@ -2439,6 +2504,8 @@
 					return this._renderLighthouse(ctx, canvasW, canvasH, opts);
 				case 'rowboat':
 					return this._renderRowboat(ctx, canvasW, canvasH, opts);
+				case 'underwater':
+					return this._renderUnderwater(ctx, canvasW, canvasH, opts);
 				case 'aurora':
 					return this._renderAurora(ctx, canvasW, canvasH, opts);
 				case 'starfield':
@@ -2749,6 +2816,47 @@
 			return false;
 		}
 
+		_triggerUnderwater(name) {
+			const rng = this._eventRng(name.length + 89);
+			switch (name) {
+				case 'bubble-burst':
+					this.timers['bubble-burst'] = jitterInt(rng, this.cfg.bubble_burst_dur, 0.3);
+					this.values.bubble_gain = this.cfg.bubble_burst_mult * (0.8 + rng() * 0.45);
+					return true;
+				case 'current-shift':
+					this.timers['current-shift'] = jitterInt(rng, this.cfg.current_shift_dur, 0.3);
+					this.timers.calm = 0;
+					this.values.current_push = (rng() < 0.5 ? -1 : 1) * this.cfg.current_shift_push * (0.55 + rng() * 0.55);
+					return true;
+				case 'calm':
+					this.timers.calm = jitterInt(rng, this.cfg.calm_dur, 0.3);
+					this.timers['current-shift'] = 0;
+					this.values.current_push = 0;
+					return true;
+				case 'intro':
+					this.timers['bubble-burst'] = 0;
+					this.timers['current-shift'] = 0;
+					this.timers.calm = 0;
+					this.timers.ending = 0;
+					this.values.bubble_gain = 1;
+					this.values.current_push = 0;
+					this.timers.intro = Math.max(1, Math.round(this.cfg.intro_dur));
+					this.values.intro_total = this.timers.intro;
+					return true;
+				case 'ending':
+					this.timers.intro = 0;
+					this.timers['bubble-burst'] = 0;
+					this.timers['current-shift'] = 0;
+					this.timers.calm = 0;
+					this.values.bubble_gain = 1;
+					this.values.current_push = 0;
+					this.timers.ending = Math.max(1, Math.round(this.cfg.ending_dur + Math.max(0, this.cfg.ending_linger)));
+					this.values.ending_total = this.timers.ending;
+					return true;
+			}
+			return false;
+		}
+
 		_triggerAurora(name) {
 			const rng = this._eventRng(name.length + 53);
 			switch (name) {
@@ -2986,6 +3094,26 @@
 			}
 			if (this.timers.drift > 0) {
 				level *= 1 + Math.abs(this.values.drift_push || this.cfg.drift_push) * 0.22;
+			}
+			return Math.max(0.04, level);
+		}
+
+		_sceneLevelUnderwater() {
+			let level = 1;
+			if (this.timers['bubble-burst'] > 0) level *= this.values.bubble_gain || this.cfg.bubble_burst_mult;
+			if (this.timers.calm > 0) level *= this.cfg.calm_mult;
+			if (this.timers.intro > 0) {
+				const total = this.values.intro_total || this.cfg.intro_dur;
+				const progress = this._phaseProgress(total, this.timers.intro);
+				level *= this.cfg.intro_reveal + (1 - this.cfg.intro_reveal) * progress;
+			}
+			if (this.timers.ending > 0) {
+				const total = this.values.ending_total || (this.cfg.ending_dur + this.cfg.ending_linger);
+				const progress = this._phaseProgress(total, this.timers.ending);
+				level *= 1 - (1 - this.cfg.ending_murk) * progress;
+			}
+			if (this.timers['current-shift'] > 0) {
+				level *= 1 + Math.abs(this.values.current_push || this.cfg.current_shift_push) * 0.18;
 			}
 			return Math.max(0.04, level);
 		}
@@ -3956,6 +4084,136 @@
 			}
 		}
 
+		_renderUnderwater(ctx, canvasW, canvasH, opts) {
+			opts = opts || {};
+			if (opts.transparent) {
+				ctx.clearRect(0, 0, canvasW, canvasH);
+			} else {
+				const top = hslToRGB((this.cfg.hue - 8 + 360) % 360, clamp01(this.cfg.sat * 0.58), clamp01(this.cfg.lmin + (this.cfg.lmax - this.cfg.lmin) * 0.54));
+				const mid = hslToRGB(this.cfg.hue, clamp01(this.cfg.sat * 0.82), clamp01(this.cfg.lmin + (this.cfg.lmax - this.cfg.lmin) * 0.28));
+				const deep = hslToRGB((this.cfg.hue + 10) % 360, clamp01(this.cfg.sat * 0.72), clamp01(this.cfg.lmin * (0.72 - this.cfg.depth * 0.18)));
+				const water = ctx.createLinearGradient(0, 0, 0, canvasH);
+				water.addColorStop(0, `rgb(${top.r},${top.g},${top.b})`);
+				water.addColorStop(0.46, `rgb(${mid.r},${mid.g},${mid.b})`);
+				water.addColorStop(1, `rgb(${deep.r},${deep.g},${deep.b})`);
+				ctx.fillStyle = water;
+				ctx.fillRect(0, 0, canvasW, canvasH);
+			}
+
+			const sx = canvasW / this.w;
+			const sy = canvasH / this.h;
+			const ceilSx = Math.ceil(sx);
+			const ceilSy = Math.ceil(sy);
+			const level = this._sceneLevelUnderwater();
+			const currentPush = this.timers['current-shift'] > 0 ? (this.values.current_push || this.cfg.current_shift_push) : 0;
+			const floorBase = Math.max(Math.floor(this.h * 0.78), Math.min(this.h - 4, Math.floor(this.h * (0.84 + this.cfg.depth * 0.08))));
+			const phase = this.tick * this.cfg.rise_speed * 0.04;
+
+			const surfaceGlow = ctx.createRadialGradient(canvasW * 0.32, 0, 0, canvasW * 0.32, 0, Math.max(canvasW, canvasH) * 0.52);
+			surfaceGlow.addColorStop(0, `rgba(210, 244, 238, ${clamp01(0.08 + this.cfg.caustics * 0.18 * level)})`);
+			surfaceGlow.addColorStop(1, 'rgba(210, 244, 238, 0)');
+			ctx.fillStyle = surfaceGlow;
+			ctx.fillRect(0, 0, canvasW, canvasH);
+
+			const beamCount = 4;
+			for (let i = 0; i < beamCount; i++) {
+				const sourceX = canvasW * (0.08 + i * 0.24 + this._hash(30100 + i) * 0.08);
+				const spread = canvasW * (0.08 + this._hash(30200 + i) * 0.08);
+				const bend = (currentPush * 12 + Math.sin(this.tick * 0.02 + i) * 10) * this.cfg.caustics;
+				ctx.fillStyle = `rgba(210, 248, 242, ${clamp01(0.04 + this.cfg.caustics * 0.12 * level)})`;
+				ctx.beginPath();
+				ctx.moveTo(sourceX - spread * 0.2, 0);
+				ctx.lineTo(sourceX + spread * 0.22, 0);
+				ctx.lineTo(sourceX + spread + bend, canvasH * 0.7);
+				ctx.lineTo(sourceX - spread * 0.65 + bend * 0.45, canvasH * 0.7);
+				ctx.closePath();
+				ctx.fill();
+			}
+
+			const causticColor = hslToRGB((this.cfg.hue - 10 + 360) % 360, clamp01(this.cfg.sat * 0.24), clamp01(this.cfg.lmax * 0.96));
+			for (let band = 0; band < 5; band++) {
+				const baseY = Math.floor(this.h * (0.16 + band * 0.09));
+				for (let x = 0; x < this.w; x++) {
+					if ((x + band) % 2 !== 0) continue;
+					const wave = Math.sin(x * 0.16 + phase * (1.2 + band * 0.18) + band) + Math.sin(x * 0.07 - phase * 1.4 + band * 1.7);
+					const row = baseY + Math.round(wave * this.cfg.caustics * level * 1.3);
+					const alpha = clamp01((0.03 + this.cfg.caustics * 0.18 * level) * (0.82 - band * 0.12));
+					this._fillCell(ctx, sx, sy, ceilSx, ceilSy, x, row, 1, 1, `rgb(${causticColor.r},${causticColor.g},${causticColor.b})`, alpha);
+				}
+			}
+
+			const particulateColor = hslToRGB((this.cfg.hue + 8) % 360, clamp01(this.cfg.sat * 0.16), clamp01(this.cfg.lmax * 0.8));
+			const particulateCount = Math.max(18, Math.round(this.w * 0.14));
+			for (let i = 0; i < particulateCount; i++) {
+				const col = Math.floor(this._hash(30300 + i) * this.w);
+				const row = Math.floor(this._hash(30400 + i) * Math.max(1, floorBase - 6));
+				const blink = 0.35 + 0.65 * Math.pow(0.5 + 0.5 * Math.sin(this.tick * 0.018 + i * 0.6), 2);
+				this._fillCell(ctx, sx, sy, ceilSx, ceilSy, col, row, 1, 1, `rgb(${particulateColor.r},${particulateColor.g},${particulateColor.b})`, clamp01((0.04 + this.cfg.depth * 0.08) * blink));
+			}
+
+			const seabedPoints = [];
+			const seabedSegments = 8;
+			for (let i = 0; i <= seabedSegments; i++) {
+				seabedPoints.push(Math.round(floorBase - Math.abs(Math.sin(i * 0.8 + this._hash(30500 + i) * 2.4)) * 2 - this._hash(30600 + i) * 2));
+			}
+			const seabedColor = hslToRGB((this.cfg.hue + 36) % 360, clamp01(this.cfg.sat * 0.22), clamp01(this.cfg.lmin * 0.85));
+			ctx.fillStyle = `rgb(${seabedColor.r},${seabedColor.g},${seabedColor.b})`;
+			ctx.beginPath();
+			ctx.moveTo(0, canvasH);
+			for (let x = 0; x < this.w; x++) {
+				const pos = (x / Math.max(1, this.w - 1)) * seabedSegments;
+				const idx = Math.min(seabedSegments - 1, Math.floor(pos));
+				const frac = pos - idx;
+				const eased = frac * frac * (3 - 2 * frac);
+				const row = seabedPoints[idx] + (seabedPoints[idx + 1] - seabedPoints[idx]) * eased;
+				ctx.lineTo(Math.floor(x * sx), Math.floor(row * sy));
+			}
+			ctx.lineTo(canvasW, canvasH);
+			ctx.closePath();
+			ctx.fill();
+
+			const weedColor = hslToRGB((this.cfg.hue - 36 + 360) % 360, clamp01(this.cfg.sat * 0.6), clamp01(this.cfg.lmin + (this.cfg.lmax - this.cfg.lmin) * 0.28));
+			const weedAccent = hslToRGB((this.cfg.hue - 18 + 360) % 360, clamp01(this.cfg.sat * 0.48), clamp01(this.cfg.lmin + (this.cfg.lmax - this.cfg.lmin) * 0.4));
+			const weedCount = Math.max(4, Math.round(this.cfg.weed_count));
+			for (let i = 0; i < weedCount; i++) {
+				const baseX = Math.floor((i + 0.35) * this.w / weedCount + (this._hash(30700 + i) - 0.5) * 5);
+				const rootY = floorBase - 1 - Math.floor(this._hash(30800 + i) * 3);
+				const fronds = 2 + Math.floor(this._hash(30900 + i) * 2);
+				for (let f = 0; f < fronds; f++) {
+					const height = Math.max(7, Math.round(this.cfg.weed_height * (0.58 + this._hash(31000 + i * 5 + f) * 0.5)));
+					const offset = (f - (fronds - 1) / 2) * 1.2;
+					const localPhase = this.tick * 0.035 * (0.8 + this._hash(31100 + i * 5 + f) * 0.4) + i * 0.7 + f * 0.4;
+					for (let seg = 0; seg < height; seg++) {
+						const progress = seg / Math.max(1, height - 1);
+						const sway = Math.sin(localPhase + progress * 2.6) * this.cfg.sway * level * (1.1 + Math.abs(currentPush) * 0.55) + currentPush * progress * 1.4;
+						const x = Math.round(baseX + offset + sway * progress * 1.2);
+						const y = rootY - seg;
+						const color = seg < height * 0.28 ? weedColor : weedAccent;
+						const alpha = clamp01(0.3 + progress * 0.42);
+						this._fillCell(ctx, sx, sy, ceilSx, ceilSy, x, y, seg < height * 0.25 ? 2 : 1, 1, `rgb(${color.r},${color.g},${color.b})`, alpha);
+					}
+				}
+			}
+
+			const burstGain = this.timers['bubble-burst'] > 0 ? (this.values.bubble_gain || this.cfg.bubble_burst_mult) : 1;
+			const bubbleDensity = Math.max(0.04, this.cfg.density * level);
+			const bubbleCount = Math.max(12, Math.round(this.w * bubbleDensity * (0.44 + Math.max(0, burstGain - 1) * 0.18)));
+			const bubbleColor = hslToRGB((this.cfg.hue - 4 + 360) % 360, clamp01(this.cfg.sat * 0.18), clamp01(this.cfg.lmax * 0.98));
+			for (let i = 0; i < bubbleCount; i++) {
+				const baseX = this._hash(31200 + i) * this.w;
+				const baseY = this._hash(31300 + i) * Math.max(6, floorBase - 6);
+				const rise = baseY - this.tick * this.cfg.rise_speed * (0.55 + this._hash(31400 + i) * 0.7);
+				const row = 1 + positiveMod(rise, Math.max(1, floorBase - 5));
+				const drift = this.cfg.drift * (0.4 + this._hash(31500 + i) * 0.9) + currentPush * 0.05 * (0.45 + this._hash(31600 + i) * 0.55);
+				const wobble = Math.sin(this.tick * 0.03 + i * 0.72) * this.cfg.sway * (0.6 + this._hash(31700 + i) * 0.5);
+				const col = positiveMod(baseX + this.tick * drift + wobble, this.w);
+				const size = this._hash(31800 + i) > 0.82 ? 2 : 1;
+				const alpha = clamp01((0.22 + this._hash(31900 + i) * 0.28) * (0.8 + Math.max(0, burstGain - 1) * 0.14));
+				this._fillCell(ctx, sx, sy, ceilSx, ceilSy, Math.round(col), Math.round(row), size, size, `rgb(${bubbleColor.r},${bubbleColor.g},${bubbleColor.b})`, alpha);
+				this._fillCell(ctx, sx, sy, ceilSx, ceilSy, Math.round(col), Math.round(row), 1, 1, `rgb(235,248,246)`, clamp01(alpha * 0.62));
+			}
+		}
+
 		_renderAurora(ctx, canvasW, canvasH, opts) {
 			opts = opts || {};
 			if (opts.transparent) {
@@ -4120,6 +4378,12 @@
 		}
 	}
 
+	class Underwater extends ProceduralScene {
+		constructor(w, h, cfg, seed) {
+			super('underwater', w, h, cfg, seed);
+		}
+	}
+
 	class Aurora extends ProceduralScene {
 		constructor(w, h, cfg, seed) {
 			super('aurora', w, h, cfg, seed);
@@ -4178,7 +4442,7 @@
 	// server's snapshot payload — the client looks up the constructor here
 	// by name so new effects just register themselves and work without
 	// client-side changes.
-	const effects = { rain: Rain, dust: Dust, fireflies: Fireflies, waterfall: Waterfall, 'wheat-field': WheatField, beach: Beach, campfire: Campfire, windmill: Windmill, lighthouse: Lighthouse, rowboat: Rowboat, aurora: Aurora, snow: Snow, 'autumn-leaves': AutumnLeaves, starfield: Starfield };
+	const effects = { rain: Rain, dust: Dust, fireflies: Fireflies, waterfall: Waterfall, 'wheat-field': WheatField, beach: Beach, campfire: Campfire, windmill: Windmill, lighthouse: Lighthouse, rowboat: Rowboat, underwater: Underwater, aurora: Aurora, snow: Snow, 'autumn-leaves': AutumnLeaves, starfield: Starfield };
 	const presets = {
 		'wheat-field': [
 			{
@@ -4685,6 +4949,93 @@
 					wake_mult: 2.1,
 					drift_p: 0.0014,
 					drift_push: 1.55,
+				},
+			},
+		],
+		underwater: [
+			{
+				key: 'quiet-shallows',
+				label: 'quiet shallows',
+				config: {
+					intro_reveal: 0.18,
+					ending_murk: 0.12,
+					density: 0.18,
+					rise_speed: 0.32,
+					drift: 0.04,
+					sway: 0.34,
+					weed_height: 16,
+					weed_count: 9,
+					caustics: 0.44,
+					depth: 0.28,
+					hue: 184,
+					hue_sp: 12,
+					sat: 0.38,
+					lmin: 0.14,
+					lmax: 0.86,
+					calm_p: 0.0011,
+				},
+			},
+			{
+				key: 'bubble-field',
+				label: 'bubble field',
+				config: {
+					density: 0.42,
+					rise_speed: 0.54,
+					drift: 0.08,
+					sway: 0.46,
+					weed_height: 18,
+					weed_count: 8,
+					caustics: 0.26,
+					depth: 0.42,
+					hue: 190,
+					hue_sp: 16,
+					sat: 0.42,
+					lmin: 0.12,
+					lmax: 0.82,
+					bubble_burst_p: 0.0012,
+				},
+			},
+			{
+				key: 'slow-current',
+				label: 'slow current',
+				config: {
+					density: 0.28,
+					rise_speed: 0.4,
+					drift: 0.12,
+					sway: 0.78,
+					weed_height: 22,
+					weed_count: 11,
+					caustics: 0.3,
+					depth: 0.56,
+					hue: 192,
+					hue_sp: 18,
+					sat: 0.42,
+					lmin: 0.12,
+					lmax: 0.82,
+					current_shift_p: 0.0011,
+				},
+			},
+			{
+				key: 'deep-water',
+				label: 'deep water',
+				config: {
+					intro_reveal: 0.1,
+					ending_murk: 0.16,
+					density: 0.16,
+					rise_speed: 0.28,
+					drift: 0.05,
+					sway: 0.26,
+					weed_height: 13,
+					weed_count: 6,
+					caustics: 0.14,
+					depth: 0.82,
+					hue: 204,
+					hue_sp: 10,
+					sat: 0.3,
+					lmin: 0.08,
+					lmax: 0.62,
+					calm_p: 0.0014,
+					calm_mult: 0.42,
 				},
 			},
 		],
@@ -5199,5 +5550,5 @@
 		],
 	};
 
-	global.AmbienceSim = { Rain, Dust, Fireflies, Waterfall, WheatField, Beach, Campfire, Windmill, Lighthouse, Rowboat, Aurora, AutumnLeaves, Snow, Starfield, subscribe, applyDefaults, hslToRGB, effects, presets };
+	global.AmbienceSim = { Rain, Dust, Fireflies, Waterfall, WheatField, Beach, Campfire, Windmill, Lighthouse, Rowboat, Underwater, Aurora, AutumnLeaves, Snow, Starfield, subscribe, applyDefaults, hslToRGB, effects, presets };
 })(window);

--- a/sim/procedural.go
+++ b/sim/procedural.go
@@ -323,6 +323,36 @@ var rowboatDefaults = ProceduralConfig{
 	"calm_mult":     0.50,
 }
 
+var underwaterDefaults = ProceduralConfig{
+	"intro_dur":          55,
+	"intro_reveal":       0.14,
+	"ending_dur":         70,
+	"ending_linger":      22,
+	"ending_murk":        0.08,
+	"density":            0.28,
+	"rise_speed":         0.42,
+	"drift":              0.10,
+	"sway":               0.54,
+	"weed_height":        20.0,
+	"weed_count":         11.0,
+	"caustics":           0.30,
+	"depth":              0.56,
+	"hue":                192,
+	"hue_sp":             18,
+	"sat":                0.42,
+	"lmin":               0.12,
+	"lmax":               0.82,
+	"bubble_burst_p":     0.0,
+	"current_shift_p":    0.0,
+	"calm_p":             0.0,
+	"bubble_burst_dur":   38,
+	"bubble_burst_mult":  1.90,
+	"current_shift_dur":  62,
+	"current_shift_push": 1.20,
+	"calm_dur":           74,
+	"calm_mult":          0.55,
+}
+
 func SnowSchema() EffectSchema {
 	return EffectSchema{
 		Name: "snow",
@@ -897,6 +927,68 @@ func RowboatSchema() EffectSchema {
 	}
 }
 
+func UnderwaterSchema() EffectSchema {
+	return EffectSchema{
+		Name: "underwater",
+		Knobs: []Knob{
+			{Key: "intro_dur", Label: "intro dur", Slot: SlotSpawn, Group: "introduction", Type: KnobInt, Min: 10, Max: 200, Step: 5, Default: 55, Trigger: "intro",
+				Description: "Ticks spent brightening out of murk before the full underwater scene settles in."},
+			{Key: "intro_reveal", Label: "intro reveal", Slot: SlotSpawn, Group: "introduction", Type: KnobFloat, Min: 0.05, Max: 0.5, Step: 0.01, Default: 0.14,
+				Description: "Starting fraction of the final bubble, caustic, and sway activity."},
+			{Key: "ending_dur", Label: "ending dur", Slot: SlotEnd, Group: "ending", Type: KnobInt, Min: 10, Max: 220, Step: 5, Default: 70, Trigger: "ending",
+				Description: "Ticks spent dimming the water column back toward still murk."},
+			{Key: "ending_linger", Label: "ending linger", Slot: SlotEnd, Group: "ending", Type: KnobInt, Min: 0, Max: 160, Step: 5, Default: 22,
+				Description: "Extra quiet ticks after the main motion has mostly faded."},
+			{Key: "ending_murk", Label: "ending murk", Slot: SlotEnd, Group: "ending", Type: KnobFloat, Min: 0.02, Max: 0.35, Step: 0.01, Default: 0.08,
+				Description: "Residual underwater activity and light left near the end of the outro."},
+			{Key: "density", Label: "bubble density", Slot: SlotLever, Group: "water", Type: KnobFloat, Min: 0.05, Max: 0.8, Step: 0.01, Default: 0.28,
+				Description: "Base density of drifting bubbles across the scene."},
+			{Key: "rise_speed", Label: "rise speed", Slot: SlotLever, Group: "water", Type: KnobFloat, Min: 0.1, Max: 1.2, Step: 0.02, Default: 0.42,
+				Description: "How quickly bubbles rise through the water column."},
+			{Key: "drift", Label: "drift", Slot: SlotLever, Group: "water", Type: KnobFloat, Min: -0.6, Max: 0.6, Step: 0.01, Default: 0.10,
+				Description: "Baseline sideways carry applied to bubbles and suspended particles."},
+			{Key: "sway", Label: "sway", Slot: SlotLever, Group: "seaweed", Type: KnobFloat, Min: 0.05, Max: 1.4, Step: 0.02, Default: 0.54,
+				Description: "How much the seaweed and finer particles sway with the water."},
+			{Key: "weed_height", Label: "weed height", Slot: SlotLever, Group: "seaweed", Type: KnobFloat, Min: 8, Max: 30, Step: 0.5, Default: 20,
+				Description: "Height of the tallest seaweed fronds."},
+			{Key: "weed_count", Label: "weed count", Slot: SlotLever, Group: "seaweed", Type: KnobInt, Min: 4, Max: 18, Step: 1, Default: 11,
+				Description: "Number of seaweed clumps anchored along the bottom."},
+			{Key: "caustics", Label: "caustics", Slot: SlotLever, Group: "light", Type: KnobFloat, Min: 0.05, Max: 0.8, Step: 0.01, Default: 0.30,
+				Description: "Strength of the shifting light bands and shafts near the surface."},
+			{Key: "depth", Label: "depth", Slot: SlotLever, Group: "light", Type: KnobFloat, Min: 0.15, Max: 0.95, Step: 0.01, Default: 0.56,
+				Description: "How murky and deep the water feels overall."},
+			{Key: "hue", Label: "hue", Slot: SlotLever, Group: "color", Type: KnobFloat, Min: 160, Max: 220, Step: 1, Default: 192,
+				Description: "Base water hue. Lower values lean greener; higher values lean bluer."},
+			{Key: "hue_sp", Label: "hue spread", Slot: SlotLever, Group: "color", Type: KnobFloat, Min: 0, Max: 30, Step: 1, Default: 18,
+				Description: "Variation between the light shafts, water body, and seaweed glow."},
+			{Key: "sat", Label: "saturation", Slot: SlotLever, Group: "color", Type: KnobFloat, Min: 0.05, Max: 0.8, Step: 0.01, Default: 0.42,
+				Description: "Overall underwater color saturation."},
+			{Key: "lmin", Label: "light min", Slot: SlotLever, Group: "color", Type: KnobFloat, Min: 0.04, Max: 0.5, Step: 0.01, Default: 0.12,
+				Description: "Minimum lightness used for deep water and seabed shadows."},
+			{Key: "lmax", Label: "light max", Slot: SlotLever, Group: "color", Type: KnobFloat, Min: 0.25, Max: 0.95, Step: 0.01, Default: 0.82,
+				Description: "Maximum lightness used for bubbles and surface caustics."},
+			{Key: "bubble_burst_p", Label: "bubble burst", Slot: SlotEvent, Type: KnobFloat, Min: 0, Max: 0.02, Step: 0.0005, Default: 0, Trigger: "bubble-burst",
+				Description: "Per-tick chance of a denser burst of bubbles rising through the frame."},
+			{Key: "current_shift_p", Label: "current shift", Slot: SlotEvent, Type: KnobFloat, Min: 0, Max: 0.02, Step: 0.0005, Default: 0, Trigger: "current-shift",
+				Description: "Per-tick chance of the water current leaning harder to one side."},
+			{Key: "calm_p", Label: "calm", Slot: SlotEvent, Type: KnobFloat, Min: 0, Max: 0.02, Step: 0.0005, Default: 0, Trigger: "calm",
+				Description: "Per-tick chance of bubble activity and sway easing into a quieter interval."},
+			{Key: "bubble_burst_dur", Label: "burst dur", Slot: SlotEventMod, Group: "bubble-burst", Type: KnobInt, Min: 10, Max: 180, Step: 5, Default: 38,
+				Description: "Duration of a denser bubble burst."},
+			{Key: "bubble_burst_mult", Label: "burst x", Slot: SlotEventMod, Group: "bubble-burst", Type: KnobFloat, Min: 1.05, Max: 3, Step: 0.05, Default: 1.9,
+				Description: "Bubble density multiplier applied during a bubble burst."},
+			{Key: "current_shift_dur", Label: "shift dur", Slot: SlotEventMod, Group: "current-shift", Type: KnobInt, Min: 10, Max: 220, Step: 5, Default: 62,
+				Description: "Duration of the stronger sideways current window."},
+			{Key: "current_shift_push", Label: "shift push", Slot: SlotEventMod, Group: "current-shift", Type: KnobFloat, Min: 0.2, Max: 3, Step: 0.05, Default: 1.2,
+				Description: "Additional horizontal push applied during a current shift."},
+			{Key: "calm_dur", Label: "calm dur", Slot: SlotEventMod, Group: "calm", Type: KnobInt, Min: 10, Max: 220, Step: 5, Default: 74,
+				Description: "Duration of the calmer low-motion underwater interval."},
+			{Key: "calm_mult", Label: "calm x", Slot: SlotEventMod, Group: "calm", Type: KnobFloat, Min: 0.1, Max: 1, Step: 0.05, Default: 0.55,
+				Description: "Bubble and sway multiplier applied while calm is active."},
+		},
+	}
+}
+
 func cloneProceduralConfig(src ProceduralConfig) ProceduralConfig {
 	if src == nil {
 		return ProceduralConfig{}
@@ -957,6 +1049,8 @@ func proceduralDefaults(kind string) ProceduralConfig {
 		return cloneProceduralConfig(lighthouseDefaults)
 	case "rowboat":
 		return cloneProceduralConfig(rowboatDefaults)
+	case "underwater":
+		return cloneProceduralConfig(underwaterDefaults)
 	default:
 		return ProceduralConfig{}
 	}
@@ -1610,6 +1704,75 @@ func mergeProceduralDefaults(kind string, cfg ProceduralConfig) ProceduralConfig
 		if out["calm_mult"] <= 0 {
 			out["calm_mult"] = rowboatDefaults["calm_mult"]
 		}
+	case "underwater":
+		if out["intro_dur"] <= 0 {
+			out["intro_dur"] = underwaterDefaults["intro_dur"]
+		}
+		out["intro_reveal"] = clamp01(out["intro_reveal"])
+		if out["ending_dur"] <= 0 {
+			out["ending_dur"] = underwaterDefaults["ending_dur"]
+		}
+		if out["ending_linger"] < 0 {
+			out["ending_linger"] = 0
+		}
+		out["ending_murk"] = clamp01(out["ending_murk"])
+		if out["density"] <= 0 {
+			out["density"] = underwaterDefaults["density"]
+		}
+		if out["rise_speed"] <= 0 {
+			out["rise_speed"] = underwaterDefaults["rise_speed"]
+		}
+		if out["sway"] <= 0 {
+			out["sway"] = underwaterDefaults["sway"]
+		}
+		if out["weed_height"] <= 0 {
+			out["weed_height"] = underwaterDefaults["weed_height"]
+		}
+		if out["weed_count"] < 1 {
+			out["weed_count"] = underwaterDefaults["weed_count"]
+		}
+		if out["caustics"] <= 0 {
+			out["caustics"] = underwaterDefaults["caustics"]
+		}
+		if out["depth"] <= 0 {
+			out["depth"] = underwaterDefaults["depth"]
+		}
+		if out["hue"] == 0 {
+			out["hue"] = underwaterDefaults["hue"]
+		}
+		if out["hue_sp"] < 0 {
+			out["hue_sp"] = 0
+		}
+		if out["sat"] <= 0 {
+			out["sat"] = underwaterDefaults["sat"]
+		}
+		if out["lmin"] <= 0 {
+			out["lmin"] = underwaterDefaults["lmin"]
+		}
+		if out["lmax"] <= 0 {
+			out["lmax"] = underwaterDefaults["lmax"]
+		}
+		if out["lmax"] < out["lmin"] {
+			out["lmin"], out["lmax"] = out["lmax"], out["lmin"]
+		}
+		if out["bubble_burst_dur"] <= 0 {
+			out["bubble_burst_dur"] = underwaterDefaults["bubble_burst_dur"]
+		}
+		if out["bubble_burst_mult"] <= 0 {
+			out["bubble_burst_mult"] = underwaterDefaults["bubble_burst_mult"]
+		}
+		if out["current_shift_dur"] <= 0 {
+			out["current_shift_dur"] = underwaterDefaults["current_shift_dur"]
+		}
+		if out["current_shift_push"] <= 0 {
+			out["current_shift_push"] = underwaterDefaults["current_shift_push"]
+		}
+		if out["calm_dur"] <= 0 {
+			out["calm_dur"] = underwaterDefaults["calm_dur"]
+		}
+		if out["calm_mult"] <= 0 {
+			out["calm_mult"] = underwaterDefaults["calm_mult"]
+		}
 	}
 	return out
 }
@@ -1910,6 +2073,24 @@ func (p *Procedural) TriggerEvent(name string) bool {
 			return false
 		}
 		return true
+	case "underwater":
+		switch name {
+		case "bubble-burst":
+			p.startUnderwaterBubbleBurstLocked("triggered")
+		case "current-shift":
+			p.startUnderwaterCurrentShiftLocked("triggered")
+		case "calm":
+			p.startUnderwaterCalmLocked("triggered")
+		case "intro":
+			p.startUnderwaterIntroLocked()
+			p.appendLog("intro", fmt.Sprintf("started (dur=%d, reveal=%.2f)", p.timers["intro"], p.cfg["intro_reveal"]))
+		case "ending":
+			p.startUnderwaterEndingLocked()
+			p.appendLog("ending", fmt.Sprintf("started (fade=%d, linger=%d)", p.intCfg("ending_dur"), p.intCfg("ending_linger")))
+		default:
+			return false
+		}
+		return true
 	default:
 		return false
 	}
@@ -1965,6 +2146,8 @@ func (p *Procedural) Step() {
 		p.stepLighthouseLocked()
 	case "rowboat":
 		p.stepRowboatLocked()
+	case "underwater":
+		p.stepUnderwaterLocked()
 	}
 }
 
@@ -2626,5 +2809,82 @@ func (p *Procedural) stepRowboatLocked() {
 	}
 	if p.timers["calm"] <= 0 && p.cfg["calm_p"] > 0 && p.rng.Float64() < p.cfg["calm_p"] {
 		p.startRowboatCalmLocked("started")
+	}
+}
+
+func (p *Procedural) startUnderwaterBubbleBurstLocked(verb string) {
+	p.timers["bubble-burst"] = jitterInt(p.rng, p.intCfg("bubble_burst_dur"), 0.3)
+	p.values["bubble_gain"] = p.cfg["bubble_burst_mult"] * (0.8 + p.rng.Float64()*0.45)
+	p.appendLog("bubble-burst", fmt.Sprintf("%s (dur=%d, x%.2f)", verb, p.timers["bubble-burst"], p.values["bubble_gain"]))
+}
+
+func (p *Procedural) startUnderwaterCurrentShiftLocked(verb string) {
+	p.timers["current-shift"] = jitterInt(p.rng, p.intCfg("current_shift_dur"), 0.3)
+	p.timers["calm"] = 0
+	sign := 1.0
+	if p.rng.Float64() < 0.5 {
+		sign = -1
+	}
+	p.values["current_push"] = sign * p.cfg["current_shift_push"] * (0.55 + p.rng.Float64()*0.55)
+	p.appendLog("current-shift", fmt.Sprintf("%s (dur=%d, push=%+.2f)", verb, p.timers["current-shift"], p.values["current_push"]))
+}
+
+func (p *Procedural) startUnderwaterCalmLocked(verb string) {
+	p.timers["calm"] = jitterInt(p.rng, p.intCfg("calm_dur"), 0.3)
+	p.timers["current-shift"] = 0
+	p.values["current_push"] = 0
+	p.appendLog("calm", fmt.Sprintf("%s (dur=%d, x%.2f)", verb, p.timers["calm"], p.cfg["calm_mult"]))
+}
+
+func (p *Procedural) startUnderwaterIntroLocked() {
+	p.timers["bubble-burst"] = 0
+	p.timers["current-shift"] = 0
+	p.timers["calm"] = 0
+	p.timers["ending"] = 0
+	p.values["bubble_gain"] = 1
+	p.values["current_push"] = 0
+	p.timers["intro"] = p.intCfg("intro_dur")
+	p.values["intro_total"] = float64(p.timers["intro"])
+}
+
+func (p *Procedural) startUnderwaterEndingLocked() {
+	p.timers["intro"] = 0
+	p.timers["bubble-burst"] = 0
+	p.timers["current-shift"] = 0
+	p.timers["calm"] = 0
+	p.values["bubble_gain"] = 1
+	p.values["current_push"] = 0
+	endingTotal := p.intCfg("ending_dur") + max(0, p.intCfg("ending_linger"))
+	if endingTotal < 1 {
+		endingTotal = max(1, p.intCfg("ending_dur"))
+	}
+	p.timers["ending"] = endingTotal
+	p.values["ending_total"] = float64(endingTotal)
+}
+
+func (p *Procedural) stepUnderwaterLocked() {
+	if p.timers["bubble-burst"] <= 0 {
+		p.values["bubble_gain"] = 1
+	}
+	if p.timers["current-shift"] <= 0 {
+		p.values["current_push"] = 0
+	}
+	if p.timers["intro"] <= 0 {
+		delete(p.values, "intro_total")
+	}
+	if p.timers["ending"] <= 0 {
+		delete(p.values, "ending_total")
+	}
+	if p.timers["intro"] > 0 || p.timers["ending"] > 0 {
+		return
+	}
+	if p.timers["bubble-burst"] <= 0 && p.cfg["bubble_burst_p"] > 0 && p.rng.Float64() < p.cfg["bubble_burst_p"] {
+		p.startUnderwaterBubbleBurstLocked("started")
+	}
+	if p.timers["current-shift"] <= 0 && p.timers["calm"] <= 0 && p.cfg["current_shift_p"] > 0 && p.rng.Float64() < p.cfg["current_shift_p"] {
+		p.startUnderwaterCurrentShiftLocked("started")
+	}
+	if p.timers["calm"] <= 0 && p.timers["current-shift"] <= 0 && p.cfg["calm_p"] > 0 && p.rng.Float64() < p.cfg["calm_p"] {
+		p.startUnderwaterCalmLocked("started")
 	}
 }

--- a/sim/procedural_test.go
+++ b/sim/procedural_test.go
@@ -102,6 +102,16 @@ func TestRowboatSchema(t *testing.T) {
 	}
 }
 
+func TestUnderwaterSchema(t *testing.T) {
+	schema := UnderwaterSchema()
+	if schema.Name != "underwater" {
+		t.Fatalf("schema name = %q, want underwater", schema.Name)
+	}
+	if len(schema.Knobs) == 0 {
+		t.Fatal("expected underwater schema knobs")
+	}
+}
+
 func TestProceduralSnowSnapshotRestore(t *testing.T) {
 	p := NewProcedural("snow", 160, 80, 42, nil)
 	if !p.TriggerEvent("gust") {
@@ -404,5 +414,46 @@ func TestProceduralRowboatSnapshotRestore(t *testing.T) {
 	}
 	if again.Values["drift_push"] != snap.Values["drift_push"] {
 		t.Fatalf("restored drift push = %f, want %f", again.Values["drift_push"], snap.Values["drift_push"])
+	}
+}
+
+func TestProceduralUnderwaterSnapshotRestore(t *testing.T) {
+	p := NewProcedural("underwater", 160, 80, 77, nil)
+	if !p.TriggerEvent("bubble-burst") {
+		t.Fatal("expected bubble-burst trigger to succeed")
+	}
+	if !p.TriggerEvent("current-shift") {
+		t.Fatal("expected current-shift trigger to succeed")
+	}
+	p.Step()
+
+	snap := p.Snapshot()
+	if snap.Timers["bubble-burst"] <= 0 {
+		t.Fatal("expected bubble-burst timer in snapshot")
+	}
+	if snap.Timers["current-shift"] <= 0 {
+		t.Fatal("expected current-shift timer in snapshot")
+	}
+	if snap.Values["bubble_gain"] <= 1 {
+		t.Fatal("expected bubble gain value in snapshot")
+	}
+	if snap.Values["current_push"] == 0 {
+		t.Fatal("expected current push value in snapshot")
+	}
+
+	restored := NewProcedural("underwater", 160, 80, 7, nil)
+	restored.RestoreSnapshot(snap)
+	again := restored.Snapshot()
+	if again.Timers["bubble-burst"] != snap.Timers["bubble-burst"] {
+		t.Fatalf("restored bubble-burst timer = %d, want %d", again.Timers["bubble-burst"], snap.Timers["bubble-burst"])
+	}
+	if again.Timers["current-shift"] != snap.Timers["current-shift"] {
+		t.Fatalf("restored current-shift timer = %d, want %d", again.Timers["current-shift"], snap.Timers["current-shift"])
+	}
+	if again.Values["bubble_gain"] != snap.Values["bubble_gain"] {
+		t.Fatalf("restored bubble gain = %f, want %f", again.Values["bubble_gain"], snap.Values["bubble_gain"])
+	}
+	if again.Values["current_push"] != snap.Values["current_push"] {
+		t.Fatalf("restored current push = %f, want %f", again.Values["current_push"], snap.Values["current_push"])
 	}
 }


### PR DESCRIPTION
## Summary
- add the `underwater` procedural effect to the Go registry, schema surface, dev-session routing, and snapshot/restore coverage
- implement the browser-side underwater renderer with bubble burst, current shift, calm, intro, and ending handling plus layered underwater presets
- tune the live dev scene around light shafts, seaweed sway, seabed silhouette, and a restrained bubble field for ambient background use

## Validation
- `node --check cmd/ambience/web/sim.js`
- `go test ./...`
- `powershell -ExecutionPolicy Bypass -File scripts/dev-deploy.ps1 -Component all`
- visual check on `https://ambience.dev.romaine.life/dev/underwater`

Refs #32