### PR TITLE
Add the burning trees dev effect prototype

### DIFF
--- a/cmd/ambience/dev_random_test.go
+++ b/cmd/ambience/dev_random_test.go
@@ -28,6 +28,7 @@ func TestRandomizedDevConfigStaysWithinSchemaBounds(t *testing.T) {
 		sim.VolcanoSchema(),
 		sim.TrainSchema(),
 		sim.MysteriousManSchema(),
+		sim.BurningTreesSchema(),
 	}
 
 	for i, schema := range schemas {
@@ -76,6 +77,7 @@ func TestRandomizedDevConfigChangesAtLeastOneKnob(t *testing.T) {
 		sim.VolcanoSchema(),
 		sim.TrainSchema(),
 		sim.MysteriousManSchema(),
+		sim.BurningTreesSchema(),
 	}
 
 	for i, schema := range schemas {

--- a/cmd/ambience/dev_sessions_test.go
+++ b/cmd/ambience/dev_sessions_test.go
@@ -27,6 +27,7 @@ func TestDevPageEffectFromPath(t *testing.T) {
 		{path: "/dev/train", want: "train", wantOK: true},
 		{path: "/dev/volcano", want: "volcano", wantOK: true},
 		{path: "/dev/mysterious-man", want: "mysterious-man", wantOK: true},
+		{path: "/dev/burning-trees", want: "burning-trees", wantOK: true},
 		{path: "/dev/waterfall", want: "waterfall", wantOK: true},
 		{path: "/dev/windmill", want: "windmill", wantOK: true},
 		{path: "/dev/wheat-field", want: "wheat-field", wantOK: true},
@@ -65,6 +66,7 @@ func TestEffectFromSchemaPath(t *testing.T) {
 		{path: "/effects/train/schema", want: "train", wantOK: true},
 		{path: "/effects/volcano/schema", want: "volcano", wantOK: true},
 		{path: "/effects/mysterious-man/schema", want: "mysterious-man", wantOK: true},
+		{path: "/effects/burning-trees/schema", want: "burning-trees", wantOK: true},
 		{path: "/effects/waterfall/schema", want: "waterfall", wantOK: true},
 		{path: "/effects/windmill/schema", want: "windmill", wantOK: true},
 		{path: "/effects/wheat-field/schema", want: "wheat-field", wantOK: true},
@@ -233,6 +235,17 @@ func TestNewDevSessionMysteriousManSnapshotType(t *testing.T) {
 	snap := session.snapshot()
 	if snap.Type != "mysterious-man" {
 		t.Fatalf("snapshot type = %q, want mysterious-man", snap.Type)
+	}
+}
+
+func TestNewDevSessionBurningTreesSnapshotType(t *testing.T) {
+	session, err := newDevSession("burning-trees")
+	if err != nil {
+		t.Fatalf("newDevSession: %v", err)
+	}
+	snap := session.snapshot()
+	if snap.Type != "burning-trees" {
+		t.Fatalf("snapshot type = %q, want burning-trees", snap.Type)
 	}
 }
 

--- a/cmd/ambience/effects.go
+++ b/cmd/ambience/effects.go
@@ -141,6 +141,11 @@ var effectRegistry = map[string]effectDefinition{
 		Schema:     sim.MysteriousManSchema,
 		NewRuntime: newMysteriousManRuntime,
 	},
+	"burning-trees": {
+		Type:       "burning-trees",
+		Schema:     sim.BurningTreesSchema,
+		NewRuntime: newBurningTreesRuntime,
+	},
 }
 
 func lookupEffectDefinition(effectType string) (effectDefinition, bool) {
@@ -335,6 +340,10 @@ func newTrainRuntime(w, h int, seed int64, cfg json.RawMessage) (effectRuntime, 
 
 func newMysteriousManRuntime(w, h int, seed int64, cfg json.RawMessage) (effectRuntime, error) {
 	return newProceduralRuntime("mysterious-man", w, h, seed, cfg)
+}
+
+func newBurningTreesRuntime(w, h int, seed int64, cfg json.RawMessage) (effectRuntime, error) {
+	return newProceduralRuntime("burning-trees", w, h, seed, cfg)
 }
 
 func (r *rainRuntime) Type() string { return "rain" }
@@ -773,6 +782,8 @@ func (p *proceduralRuntime) Schema() sim.EffectSchema {
 		return sim.TrainSchema()
 	case "mysterious-man":
 		return sim.MysteriousManSchema()
+	case "burning-trees":
+		return sim.BurningTreesSchema()
 	default:
 		return sim.EffectSchema{}
 	}

--- a/cmd/ambience/web/sim.js
+++ b/cmd/ambience/web/sim.js
@@ -2098,6 +2098,36 @@
 			lighter_flick_dur: 20,
 			lighter_flick_mult: 2.25,
 		},
+		'burning-trees': {
+			intro_dur: 55,
+			intro_growth: 0.14,
+			ending_dur: 72,
+			ending_linger: 22,
+			ending_ash: 0.1,
+			horizon: 0.84,
+			tree_count: 10,
+			tree_height: 13,
+			canopy: 0.78,
+			spread: 1.35,
+			flame: 0.28,
+			embers: 0.18,
+			smoke: 0.16,
+			char: 0.42,
+			hue: 112,
+			hue_sp: 20,
+			sat: 0.48,
+			lmin: 0.06,
+			lmax: 0.88,
+			ignite_p: 0,
+			flare_p: 0,
+			lull_p: 0,
+			ignite_dur: 76,
+			ignite_span: 1.6,
+			flare_dur: 38,
+			flare_mult: 1.85,
+			lull_dur: 54,
+			lull_mult: 0.55,
+		},
 		starfield: {
 			intro_dur: 50,
 			intro_density: 0.08,
@@ -2437,6 +2467,34 @@
 				if (c.lighter_flick_dur <= 0) c.lighter_flick_dur = base.lighter_flick_dur;
 				if (c.lighter_flick_mult <= 0) c.lighter_flick_mult = base.lighter_flick_mult;
 				break;
+			case 'burning-trees':
+				if (c.intro_dur <= 0) c.intro_dur = base.intro_dur;
+				c.intro_growth = clamp01(c.intro_growth);
+				if (c.ending_dur <= 0) c.ending_dur = base.ending_dur;
+				if (c.ending_linger < 0) c.ending_linger = 0;
+				c.ending_ash = clamp01(c.ending_ash);
+				if (c.horizon <= 0) c.horizon = base.horizon;
+				if (c.tree_count < 1) c.tree_count = base.tree_count;
+				if (c.tree_height <= 0) c.tree_height = base.tree_height;
+				c.canopy = clamp01(c.canopy);
+				if (c.spread <= 0) c.spread = base.spread;
+				if (c.flame <= 0) c.flame = base.flame;
+				if (c.embers <= 0) c.embers = base.embers;
+				if (c.smoke <= 0) c.smoke = base.smoke;
+				c.char = clamp01(c.char);
+				if (c.hue <= 0) c.hue = base.hue;
+				if (c.hue_sp < 0) c.hue_sp = 0;
+				if (c.sat <= 0) c.sat = base.sat;
+				if (c.lmin <= 0) c.lmin = base.lmin;
+				if (c.lmax <= 0) c.lmax = base.lmax;
+				if (c.lmax < c.lmin) [c.lmin, c.lmax] = [c.lmax, c.lmin];
+				if (c.ignite_dur <= 0) c.ignite_dur = base.ignite_dur;
+				if (c.ignite_span <= 0) c.ignite_span = base.ignite_span;
+				if (c.flare_dur <= 0) c.flare_dur = base.flare_dur;
+				if (c.flare_mult <= 0) c.flare_mult = base.flare_mult;
+				if (c.lull_dur <= 0) c.lull_dur = base.lull_dur;
+				if (c.lull_mult <= 0) c.lull_mult = base.lull_mult;
+				break;
 			case 'aurora':
 				if (c.intro_dur <= 0) c.intro_dur = base.intro_dur;
 				c.intro_glow = clamp01(c.intro_glow);
@@ -2592,6 +2650,8 @@
 					return this._triggerTrain(name);
 				case 'mysterious-man':
 					return this._triggerMysteriousMan(name);
+				case 'burning-trees':
+					return this._triggerBurningTrees(name);
 				case 'aurora':
 					return this._triggerAurora(name);
 				case 'starfield':
@@ -2709,6 +2769,36 @@
 					this.values.lighter_gain = 1;
 				}
 			}
+			if (this.kind === 'burning-trees') {
+				this._stepBurningTreesChar();
+				if (!this.timers.ignite || this.timers.ignite <= 0) {
+					this.values.ignite_gain = 0;
+					this.values.ignite_total = 0;
+					this.values.ignite_center = 0;
+					this.values.ignite_span = 0;
+					this.values.ignite_seed = 0;
+				}
+				if (!this.timers.flare || this.timers.flare <= 0) {
+					this.values.flare_gain = 1;
+				}
+				if (!this.timers.lull || this.timers.lull <= 0) {
+					this.values.lull_gain = 1;
+				}
+				if (!this.timers.intro || this.timers.intro <= 0) {
+					delete this.values.intro_total;
+				}
+				if (!this.timers.ending || this.timers.ending <= 0) {
+					delete this.values.ending_total;
+				}
+				if (this.timers.ending > 0) {
+					const treeCount = Math.max(1, Math.round(this.cfg.tree_count));
+					for (let i = 0; i < treeCount; i++) {
+						const key = `char_${i}`;
+						if ((this.values[key] || 0) <= 0) continue;
+						this.values[key] = clamp01(this.values[key] + this.cfg.char * 0.004);
+					}
+				}
+			}
 		}
 
 		render(ctx, canvasW, canvasH, opts) {
@@ -2733,6 +2823,8 @@
 					return this._renderTrain(ctx, canvasW, canvasH, opts);
 				case 'mysterious-man':
 					return this._renderMysteriousMan(ctx, canvasW, canvasH, opts);
+				case 'burning-trees':
+					return this._renderBurningTrees(ctx, canvasW, canvasH, opts);
 				case 'aurora':
 					return this._renderAurora(ctx, canvasW, canvasH, opts);
 				case 'starfield':
@@ -3278,6 +3370,73 @@
 			return false;
 		}
 
+		_triggerBurningTrees(name) {
+			const rng = this._eventRng(name.length + 133);
+			switch (name) {
+				case 'ignite': {
+					this.timers.flare = 0;
+					this.timers.lull = 0;
+					this.timers.ignite = jitterInt(rng, this.cfg.ignite_dur, 0.3);
+					this.values.flare_gain = 1;
+					this.values.lull_gain = 1;
+					this.values.ignite_gain = this.cfg.flame * (0.95 + rng() * 0.45);
+					this.values.ignite_total = this.timers.ignite;
+					const treeCount = Math.max(1, Math.round(this.cfg.tree_count));
+					this.values.ignite_center = Math.floor(rng() * treeCount);
+					const span = Math.max(0.75, this.cfg.ignite_span * (0.7 + rng() * 0.7));
+					this.values.ignite_span = Math.min(Math.max(1, treeCount - 1), span);
+					this.values.ignite_seed = rng() * 1000;
+					return true;
+				}
+				case 'flare':
+					if (!this.timers.ignite || this.timers.ignite <= 0) this._triggerBurningTrees('ignite');
+					this.timers.lull = 0;
+					this.timers.flare = jitterInt(rng, this.cfg.flare_dur, 0.3);
+					this.values.lull_gain = 1;
+					this.values.flare_gain = this.cfg.flare_mult * (0.85 + rng() * 0.35);
+					return true;
+				case 'lull':
+					if (!this.timers.ignite || this.timers.ignite <= 0) this._triggerBurningTrees('ignite');
+					this.timers.flare = 0;
+					this.timers.lull = jitterInt(rng, this.cfg.lull_dur, 0.3);
+					this.values.flare_gain = 1;
+					this.values.lull_gain = Math.max(0.15, this.cfg.lull_mult * (0.85 + rng() * 0.25));
+					return true;
+				case 'intro':
+					this.timers.ignite = 0;
+					this.timers.flare = 0;
+					this.timers.lull = 0;
+					this.timers.ending = 0;
+					this.values.ignite_gain = 0;
+					this.values.ignite_total = 0;
+					this.values.ignite_center = 0;
+					this.values.ignite_span = 0;
+					this.values.ignite_seed = 0;
+					this.values.flare_gain = 1;
+					this.values.lull_gain = 1;
+					this._clearBurningTreesChar();
+					this.timers.intro = Math.max(1, Math.round(this.cfg.intro_dur));
+					this.values.intro_total = this.timers.intro;
+					return true;
+				case 'ending':
+					this.timers.intro = 0;
+					this.timers.ignite = 0;
+					this.timers.flare = 0;
+					this.timers.lull = 0;
+					this.values.ignite_gain = 0;
+					this.values.ignite_total = 0;
+					this.values.ignite_center = 0;
+					this.values.ignite_span = 0;
+					this.values.ignite_seed = 0;
+					this.values.flare_gain = 1;
+					this.values.lull_gain = 1;
+					this.timers.ending = Math.max(1, Math.round(this.cfg.ending_dur + Math.max(0, this.cfg.ending_linger)));
+					this.values.ending_total = this.timers.ending;
+					return true;
+			}
+			return false;
+		}
+
 		_triggerAurora(name) {
 			const rng = this._eventRng(name.length + 53);
 			switch (name) {
@@ -3591,6 +3750,59 @@
 				level *= 1 - (1 - this.cfg.ending_shadow) * progress;
 			}
 			return Math.max(0.03, level);
+		}
+
+		_clearBurningTreesChar() {
+			const limit = Math.max(32, Math.round(this.cfg.tree_count || 0) + 4);
+			for (let i = 0; i < limit; i++) delete this.values[`char_${i}`];
+		}
+
+		_stepBurningTreesChar() {
+			if (!this.timers.ignite || this.timers.ignite <= 0) return;
+			const treeCount = Math.max(1, Math.round(this.cfg.tree_count));
+			const total = Math.max(1, this.values.ignite_total || 0);
+			const progress = clamp01(1 - this.timers.ignite / total);
+			const center = this.values.ignite_center || 0;
+			const span = Math.max(0.75, this.values.ignite_span || this.cfg.ignite_span);
+			const fireGain = this.values.ignite_gain > 0 ? this.values.ignite_gain : this.cfg.flame;
+			let mod = 1;
+			if (this.timers.flare > 0) {
+				const gain = this.values.flare_gain > 0 ? this.values.flare_gain : this.cfg.flare_mult;
+				mod *= 1 + Math.max(0, gain - 1) * 0.55;
+			}
+			if (this.timers.lull > 0) {
+				const gain = this.values.lull_gain > 0 ? this.values.lull_gain : this.cfg.lull_mult;
+				mod *= Math.max(0.18, gain);
+			}
+			const ramp = 0.45 + 0.55 * Math.sin(progress * Math.PI);
+			const reach = span + this.cfg.spread * (0.15 + progress * 0.55);
+			for (let i = 0; i < treeCount; i++) {
+				const dist = Math.abs(i - center);
+				let influence = 1 - dist / Math.max(1, reach + 0.75);
+				if (influence <= 0) continue;
+				influence = Math.pow(influence, 0.72);
+				const delta = this.cfg.char * 0.022 * (0.55 + fireGain * 1.6) * mod * ramp * influence;
+				const key = `char_${i}`;
+				this.values[key] = clamp01((this.values[key] || 0) + delta);
+			}
+		}
+
+		_sceneLevelBurningTrees() {
+			let level = 1;
+			if (this.timers.ignite > 0) level *= 0.72 + (this.values.ignite_gain || this.cfg.flame) * 1.6;
+			if (this.timers.flare > 0) level *= this.values.flare_gain || this.cfg.flare_mult;
+			if (this.timers.lull > 0) level *= this.values.lull_gain || this.cfg.lull_mult;
+			if (this.timers.intro > 0) {
+				const total = this.values.intro_total || this.cfg.intro_dur;
+				const progress = this._phaseProgress(total, this.timers.intro);
+				level *= this.cfg.intro_growth + (1 - this.cfg.intro_growth) * progress;
+			}
+			if (this.timers.ending > 0) {
+				const total = this.values.ending_total || (this.cfg.ending_dur + this.cfg.ending_linger);
+				const progress = this._phaseProgress(total, this.timers.ending);
+				level *= 1 - (1 - this.cfg.ending_ash) * progress;
+			}
+			return Math.max(0.04, level);
 		}
 
 		_renderSnow(ctx, canvasW, canvasH, opts) {
@@ -5178,6 +5390,217 @@
 			}
 		}
 
+		_renderBurningTrees(ctx, canvasW, canvasH, opts) {
+			opts = opts || {};
+			if (opts.transparent) {
+				ctx.clearRect(0, 0, canvasW, canvasH);
+			} else {
+				const skyTop = hslToRGB((this.cfg.hue - 34 + 360) % 360, clamp01(this.cfg.sat * 0.28), clamp01(this.cfg.lmin * 0.45));
+				const skyMid = hslToRGB((this.cfg.hue - 16 + 360) % 360, clamp01(this.cfg.sat * 0.14), clamp01(this.cfg.lmin + (this.cfg.lmax - this.cfg.lmin) * 0.09));
+				const skyLow = hslToRGB(22, clamp01(this.cfg.sat * 0.24), clamp01(this.cfg.lmin + (this.cfg.lmax - this.cfg.lmin) * 0.18));
+				const bg = ctx.createLinearGradient(0, 0, 0, canvasH);
+				bg.addColorStop(0, `rgb(${skyTop.r},${skyTop.g},${skyTop.b})`);
+				bg.addColorStop(0.62, `rgb(${skyMid.r},${skyMid.g},${skyMid.b})`);
+				bg.addColorStop(1, `rgb(${skyLow.r},${skyLow.g},${skyLow.b})`);
+				ctx.fillStyle = bg;
+				ctx.fillRect(0, 0, canvasW, canvasH);
+			}
+
+			const sx = canvasW / this.w;
+			const sy = canvasH / this.h;
+			const ceilSx = Math.ceil(sx);
+			const ceilSy = Math.ceil(sy);
+			const treeCount = Math.max(1, Math.round(this.cfg.tree_count));
+			const sceneLevel = this._sceneLevelBurningTrees();
+			const groundRow = Math.max(10, Math.min(this.h - 6, Math.floor(this.h * this.cfg.horizon)));
+			const activeTotal = Math.max(1, this.values.ignite_total || this.cfg.ignite_dur);
+			const activeProgress = this.timers.ignite > 0 ? clamp01(1 - this.timers.ignite / activeTotal) : 0;
+			const activeCenter = Number.isFinite(this.values.ignite_center) ? this.values.ignite_center : Math.floor(treeCount / 2);
+			const activeSpan = Math.max(0.75, this.values.ignite_span || this.cfg.ignite_span);
+			const igniteSeed = Math.floor((this.values.ignite_seed || 0) * 10);
+			const flareBoost = this.timers.flare > 0 ? (this.values.flare_gain || this.cfg.flare_mult) : 1;
+			const lullClamp = this.timers.lull > 0 ? Math.max(0.18, this.values.lull_gain || this.cfg.lull_mult) : 1;
+			const focusX = ((activeCenter + 1) / (treeCount + 1)) * this.w;
+
+			const horizonGlow = ctx.createRadialGradient(focusX * sx, Math.floor((groundRow - 4) * sy), 0, focusX * sx, Math.floor((groundRow - 4) * sy), Math.max(42, 32 * sx));
+			horizonGlow.addColorStop(0, `rgba(255, 138, 72, ${clamp01(0.08 + this.cfg.flame * 0.34 * sceneLevel)})`);
+			horizonGlow.addColorStop(1, 'rgba(255, 138, 72, 0)');
+			ctx.fillStyle = horizonGlow;
+			ctx.fillRect(Math.floor((focusX - 24) * sx), Math.floor((groundRow - 18) * sy), Math.ceil(48 * sx), Math.ceil(28 * sy));
+
+			const smokeWash = ctx.createLinearGradient(0, Math.floor((groundRow - 20) * sy), 0, Math.floor((groundRow + 2) * sy));
+			smokeWash.addColorStop(0, 'rgba(36, 32, 28, 0)');
+			smokeWash.addColorStop(1, `rgba(36, 32, 28, ${clamp01(0.16 + this.cfg.smoke * 0.32 * sceneLevel)})`);
+			ctx.fillStyle = smokeWash;
+			ctx.fillRect(0, Math.floor((groundRow - 20) * sy), canvasW, Math.ceil(24 * sy));
+
+			const ridgeColor = hslToRGB((this.cfg.hue + 18) % 360, clamp01(this.cfg.sat * 0.18), clamp01(this.cfg.lmin * 0.85));
+			const ridgePoints = [];
+			const ridgeSegments = 7;
+			for (let i = 0; i <= ridgeSegments; i++) {
+				ridgePoints.push(groundRow - Math.floor(this._hash(35100 + i) * 3) - Math.floor((0.5 + 0.5 * Math.sin(i * 1.1 + this._hash(35200 + i) * 3.2)) * 2));
+			}
+			ctx.fillStyle = `rgb(${ridgeColor.r},${ridgeColor.g},${ridgeColor.b})`;
+			ctx.beginPath();
+			ctx.moveTo(0, canvasH);
+			for (let x = 0; x < this.w; x++) {
+				const pos = (x / Math.max(1, this.w - 1)) * ridgeSegments;
+				const idx = Math.min(ridgeSegments - 1, Math.floor(pos));
+				const frac = pos - idx;
+				const eased = frac * frac * (3 - 2 * frac);
+				const row = ridgePoints[idx] + (ridgePoints[idx + 1] - ridgePoints[idx]) * eased;
+				ctx.lineTo(Math.floor(x * sx), Math.floor(row * sy));
+			}
+			ctx.lineTo(canvasW, canvasH);
+			ctx.closePath();
+			ctx.fill();
+
+			const fieldColor = hslToRGB((this.cfg.hue + 6) % 360, clamp01(this.cfg.sat * 0.22), clamp01(this.cfg.lmin * 1.05));
+			this._fillCell(ctx, sx, sy, ceilSx, ceilSy, 0, groundRow, this.w, this.h - groundRow, `rgb(${fieldColor.r},${fieldColor.g},${fieldColor.b})`, 1);
+
+			const healthyLeaf = hslToRGB((this.cfg.hue - 6 + 360) % 360, clamp01(this.cfg.sat * 0.5), clamp01(this.cfg.lmin + (this.cfg.lmax - this.cfg.lmin) * 0.24));
+			const healthyShade = hslToRGB((this.cfg.hue - 14 + 360) % 360, clamp01(this.cfg.sat * 0.38), clamp01(this.cfg.lmin + (this.cfg.lmax - this.cfg.lmin) * 0.14));
+			const trunkColor = hslToRGB((this.cfg.hue + 26) % 360, clamp01(this.cfg.sat * 0.18), clamp01(this.cfg.lmin * 0.72));
+			const charColor = hslToRGB(18, 0.08, clamp01(this.cfg.lmin * 0.52));
+			const emberColor = hslToRGB(18, 0.88, clamp01(this.cfg.lmax * 0.96));
+			const emberCore = hslToRGB(34, 0.8, clamp01(this.cfg.lmax));
+			const smokeTint = hslToRGB((this.cfg.hue + this.cfg.hue_sp * 0.5) % 360, clamp01(this.cfg.sat * 0.12), clamp01(this.cfg.lmin + (this.cfg.lmax - this.cfg.lmin) * 0.48));
+			const ashTint = hslToRGB((this.cfg.hue + 26) % 360, clamp01(this.cfg.sat * 0.06), clamp01(this.cfg.lmin + (this.cfg.lmax - this.cfg.lmin) * 0.62));
+			const spacing = this.w / (treeCount + 1);
+			const sources = [];
+
+			for (let i = 0; i < treeCount; i++) {
+				const x = Math.round((i + 1) * spacing + (this._hash(35300 + i) - 0.5) * spacing * 0.26);
+				const baseY = groundRow - 1 - Math.floor(this._hash(35400 + i) * 2);
+				const treeH = Math.max(8, Math.round(this.cfg.tree_height * (0.78 + this._hash(35500 + i) * 0.42)));
+				const trunkH = Math.max(3, Math.round(treeH * (0.28 + this._hash(35600 + i) * 0.08)));
+				const char = clamp01(this.values[`char_${i}`] || 0);
+				let heat = 0;
+				if (this.timers.ignite > 0) {
+					const dist = Math.abs(i - activeCenter);
+					let influence = 1 - dist / Math.max(1, activeSpan + this.cfg.spread * (0.15 + activeProgress * 0.55) + 0.75);
+					if (influence > 0) {
+						influence = Math.pow(influence, 0.72);
+						const fireBase = 0.45 + (this.values.ignite_gain || this.cfg.flame) * 2.2;
+						heat = clamp01((0.22 + influence * 0.78) * fireBase * (0.72 + 0.28 * Math.sin(activeProgress * Math.PI)) * flareBoost * lullClamp);
+					}
+				}
+				const crownScale = 1 - char * 0.55;
+				const crownH = Math.max(3, Math.round(treeH * (0.5 + this.cfg.canopy * 0.45) * crownScale));
+				const crownHalf = Math.max(2, Math.round((1.5 + this.cfg.canopy * 3.2) * (treeH / 10) * (1 - char * 0.38)));
+				const shadowWidth = Math.max(2, crownHalf * 2 + 1);
+				this._fillCell(ctx, sx, sy, ceilSx, ceilSy, x - Math.floor(shadowWidth / 2), baseY + 1, shadowWidth, 1, `rgb(${charColor.r},${charColor.g},${charColor.b})`, clamp01(0.14 + char * 0.18));
+
+				const trunkDrawH = Math.max(2, Math.round(trunkH * (1 - Math.min(0.7, char * 0.45))));
+				for (let row = 0; row < trunkDrawH; row++) {
+					const y = baseY - row;
+					const color = char > 0.45 ? charColor : trunkColor;
+					const alpha = clamp01(0.72 + char * 0.18);
+					this._fillCell(ctx, sx, sy, ceilSx, ceilSy, x, y, 1 + (row < trunkDrawH * 0.22 ? 1 : 0), 1, `rgb(${color.r},${color.g},${color.b})`, alpha);
+				}
+
+				for (let row = 0; row < crownH; row++) {
+					const progress = row / Math.max(1, crownH - 1);
+					const width = Math.max(1, Math.round(crownHalf * (1 - progress * 0.72))) + (row < crownH * 0.3 ? 1 : 0);
+					const y = baseY - trunkDrawH - crownH + row + 1;
+					for (let dx = -width; dx <= width; dx++) {
+						const edge = 1 - Math.abs(dx) / Math.max(1, width);
+						const burnMask = clamp01(char * 0.78 + heat * (0.1 + edge * 0.42) * (1 - progress * 0.42));
+						if (burnMask > 0.88 && ((dx + row + i) % 3 === 0)) continue;
+						const baseColor = burnMask > 0.48
+							? charColor
+							: (row < crownH * 0.45 ? healthyLeaf : healthyShade);
+						this._fillCell(ctx, sx, sy, ceilSx, ceilSy, x + dx, y, 1, 1, `rgb(${baseColor.r},${baseColor.g},${baseColor.b})`, clamp01(0.7 + edge * 0.22));
+						const flameHere = heat > 0.08 && row >= crownH * 0.14 && edge > 0.22 && ((dx + row + this.tick + i) % 2 === 0);
+						if (flameHere) {
+							const flameAlpha = clamp01((0.18 + this.cfg.flame * 0.42) * heat * sceneLevel * (0.9 - progress * 0.3));
+							const flameColor = row < crownH * 0.36 ? emberCore : emberColor;
+							this._fillCell(ctx, sx, sy, ceilSx, ceilSy, x + dx, y, 1, 1, `rgb(${flameColor.r},${flameColor.g},${flameColor.b})`, flameAlpha);
+							if (flameAlpha > 0.16) {
+								this._fillCell(ctx, sx, sy, ceilSx, ceilSy, x + dx, y - 1, 1, 1, `rgb(${emberCore.r},${emberCore.g},${emberCore.b})`, flameAlpha * 0.65);
+							}
+							if (progress > 0.18 && this._hash(35700 + i * 23 + row * 7 + dx + igniteSeed) > 0.5) {
+								this._fillCell(ctx, sx, sy, ceilSx, ceilSy, x + dx, y - 1, 1, 1, `rgb(${emberCore.r},${emberCore.g},${emberCore.b})`, flameAlpha * 0.55);
+							}
+						}
+					}
+				}
+
+				if (heat > 0.08) {
+					const glow = ctx.createRadialGradient(x * sx, (baseY - crownH * 0.35) * sy, 0, x * sx, (baseY - crownH * 0.35) * sy, Math.max(16, 9 * sx));
+					glow.addColorStop(0, `rgba(255, 152, 74, ${clamp01(0.08 + heat * 0.22)})`);
+					glow.addColorStop(1, 'rgba(255, 152, 74, 0)');
+					ctx.fillStyle = glow;
+					ctx.fillRect(Math.floor((x - 6) * sx), Math.floor((baseY - crownH - 4) * sy), Math.ceil(12 * sx), Math.ceil((crownH + 8) * sy));
+
+					const tongues = 3 + Math.round(heat * 4);
+					for (let tongue = 0; tongue < tongues; tongue++) {
+						const offset = -1 + tongue - Math.floor(tongues / 2);
+						const flicker = this._hash(36500 + i * 17 + tongue * 5 + igniteSeed);
+						const flameH = 1 + Math.floor(flicker * (2 + heat * 3));
+						const flameY = baseY - Math.floor(1 + flicker * (2 + heat * 3));
+						const flameColor = tongue % 2 === 0 ? emberCore : emberColor;
+						this._fillCell(ctx, sx, sy, ceilSx, ceilSy, x + offset, flameY - flameH + 1, 1, flameH, `rgb(${flameColor.r},${flameColor.g},${flameColor.b})`, clamp01(0.3 + heat * 0.5));
+					}
+				}
+
+				if (char > 0.58 || this.timers.ending > 0) {
+					this._fillCell(ctx, sx, sy, ceilSx, ceilSy, x - 1, baseY - Math.min(2, trunkDrawH - 1), 3, 1, `rgb(${charColor.r},${charColor.g},${charColor.b})`, clamp01(0.72 + char * 0.16));
+				}
+
+				sources.push({
+					x,
+					y: baseY - trunkDrawH - Math.max(2, Math.round(crownH * 0.42)),
+					heat,
+					char,
+				});
+			}
+
+			for (const source of sources) {
+				const sourceStrength = Math.max(source.heat, source.char * 0.65);
+				if (sourceStrength <= 0.04) continue;
+				const puffCount = Math.max(2, Math.round((2 + this.cfg.smoke * 8) * (0.45 + sourceStrength * 1.4)));
+				for (let i = 0; i < puffCount; i++) {
+					const life = 34 + Math.floor(this._hash(35800 + source.x * 11 + i) * 34);
+					const age = positiveMod(this.tick + i * 9 + Math.floor(source.x * 2), life);
+					const t = age / Math.max(1, life - 1);
+					const drift = (this._hash(35900 + source.x * 13 + i) * 2 - 1) * (0.8 + t * 4.5);
+					const lift = t * (5 + this.cfg.smoke * 16 + sourceStrength * 7);
+					const x = Math.round(source.x + drift + Math.sin(this.tick * 0.03 + i + source.x * 0.08) * (0.4 + t * 1.8));
+					const y = Math.round(source.y - lift);
+					const alpha = clamp01((0.03 + this.cfg.smoke * 0.18) * (1 - t) * (0.55 + sourceStrength) * sceneLevel);
+					const size = 1 + Math.floor(this._hash(36000 + source.x * 17 + i) * (1 + t * 3));
+					this._fillCell(ctx, sx, sy, ceilSx, ceilSy, x, y, size, 1 + (t > 0.45 ? 1 : 0), `rgb(${smokeTint.r},${smokeTint.g},${smokeTint.b})`, alpha);
+				}
+			}
+
+			for (const source of sources) {
+				if (source.heat <= 0.06) continue;
+				const emberCount = Math.max(2, Math.round(this.cfg.embers * 18 + source.heat * 6));
+				for (let i = 0; i < emberCount; i++) {
+					const life = 24 + Math.floor(this._hash(36100 + source.x * 19 + i) * 26);
+					const age = positiveMod(this.tick + i * 7 + igniteSeed, life);
+					const t = age / Math.max(1, life - 1);
+					const x = Math.round(source.x + (this._hash(36200 + source.x * 23 + i) * 2 - 1) * (1 + t * 4));
+					const y = Math.round(source.y - t * (3 + source.heat * 8));
+					const alpha = clamp01((0.08 + this.cfg.embers * 0.34) * (1 - t) * source.heat);
+					const color = t < 0.35 ? emberCore : emberColor;
+					this._fillCell(ctx, sx, sy, ceilSx, ceilSy, x, y, 1, 1, `rgb(${color.r},${color.g},${color.b})`, alpha);
+				}
+			}
+
+			if (this.timers.ending > 0 || this.timers.lull > 0) {
+				const ashCount = Math.max(8, Math.round(this.w * (0.03 + this.cfg.ending_ash * 0.08)));
+				for (let i = 0; i < ashCount; i++) {
+					const x = Math.round(this._hash(36300 + i) * this.w);
+					const drop = positiveMod(this.tick * (0.18 + this._hash(36400 + i) * 0.22) + i * 2.3, Math.max(8, groundRow - 8));
+					const y = Math.round(Math.max(4, groundRow - 14 + drop));
+					const alpha = clamp01(0.03 + this.cfg.ending_ash * 0.18);
+					this._fillCell(ctx, sx, sy, ceilSx, ceilSy, x, y, 1, 1, `rgb(${ashTint.r},${ashTint.g},${ashTint.b})`, alpha);
+				}
+			}
+		}
+
 		_renderAurora(ctx, canvasW, canvasH, opts) {
 			opts = opts || {};
 			if (opts.transparent) {
@@ -5366,6 +5789,12 @@
 		}
 	}
 
+	class BurningTrees extends ProceduralScene {
+		constructor(w, h, cfg, seed) {
+			super('burning-trees', w, h, cfg, seed);
+		}
+	}
+
 	class Aurora extends ProceduralScene {
 		constructor(w, h, cfg, seed) {
 			super('aurora', w, h, cfg, seed);
@@ -5424,7 +5853,7 @@
 	// server's snapshot payload — the client looks up the constructor here
 	// by name so new effects just register themselves and work without
 	// client-side changes.
-	const effects = { rain: Rain, dust: Dust, fireflies: Fireflies, waterfall: Waterfall, 'wheat-field': WheatField, beach: Beach, campfire: Campfire, windmill: Windmill, lighthouse: Lighthouse, rowboat: Rowboat, underwater: Underwater, volcano: Volcano, train: Train, 'mysterious-man': MysteriousMan, aurora: Aurora, snow: Snow, 'autumn-leaves': AutumnLeaves, starfield: Starfield };
+	const effects = { rain: Rain, dust: Dust, fireflies: Fireflies, waterfall: Waterfall, 'wheat-field': WheatField, beach: Beach, campfire: Campfire, windmill: Windmill, lighthouse: Lighthouse, rowboat: Rowboat, underwater: Underwater, volcano: Volcano, train: Train, 'mysterious-man': MysteriousMan, 'burning-trees': BurningTrees, aurora: Aurora, snow: Snow, 'autumn-leaves': AutumnLeaves, starfield: Starfield };
 	const presets = {
 		'wheat-field': [
 			{
@@ -6297,6 +6726,105 @@
 				},
 			},
 		],
+		'burning-trees': [
+			{
+				key: 'single-ignition',
+				label: 'single ignition',
+				config: {
+					intro_growth: 0.12,
+					ending_ash: 0.14,
+					horizon: 0.84,
+					tree_count: 9,
+					tree_height: 12,
+					canopy: 0.82,
+					spread: 0.9,
+					flame: 0.22,
+					embers: 0.12,
+					smoke: 0.12,
+					char: 0.38,
+					hue: 118,
+					hue_sp: 14,
+					sat: 0.46,
+					lmin: 0.06,
+					lmax: 0.82,
+					ignite_p: 0.0011,
+				},
+			},
+			{
+				key: 'slow-spread',
+				label: 'slow spread',
+				config: {
+					intro_growth: 0.14,
+					ending_ash: 0.12,
+					horizon: 0.84,
+					tree_count: 10,
+					tree_height: 13,
+					canopy: 0.78,
+					spread: 1.35,
+					flame: 0.26,
+					embers: 0.16,
+					smoke: 0.16,
+					char: 0.42,
+					hue: 112,
+					hue_sp: 20,
+					sat: 0.48,
+					lmin: 0.06,
+					lmax: 0.88,
+					ignite_p: 0.0013,
+					lull_p: 0.0007,
+				},
+			},
+			{
+				key: 'smoldering-line',
+				label: 'smoldering line',
+				config: {
+					intro_growth: 0.1,
+					ending_ash: 0.18,
+					horizon: 0.85,
+					tree_count: 11,
+					tree_height: 11.5,
+					canopy: 0.68,
+					spread: 1.1,
+					flame: 0.18,
+					embers: 0.24,
+					smoke: 0.24,
+					char: 0.56,
+					hue: 104,
+					hue_sp: 18,
+					sat: 0.38,
+					lmin: 0.05,
+					lmax: 0.8,
+					ignite_p: 0.001,
+					lull_p: 0.0012,
+					lull_mult: 0.42,
+				},
+			},
+			{
+				key: 'active-burn',
+				label: 'active burn',
+				config: {
+					intro_growth: 0.16,
+					ending_ash: 0.1,
+					horizon: 0.83,
+					tree_count: 12,
+					tree_height: 14,
+					canopy: 0.84,
+					spread: 1.75,
+					flame: 0.34,
+					embers: 0.24,
+					smoke: 0.2,
+					char: 0.48,
+					hue: 108,
+					hue_sp: 24,
+					sat: 0.54,
+					lmin: 0.06,
+					lmax: 0.92,
+					ignite_p: 0.0016,
+					flare_p: 0.0012,
+					flare_mult: 2.1,
+				},
+			},
+		],
 		aurora: [
 			{
 				key: 'green-veil',
@@ -6808,5 +7336,5 @@
 		],
 	};
 
-	global.AmbienceSim = { Rain, Dust, Fireflies, Waterfall, WheatField, Beach, Campfire, Windmill, Lighthouse, Rowboat, Underwater, Volcano, Train, MysteriousMan, Aurora, AutumnLeaves, Snow, Starfield, subscribe, applyDefaults, hslToRGB, effects, presets };
+	global.AmbienceSim = { Rain, Dust, Fireflies, Waterfall, WheatField, Beach, Campfire, Windmill, Lighthouse, Rowboat, Underwater, Volcano, Train, MysteriousMan, BurningTrees, Aurora, AutumnLeaves, Snow, Starfield, subscribe, applyDefaults, hslToRGB, effects, presets };
 })(window);

--- a/sim/procedural.go
+++ b/sim/procedural.go
@@ -446,6 +446,37 @@ var mysteriousManDefaults = ProceduralConfig{
 	"lighter_flick_mult": 2.25,
 }
 
+var burningTreesDefaults = ProceduralConfig{
+	"intro_dur":     55,
+	"intro_growth":  0.14,
+	"ending_dur":    72,
+	"ending_linger": 22,
+	"ending_ash":    0.10,
+	"horizon":       0.84,
+	"tree_count":    10.0,
+	"tree_height":   13.0,
+	"canopy":        0.78,
+	"spread":        1.35,
+	"flame":         0.28,
+	"embers":        0.18,
+	"smoke":         0.16,
+	"char":          0.42,
+	"hue":           112,
+	"hue_sp":        20,
+	"sat":           0.48,
+	"lmin":          0.06,
+	"lmax":          0.88,
+	"ignite_p":      0.0,
+	"flare_p":       0.0,
+	"lull_p":        0.0,
+	"ignite_dur":    76,
+	"ignite_span":   1.60,
+	"flare_dur":     38,
+	"flare_mult":    1.85,
+	"lull_dur":      54,
+	"lull_mult":     0.55,
+}
+
 func SnowSchema() EffectSchema {
 	return EffectSchema{
 		Name: "snow",
@@ -1274,6 +1305,70 @@ func MysteriousManSchema() EffectSchema {
 	}
 }
 
+func BurningTreesSchema() EffectSchema {
+	return EffectSchema{
+		Name: "burning-trees",
+		Knobs: []Knob{
+			{Key: "intro_dur", Label: "intro dur", Slot: SlotSpawn, Group: "introduction", Type: KnobInt, Min: 10, Max: 220, Step: 5, Default: 55, Trigger: "intro",
+				Description: "Ticks spent growing the grove into view before the first ignition takes over."},
+			{Key: "intro_growth", Label: "intro growth", Slot: SlotSpawn, Group: "introduction", Type: KnobFloat, Min: 0.04, Max: 0.5, Step: 0.01, Default: 0.14,
+				Description: "Starting fraction of the full grove height and canopy mass during the intro."},
+			{Key: "ending_dur", Label: "ending dur", Slot: SlotEnd, Group: "ending", Type: KnobInt, Min: 10, Max: 240, Step: 5, Default: 72, Trigger: "ending",
+				Description: "Ticks spent cooling the active flames down toward embers and ash."},
+			{Key: "ending_linger", Label: "ending linger", Slot: SlotEnd, Group: "ending", Type: KnobInt, Min: 0, Max: 180, Step: 5, Default: 22,
+				Description: "Extra quiet ticks for the last smoke and ember glow to settle."},
+			{Key: "ending_ash", Label: "ending ash", Slot: SlotEnd, Group: "ending", Type: KnobFloat, Min: 0.02, Max: 0.4, Step: 0.01, Default: 0.10,
+				Description: "Residual ash and ember activity remaining near the end of the outro."},
+			{Key: "horizon", Label: "ground row", Slot: SlotLever, Group: "grove", Type: KnobFloat, Min: 0.72, Max: 0.9, Step: 0.01, Default: 0.84,
+				Description: "Height of the ground line where the tree row sits."},
+			{Key: "tree_count", Label: "tree count", Slot: SlotLever, Group: "grove", Type: KnobInt, Min: 5, Max: 16, Step: 1, Default: 10,
+				Description: "Number of trees in the grove row."},
+			{Key: "tree_height", Label: "tree height", Slot: SlotLever, Group: "grove", Type: KnobFloat, Min: 7, Max: 20, Step: 0.5, Default: 13,
+				Description: "Typical tree height above the ground row."},
+			{Key: "canopy", Label: "canopy", Slot: SlotLever, Group: "grove", Type: KnobFloat, Min: 0.2, Max: 1, Step: 0.01, Default: 0.78,
+				Description: "Density and fullness of the tree canopies."},
+			{Key: "spread", Label: "spread", Slot: SlotLever, Group: "fire", Type: KnobFloat, Min: 0.5, Max: 3, Step: 0.05, Default: 1.35,
+				Description: "How readily a burn event spreads to neighboring trees."},
+			{Key: "flame", Label: "flame", Slot: SlotLever, Group: "fire", Type: KnobFloat, Min: 0.05, Max: 0.8, Step: 0.01, Default: 0.28,
+				Description: "Baseline visible flame activity on the active burning trees."},
+			{Key: "embers", Label: "embers", Slot: SlotLever, Group: "fire", Type: KnobFloat, Min: 0.02, Max: 0.6, Step: 0.01, Default: 0.18,
+				Description: "Amount of ember flecks floating above the fire line."},
+			{Key: "smoke", Label: "smoke", Slot: SlotLever, Group: "fire", Type: KnobFloat, Min: 0.02, Max: 0.6, Step: 0.01, Default: 0.16,
+				Description: "Amount of smoke drifting up from the burning section of the grove."},
+			{Key: "char", Label: "char", Slot: SlotLever, Group: "fire", Type: KnobFloat, Min: 0.1, Max: 1, Step: 0.01, Default: 0.42,
+				Description: "How quickly burned trees darken into charred silhouettes."},
+			{Key: "hue", Label: "hue", Slot: SlotLever, Group: "palette", Type: KnobFloat, Min: 70, Max: 180, Step: 1, Default: 112,
+				Description: "Base grove hue. Lower values warm toward dry grass; higher values cool toward pine green."},
+			{Key: "hue_sp", Label: "hue spread", Slot: SlotLever, Group: "palette", Type: KnobFloat, Min: 0, Max: 40, Step: 1, Default: 20,
+				Description: "Variation between healthy foliage, smoke tint, and ember-adjacent glow."},
+			{Key: "sat", Label: "saturation", Slot: SlotLever, Group: "palette", Type: KnobFloat, Min: 0.08, Max: 0.8, Step: 0.01, Default: 0.48,
+				Description: "Overall scene saturation."},
+			{Key: "lmin", Label: "light min", Slot: SlotLever, Group: "palette", Type: KnobFloat, Min: 0.03, Max: 0.4, Step: 0.01, Default: 0.06,
+				Description: "Minimum lightness used for char, ground, and deep background tones."},
+			{Key: "lmax", Label: "light max", Slot: SlotLever, Group: "palette", Type: KnobFloat, Min: 0.3, Max: 1, Step: 0.01, Default: 0.88,
+				Description: "Maximum lightness used for the hottest flames and ember highlights."},
+			{Key: "ignite_p", Label: "ignite", Slot: SlotEvent, Type: KnobFloat, Min: 0, Max: 0.02, Step: 0.0005, Default: 0, Trigger: "ignite",
+				Description: "Per-tick chance of a new localized ignition starting in the grove."},
+			{Key: "flare_p", Label: "flare", Slot: SlotEvent, Type: KnobFloat, Min: 0, Max: 0.02, Step: 0.0005, Default: 0, Trigger: "flare",
+				Description: "Per-tick chance of the active fire surging brighter for a short interval."},
+			{Key: "lull_p", Label: "lull", Slot: SlotEvent, Type: KnobFloat, Min: 0, Max: 0.02, Step: 0.0005, Default: 0, Trigger: "lull",
+				Description: "Per-tick chance of the active fire calming into a smokier lower-flame phase."},
+			{Key: "ignite_dur", Label: "ignite dur", Slot: SlotEventMod, Group: "ignite", Type: KnobInt, Min: 20, Max: 220, Step: 5, Default: 76,
+				Description: "Duration of the active ignition window before it settles back to aftermath."},
+			{Key: "ignite_span", Label: "ignite span", Slot: SlotEventMod, Group: "ignite", Type: KnobFloat, Min: 0.5, Max: 4, Step: 0.1, Default: 1.6,
+				Description: "Typical number of neighboring trees influenced by a single ignition."},
+			{Key: "flare_dur", Label: "flare dur", Slot: SlotEventMod, Group: "flare", Type: KnobInt, Min: 10, Max: 160, Step: 5, Default: 38,
+				Description: "Duration of the brighter flare window."},
+			{Key: "flare_mult", Label: "flare x", Slot: SlotEventMod, Group: "flare", Type: KnobFloat, Min: 1.05, Max: 3, Step: 0.05, Default: 1.85,
+				Description: "Flame and ember multiplier applied during a flare."},
+			{Key: "lull_dur", Label: "lull dur", Slot: SlotEventMod, Group: "lull", Type: KnobInt, Min: 10, Max: 180, Step: 5, Default: 54,
+				Description: "Duration of the quieter smoldering lull."},
+			{Key: "lull_mult", Label: "lull x", Slot: SlotEventMod, Group: "lull", Type: KnobFloat, Min: 0.1, Max: 1, Step: 0.05, Default: 0.55,
+				Description: "Flame multiplier applied while lull is active."},
+		},
+	}
+}
+
 func cloneProceduralConfig(src ProceduralConfig) ProceduralConfig {
 	if src == nil {
 		return ProceduralConfig{}
@@ -1342,6 +1437,8 @@ func proceduralDefaults(kind string) ProceduralConfig {
 		return cloneProceduralConfig(trainDefaults)
 	case "mysterious-man":
 		return cloneProceduralConfig(mysteriousManDefaults)
+	case "burning-trees":
+		return cloneProceduralConfig(burningTreesDefaults)
 	default:
 		return ProceduralConfig{}
 	}
@@ -2277,6 +2374,77 @@ func mergeProceduralDefaults(kind string, cfg ProceduralConfig) ProceduralConfig
 		if out["lighter_flick_mult"] <= 0 {
 			out["lighter_flick_mult"] = mysteriousManDefaults["lighter_flick_mult"]
 		}
+	case "burning-trees":
+		if out["intro_dur"] <= 0 {
+			out["intro_dur"] = burningTreesDefaults["intro_dur"]
+		}
+		out["intro_growth"] = clamp01(out["intro_growth"])
+		if out["ending_dur"] <= 0 {
+			out["ending_dur"] = burningTreesDefaults["ending_dur"]
+		}
+		if out["ending_linger"] < 0 {
+			out["ending_linger"] = 0
+		}
+		out["ending_ash"] = clamp01(out["ending_ash"])
+		if out["horizon"] <= 0 {
+			out["horizon"] = burningTreesDefaults["horizon"]
+		}
+		if out["tree_count"] < 1 {
+			out["tree_count"] = burningTreesDefaults["tree_count"]
+		}
+		if out["tree_height"] <= 0 {
+			out["tree_height"] = burningTreesDefaults["tree_height"]
+		}
+		out["canopy"] = clamp01(out["canopy"])
+		if out["spread"] <= 0 {
+			out["spread"] = burningTreesDefaults["spread"]
+		}
+		if out["flame"] <= 0 {
+			out["flame"] = burningTreesDefaults["flame"]
+		}
+		if out["embers"] <= 0 {
+			out["embers"] = burningTreesDefaults["embers"]
+		}
+		if out["smoke"] <= 0 {
+			out["smoke"] = burningTreesDefaults["smoke"]
+		}
+		out["char"] = clamp01(out["char"])
+		if out["hue"] <= 0 {
+			out["hue"] = burningTreesDefaults["hue"]
+		}
+		if out["hue_sp"] < 0 {
+			out["hue_sp"] = 0
+		}
+		if out["sat"] <= 0 {
+			out["sat"] = burningTreesDefaults["sat"]
+		}
+		if out["lmin"] <= 0 {
+			out["lmin"] = burningTreesDefaults["lmin"]
+		}
+		if out["lmax"] <= 0 {
+			out["lmax"] = burningTreesDefaults["lmax"]
+		}
+		if out["lmax"] < out["lmin"] {
+			out["lmin"], out["lmax"] = out["lmax"], out["lmin"]
+		}
+		if out["ignite_dur"] <= 0 {
+			out["ignite_dur"] = burningTreesDefaults["ignite_dur"]
+		}
+		if out["ignite_span"] <= 0 {
+			out["ignite_span"] = burningTreesDefaults["ignite_span"]
+		}
+		if out["flare_dur"] <= 0 {
+			out["flare_dur"] = burningTreesDefaults["flare_dur"]
+		}
+		if out["flare_mult"] <= 0 {
+			out["flare_mult"] = burningTreesDefaults["flare_mult"]
+		}
+		if out["lull_dur"] <= 0 {
+			out["lull_dur"] = burningTreesDefaults["lull_dur"]
+		}
+		if out["lull_mult"] <= 0 {
+			out["lull_mult"] = burningTreesDefaults["lull_mult"]
+		}
 	}
 	return out
 }
@@ -2651,6 +2819,24 @@ func (p *Procedural) TriggerEvent(name string) bool {
 			return false
 		}
 		return true
+	case "burning-trees":
+		switch name {
+		case "ignite":
+			p.startBurningTreesIgniteLocked("triggered")
+		case "flare":
+			p.startBurningTreesFlareLocked("triggered")
+		case "lull":
+			p.startBurningTreesLullLocked("triggered")
+		case "intro":
+			p.startBurningTreesIntroLocked()
+			p.appendLog("intro", fmt.Sprintf("started (dur=%d, growth=%.2f)", p.timers["intro"], p.cfg["intro_growth"]))
+		case "ending":
+			p.startBurningTreesEndingLocked()
+			p.appendLog("ending", fmt.Sprintf("started (fade=%d, linger=%d)", p.intCfg("ending_dur"), p.intCfg("ending_linger")))
+		default:
+			return false
+		}
+		return true
 	default:
 		return false
 	}
@@ -2714,6 +2900,8 @@ func (p *Procedural) Step() {
 		p.stepTrainLocked()
 	case "mysterious-man":
 		p.stepMysteriousManLocked()
+	case "burning-trees":
+		p.stepBurningTreesLocked()
 	}
 }
 
@@ -3791,5 +3979,177 @@ func (p *Procedural) stepMysteriousManLocked() {
 	}
 	if p.timers["lighter-flick"] <= 0 && p.cfg["lighter_flick_p"] > 0 && p.rng.Float64() < p.cfg["lighter_flick_p"] {
 		p.startMysteriousManLighterFlickLocked("started")
+	}
+}
+
+func (p *Procedural) clearBurningTreesCharLocked() {
+	limit := max(32, p.intCfg("tree_count")+4)
+	for i := 0; i < limit; i++ {
+		delete(p.values, fmt.Sprintf("char_%d", i))
+	}
+}
+
+func (p *Procedural) startBurningTreesIgniteLocked(verb string) {
+	p.timers["flare"] = 0
+	p.timers["lull"] = 0
+	p.timers["ignite"] = jitterInt(p.rng, p.intCfg("ignite_dur"), 0.3)
+	p.values["flare_gain"] = 1
+	p.values["lull_gain"] = 1
+	p.values["ignite_gain"] = p.cfg["flame"] * (0.95 + p.rng.Float64()*0.45)
+	p.values["ignite_total"] = float64(p.timers["ignite"])
+	treeCount := max(1, p.intCfg("tree_count"))
+	p.values["ignite_center"] = float64(p.rng.Intn(treeCount))
+	span := math.Max(0.75, p.cfg["ignite_span"]*(0.7+p.rng.Float64()*0.7))
+	p.values["ignite_span"] = math.Min(float64(max(1, treeCount-1)), span)
+	p.values["ignite_seed"] = p.rng.Float64() * 1000
+	p.appendLog("ignite", fmt.Sprintf("%s (dur=%d, tree=%d, span=%.1f)", verb, p.timers["ignite"], int(p.values["ignite_center"])+1, p.values["ignite_span"]))
+}
+
+func (p *Procedural) startBurningTreesFlareLocked(verb string) {
+	if p.timers["ignite"] <= 0 {
+		p.startBurningTreesIgniteLocked("kindled")
+	}
+	p.timers["lull"] = 0
+	p.timers["flare"] = jitterInt(p.rng, p.intCfg("flare_dur"), 0.3)
+	p.values["lull_gain"] = 1
+	p.values["flare_gain"] = p.cfg["flare_mult"] * (0.85 + p.rng.Float64()*0.35)
+	p.appendLog("flare", fmt.Sprintf("%s (dur=%d, x%.2f)", verb, p.timers["flare"], p.values["flare_gain"]))
+}
+
+func (p *Procedural) startBurningTreesLullLocked(verb string) {
+	if p.timers["ignite"] <= 0 {
+		p.startBurningTreesIgniteLocked("kindled")
+	}
+	p.timers["flare"] = 0
+	p.timers["lull"] = jitterInt(p.rng, p.intCfg("lull_dur"), 0.3)
+	p.values["flare_gain"] = 1
+	p.values["lull_gain"] = math.Max(0.15, p.cfg["lull_mult"]*(0.85+p.rng.Float64()*0.25))
+	p.appendLog("lull", fmt.Sprintf("%s (dur=%d, x%.2f)", verb, p.timers["lull"], p.values["lull_gain"]))
+}
+
+func (p *Procedural) startBurningTreesIntroLocked() {
+	p.timers["ignite"] = 0
+	p.timers["flare"] = 0
+	p.timers["lull"] = 0
+	p.timers["ending"] = 0
+	p.values["ignite_gain"] = 0
+	p.values["ignite_total"] = 0
+	p.values["ignite_center"] = 0
+	p.values["ignite_span"] = 0
+	p.values["ignite_seed"] = 0
+	p.values["flare_gain"] = 1
+	p.values["lull_gain"] = 1
+	p.clearBurningTreesCharLocked()
+	p.timers["intro"] = p.intCfg("intro_dur")
+	p.values["intro_total"] = float64(p.timers["intro"])
+}
+
+func (p *Procedural) startBurningTreesEndingLocked() {
+	p.timers["intro"] = 0
+	p.timers["ignite"] = 0
+	p.timers["flare"] = 0
+	p.timers["lull"] = 0
+	p.values["ignite_gain"] = 0
+	p.values["ignite_total"] = 0
+	p.values["ignite_center"] = 0
+	p.values["ignite_span"] = 0
+	p.values["ignite_seed"] = 0
+	p.values["flare_gain"] = 1
+	p.values["lull_gain"] = 1
+	endingTotal := p.intCfg("ending_dur") + max(0, p.intCfg("ending_linger"))
+	if endingTotal < 1 {
+		endingTotal = max(1, p.intCfg("ending_dur"))
+	}
+	p.timers["ending"] = endingTotal
+	p.values["ending_total"] = float64(endingTotal)
+}
+
+func (p *Procedural) stepBurningTreesCharLocked() {
+	if p.timers["ignite"] <= 0 {
+		return
+	}
+	treeCount := max(1, p.intCfg("tree_count"))
+	total := math.Max(1, p.values["ignite_total"])
+	progress := clamp01(1 - float64(p.timers["ignite"])/total)
+	center := p.values["ignite_center"]
+	span := math.Max(0.75, p.values["ignite_span"])
+	fireGain := p.values["ignite_gain"]
+	if fireGain <= 0 {
+		fireGain = p.cfg["flame"]
+	}
+	mod := 1.0
+	if p.timers["flare"] > 0 {
+		gain := p.values["flare_gain"]
+		if gain <= 0 {
+			gain = p.cfg["flare_mult"]
+		}
+		mod *= 1 + math.Max(0, gain-1)*0.55
+	}
+	if p.timers["lull"] > 0 {
+		gain := p.values["lull_gain"]
+		if gain <= 0 {
+			gain = p.cfg["lull_mult"]
+		}
+		mod *= math.Max(0.18, gain)
+	}
+	ramp := 0.45 + 0.55*math.Sin(progress*math.Pi)
+	reach := span + p.cfg["spread"]*(0.15+progress*0.55)
+	for i := 0; i < treeCount; i++ {
+		dist := math.Abs(float64(i) - center)
+		influence := 1 - dist/math.Max(1, reach+0.75)
+		if influence <= 0 {
+			continue
+		}
+		influence = math.Pow(influence, 0.72)
+		delta := p.cfg["char"] * 0.022 * (0.55 + fireGain*1.6) * mod * ramp * influence
+		key := fmt.Sprintf("char_%d", i)
+		p.values[key] = clamp01(p.values[key] + delta)
+	}
+}
+
+func (p *Procedural) stepBurningTreesLocked() {
+	p.stepBurningTreesCharLocked()
+	if p.timers["ignite"] <= 0 {
+		p.values["ignite_gain"] = 0
+		p.values["ignite_total"] = 0
+		p.values["ignite_center"] = 0
+		p.values["ignite_span"] = 0
+		p.values["ignite_seed"] = 0
+	}
+	if p.timers["flare"] <= 0 {
+		p.values["flare_gain"] = 1
+	}
+	if p.timers["lull"] <= 0 {
+		p.values["lull_gain"] = 1
+	}
+	if p.timers["intro"] <= 0 {
+		delete(p.values, "intro_total")
+	}
+	if p.timers["ending"] <= 0 {
+		delete(p.values, "ending_total")
+	}
+	if p.timers["ending"] > 0 {
+		treeCount := max(1, p.intCfg("tree_count"))
+		for i := 0; i < treeCount; i++ {
+			key := fmt.Sprintf("char_%d", i)
+			if p.values[key] <= 0 {
+				continue
+			}
+			p.values[key] = clamp01(p.values[key] + p.cfg["char"]*0.004)
+		}
+	}
+	if p.timers["intro"] > 0 || p.timers["ending"] > 0 {
+		return
+	}
+	if p.timers["ignite"] <= 0 && p.cfg["ignite_p"] > 0 && p.rng.Float64() < p.cfg["ignite_p"] {
+		p.startBurningTreesIgniteLocked("started")
+		return
+	}
+	if p.timers["ignite"] > 0 && p.timers["flare"] <= 0 && p.timers["lull"] <= 0 && p.cfg["flare_p"] > 0 && p.rng.Float64() < p.cfg["flare_p"] {
+		p.startBurningTreesFlareLocked("started")
+		return
+	}
+	if p.timers["ignite"] > 0 && p.timers["lull"] <= 0 && p.timers["flare"] <= 0 && p.cfg["lull_p"] > 0 && p.rng.Float64() < p.cfg["lull_p"] {
+		p.startBurningTreesLullLocked("started")
 	}
 }

--- a/sim/procedural_test.go
+++ b/sim/procedural_test.go
@@ -142,6 +142,16 @@ func TestMysteriousManSchema(t *testing.T) {
 	}
 }
 
+func TestBurningTreesSchema(t *testing.T) {
+	schema := BurningTreesSchema()
+	if schema.Name != "burning-trees" {
+		t.Fatalf("schema name = %q, want burning-trees", schema.Name)
+	}
+	if len(schema.Knobs) == 0 {
+		t.Fatal("expected burning-trees schema knobs")
+	}
+}
+
 func TestProceduralSnowSnapshotRestore(t *testing.T) {
 	p := NewProcedural("snow", 160, 80, 42, nil)
 	if !p.TriggerEvent("gust") {
@@ -611,5 +621,60 @@ func TestProceduralMysteriousManSnapshotRestore(t *testing.T) {
 	}
 	if again.Values["lighter_gain"] != snap.Values["lighter_gain"] {
 		t.Fatalf("restored lighter gain = %f, want %f", again.Values["lighter_gain"], snap.Values["lighter_gain"])
+	}
+}
+
+func TestProceduralBurningTreesSnapshotRestore(t *testing.T) {
+	p := NewProcedural("burning-trees", 160, 80, 63, nil)
+	if !p.TriggerEvent("ignite") {
+		t.Fatal("expected ignite trigger to succeed")
+	}
+	if !p.TriggerEvent("flare") {
+		t.Fatal("expected flare trigger to succeed")
+	}
+	p.Step()
+
+	snap := p.Snapshot()
+	if snap.Timers["ignite"] <= 0 {
+		t.Fatal("expected ignite timer in snapshot")
+	}
+	if snap.Timers["flare"] <= 0 {
+		t.Fatal("expected flare timer in snapshot")
+	}
+	if snap.Values["ignite_center"] < 0 {
+		t.Fatal("expected ignite center value in snapshot")
+	}
+	if snap.Values["flare_gain"] <= 1 {
+		t.Fatal("expected flare gain value in snapshot")
+	}
+	foundChar := false
+	for key, value := range snap.Values {
+		if len(key) > 5 && key[:5] == "char_" && value > 0 {
+			foundChar = true
+			break
+		}
+	}
+	if !foundChar {
+		t.Fatal("expected char accumulation in snapshot")
+	}
+
+	restored := NewProcedural("burning-trees", 160, 80, 7, nil)
+	restored.RestoreSnapshot(snap)
+	again := restored.Snapshot()
+	if again.Timers["ignite"] != snap.Timers["ignite"] {
+		t.Fatalf("restored ignite timer = %d, want %d", again.Timers["ignite"], snap.Timers["ignite"])
+	}
+	if again.Values["ignite_center"] != snap.Values["ignite_center"] {
+		t.Fatalf("restored ignite center = %f, want %f", again.Values["ignite_center"], snap.Values["ignite_center"])
+	}
+	if again.Values["flare_gain"] != snap.Values["flare_gain"] {
+		t.Fatalf("restored flare gain = %f, want %f", again.Values["flare_gain"], snap.Values["flare_gain"])
+	}
+	for key, value := range snap.Values {
+		if len(key) > 5 && key[:5] == "char_" && value > 0 {
+			if again.Values[key] != value {
+				t.Fatalf("restored %s = %f, want %f", key, again.Values[key], value)
+			}
+		}
 	}
 }


### PR DESCRIPTION
## Summary
- add the urning-trees procedural dev effect on the Go and browser runtime paths
- model localized ignite/flare/lull events with persistent char buildup, presets, and snapshot coverage
- wire the new effect into the dev-session schema/runtime registry so /dev/burning-trees works like the other new prototypes

## Testing
- go test ./...
- node --check cmd/ambience/web/sim.js
- powershell -ExecutionPolicy Bypass -File scripts/dev-deploy.ps1 -Component all
- powershell -ExecutionPolicy Bypass -File scripts/dev-loop.ps1 -Once
- visual validation on https://ambience.dev.romaine.life/dev/burning-trees

Refs #6