### PR TITLE
Add the sand dev effect prototype

### DIFF
--- a/cmd/ambience/dev_random_test.go
+++ b/cmd/ambience/dev_random_test.go
@@ -29,6 +29,7 @@ func TestRandomizedDevConfigStaysWithinSchemaBounds(t *testing.T) {
 		sim.TrainSchema(),
 		sim.MysteriousManSchema(),
 		sim.BurningTreesSchema(),
+		sim.SandSchema(),
 	}
 
 	for i, schema := range schemas {
@@ -78,6 +79,7 @@ func TestRandomizedDevConfigChangesAtLeastOneKnob(t *testing.T) {
 		sim.TrainSchema(),
 		sim.MysteriousManSchema(),
 		sim.BurningTreesSchema(),
+		sim.SandSchema(),
 	}
 
 	for i, schema := range schemas {

--- a/cmd/ambience/dev_sessions_test.go
+++ b/cmd/ambience/dev_sessions_test.go
@@ -28,6 +28,7 @@ func TestDevPageEffectFromPath(t *testing.T) {
 		{path: "/dev/volcano", want: "volcano", wantOK: true},
 		{path: "/dev/mysterious-man", want: "mysterious-man", wantOK: true},
 		{path: "/dev/burning-trees", want: "burning-trees", wantOK: true},
+		{path: "/dev/sand", want: "sand", wantOK: true},
 		{path: "/dev/waterfall", want: "waterfall", wantOK: true},
 		{path: "/dev/windmill", want: "windmill", wantOK: true},
 		{path: "/dev/wheat-field", want: "wheat-field", wantOK: true},
@@ -67,6 +68,7 @@ func TestEffectFromSchemaPath(t *testing.T) {
 		{path: "/effects/volcano/schema", want: "volcano", wantOK: true},
 		{path: "/effects/mysterious-man/schema", want: "mysterious-man", wantOK: true},
 		{path: "/effects/burning-trees/schema", want: "burning-trees", wantOK: true},
+		{path: "/effects/sand/schema", want: "sand", wantOK: true},
 		{path: "/effects/waterfall/schema", want: "waterfall", wantOK: true},
 		{path: "/effects/windmill/schema", want: "windmill", wantOK: true},
 		{path: "/effects/wheat-field/schema", want: "wheat-field", wantOK: true},
@@ -246,6 +248,17 @@ func TestNewDevSessionBurningTreesSnapshotType(t *testing.T) {
 	snap := session.snapshot()
 	if snap.Type != "burning-trees" {
 		t.Fatalf("snapshot type = %q, want burning-trees", snap.Type)
+	}
+}
+
+func TestNewDevSessionSandSnapshotType(t *testing.T) {
+	session, err := newDevSession("sand")
+	if err != nil {
+		t.Fatalf("newDevSession: %v", err)
+	}
+	snap := session.snapshot()
+	if snap.Type != "sand" {
+		t.Fatalf("snapshot type = %q, want sand", snap.Type)
 	}
 }
 

--- a/cmd/ambience/effects.go
+++ b/cmd/ambience/effects.go
@@ -146,6 +146,11 @@ var effectRegistry = map[string]effectDefinition{
 		Schema:     sim.BurningTreesSchema,
 		NewRuntime: newBurningTreesRuntime,
 	},
+	"sand": {
+		Type:       "sand",
+		Schema:     sim.SandSchema,
+		NewRuntime: newSandRuntime,
+	},
 }
 
 func lookupEffectDefinition(effectType string) (effectDefinition, bool) {
@@ -344,6 +349,10 @@ func newMysteriousManRuntime(w, h int, seed int64, cfg json.RawMessage) (effectR
 
 func newBurningTreesRuntime(w, h int, seed int64, cfg json.RawMessage) (effectRuntime, error) {
 	return newProceduralRuntime("burning-trees", w, h, seed, cfg)
+}
+
+func newSandRuntime(w, h int, seed int64, cfg json.RawMessage) (effectRuntime, error) {
+	return newProceduralRuntime("sand", w, h, seed, cfg)
 }
 
 func (r *rainRuntime) Type() string { return "rain" }
@@ -784,6 +793,8 @@ func (p *proceduralRuntime) Schema() sim.EffectSchema {
 		return sim.MysteriousManSchema()
 	case "burning-trees":
 		return sim.BurningTreesSchema()
+	case "sand":
+		return sim.SandSchema()
 	default:
 		return sim.EffectSchema{}
 	}

--- a/cmd/ambience/web/sim.js
+++ b/cmd/ambience/web/sim.js
@@ -2128,6 +2128,35 @@
 			lull_dur: 54,
 			lull_mult: 0.55,
 		},
+		sand: {
+			intro_dur: 55,
+			intro_trickle: 0.1,
+			intro_fill: 0.02,
+			ending_dur: 70,
+			ending_linger: 20,
+			ending_settle: 0.08,
+			pipe_x: 0.28,
+			pipe_width: 7,
+			pipe_drop: 18,
+			container_x: 0.58,
+			container_width: 34,
+			container_depth: 10,
+			flow: 0.24,
+			spread: 0.9,
+			settle: 0.32,
+			overflow: 0.28,
+			hue: 38,
+			hue_sp: 10,
+			sat: 0.54,
+			lmin: 0.16,
+			lmax: 0.86,
+			surge_p: 0,
+			calm_p: 0,
+			surge_dur: 42,
+			surge_mult: 2.0,
+			calm_dur: 60,
+			calm_mult: 0.42,
+		},
 		starfield: {
 			intro_dur: 50,
 			intro_density: 0.08,
@@ -2495,6 +2524,34 @@
 				if (c.lull_dur <= 0) c.lull_dur = base.lull_dur;
 				if (c.lull_mult <= 0) c.lull_mult = base.lull_mult;
 				break;
+			case 'sand':
+				if (c.intro_dur <= 0) c.intro_dur = base.intro_dur;
+				c.intro_trickle = clamp01(c.intro_trickle);
+				c.intro_fill = clamp01(c.intro_fill);
+				if (c.ending_dur <= 0) c.ending_dur = base.ending_dur;
+				if (c.ending_linger < 0) c.ending_linger = 0;
+				c.ending_settle = clamp01(c.ending_settle);
+				if (c.pipe_x <= 0) c.pipe_x = base.pipe_x;
+				if (c.pipe_width <= 0) c.pipe_width = base.pipe_width;
+				if (c.pipe_drop <= 0) c.pipe_drop = base.pipe_drop;
+				if (c.container_x <= 0) c.container_x = base.container_x;
+				if (c.container_width <= 0) c.container_width = base.container_width;
+				if (c.container_depth <= 0) c.container_depth = base.container_depth;
+				if (c.flow <= 0) c.flow = base.flow;
+				if (c.spread <= 0) c.spread = base.spread;
+				if (c.settle <= 0) c.settle = base.settle;
+				if (c.overflow <= 0) c.overflow = base.overflow;
+				if (c.hue <= 0) c.hue = base.hue;
+				if (c.hue_sp < 0) c.hue_sp = 0;
+				if (c.sat <= 0) c.sat = base.sat;
+				if (c.lmin <= 0) c.lmin = base.lmin;
+				if (c.lmax <= 0) c.lmax = base.lmax;
+				if (c.lmax < c.lmin) [c.lmin, c.lmax] = [c.lmax, c.lmin];
+				if (c.surge_dur <= 0) c.surge_dur = base.surge_dur;
+				if (c.surge_mult <= 0) c.surge_mult = base.surge_mult;
+				if (c.calm_dur <= 0) c.calm_dur = base.calm_dur;
+				if (c.calm_mult <= 0) c.calm_mult = base.calm_mult;
+				break;
 			case 'aurora':
 				if (c.intro_dur <= 0) c.intro_dur = base.intro_dur;
 				c.intro_glow = clamp01(c.intro_glow);
@@ -2652,6 +2709,8 @@
 					return this._triggerMysteriousMan(name);
 				case 'burning-trees':
 					return this._triggerBurningTrees(name);
+				case 'sand':
+					return this._triggerSand(name);
 				case 'aurora':
 					return this._triggerAurora(name);
 				case 'starfield':
@@ -2799,6 +2858,13 @@
 					}
 				}
 			}
+			if (this.kind === 'sand') {
+				this._stepSandState();
+				if (!this.timers.surge || this.timers.surge <= 0) this.values.surge_gain = 1;
+				if (!this.timers.calm || this.timers.calm <= 0) this.values.calm_gain = 1;
+				if (!this.timers.intro || this.timers.intro <= 0) delete this.values.intro_total;
+				if (!this.timers.ending || this.timers.ending <= 0) delete this.values.ending_total;
+			}
 		}
 
 		render(ctx, canvasW, canvasH, opts) {
@@ -2825,6 +2891,8 @@
 					return this._renderMysteriousMan(ctx, canvasW, canvasH, opts);
 				case 'burning-trees':
 					return this._renderBurningTrees(ctx, canvasW, canvasH, opts);
+				case 'sand':
+					return this._renderSand(ctx, canvasW, canvasH, opts);
 				case 'aurora':
 					return this._renderAurora(ctx, canvasW, canvasH, opts);
 				case 'starfield':
@@ -3437,6 +3505,46 @@
 			return false;
 		}
 
+		_triggerSand(name) {
+			const rng = this._eventRng(name.length + 145);
+			switch (name) {
+				case 'surge':
+					this.timers.calm = 0;
+					this.timers.surge = jitterInt(rng, this.cfg.surge_dur, 0.3);
+					this.values.calm_gain = 1;
+					this.values.surge_gain = this.cfg.surge_mult * (0.9 + rng() * 0.4);
+					return true;
+				case 'calm':
+					this.timers.surge = 0;
+					this.timers.calm = jitterInt(rng, this.cfg.calm_dur, 0.3);
+					this.values.surge_gain = 1;
+					this.values.calm_gain = Math.max(0.08, this.cfg.calm_mult * (0.85 + rng() * 0.25));
+					return true;
+				case 'intro':
+					this.timers.surge = 0;
+					this.timers.calm = 0;
+					this.timers.ending = 0;
+					this.values.surge_gain = 1;
+					this.values.calm_gain = 1;
+					this.values.fill_level = clamp01(this.cfg.intro_fill);
+					this.values.spill_level = 0;
+					this.values.surface_bias = 0;
+					this.timers.intro = Math.max(1, Math.round(this.cfg.intro_dur));
+					this.values.intro_total = this.timers.intro;
+					return true;
+				case 'ending':
+					this.timers.intro = 0;
+					this.timers.surge = 0;
+					this.timers.calm = 0;
+					this.values.surge_gain = 1;
+					this.values.calm_gain = 1;
+					this.timers.ending = Math.max(1, Math.round(this.cfg.ending_dur + Math.max(0, this.cfg.ending_linger)));
+					this.values.ending_total = this.timers.ending;
+					return true;
+			}
+			return false;
+		}
+
 		_triggerAurora(name) {
 			const rng = this._eventRng(name.length + 53);
 			switch (name) {
@@ -3803,6 +3911,56 @@
 				level *= 1 - (1 - this.cfg.ending_ash) * progress;
 			}
 			return Math.max(0.04, level);
+		}
+
+		_sandFlowLevel() {
+			let flow = Math.max(0, this.cfg.flow);
+			if (this.timers.intro > 0) {
+				const total = this.values.intro_total || this.cfg.intro_dur;
+				const progress = this._phaseProgress(total, this.timers.intro);
+				flow = this.cfg.intro_trickle + (flow - this.cfg.intro_trickle) * progress;
+			}
+			if (this.timers.ending > 0) {
+				const total = this.values.ending_total || (this.cfg.ending_dur + this.cfg.ending_linger);
+				const progress = this._phaseProgress(total, this.timers.ending);
+				flow *= Math.max(0, 1 - progress);
+			}
+			if (this.timers.surge > 0) flow *= this.values.surge_gain || this.cfg.surge_mult;
+			if (this.timers.calm > 0) flow *= this.values.calm_gain || this.cfg.calm_mult;
+			return Math.max(0, flow);
+		}
+
+		_stepSandState() {
+			const flow = this._sandFlowLevel();
+			let fill = clamp01(this.values.fill_level || 0);
+			let spill = clamp01(this.values.spill_level || 0);
+			let bias = this.values.surface_bias || 0;
+
+			const incoming = flow * (0.02 + this.cfg.spread * 0.012);
+			fill += incoming * (0.8 + this.cfg.settle * 0.35);
+			if (fill > 1) {
+				spill += (fill - 1) * (0.6 + this.cfg.overflow * 0.5);
+				fill = 1;
+			}
+			if (fill > 0.88) {
+				spill += (fill - 0.88) * incoming * (0.4 + this.cfg.overflow * 0.8);
+			}
+			spill -= (0.004 + this.cfg.settle * 0.008) * Math.max(0.12, 1 - flow * 1.2);
+			if (this.timers.ending > 0) {
+				const total = this.values.ending_total || (this.cfg.ending_dur + this.cfg.ending_linger);
+				const progress = this._phaseProgress(total, this.timers.ending);
+				spill += this.cfg.ending_settle * 0.006 * (1 - progress);
+			}
+
+			let targetBias = (this.cfg.pipe_x - this.cfg.container_x) / 0.22;
+			targetBias = Math.max(-1, Math.min(1, targetBias));
+			bias += (targetBias - bias) * (0.04 + flow * 0.08 + this.cfg.settle * 0.04);
+			if (spill > 0.02) bias += (targetBias < 0 ? -1 : 1) * spill * 0.01;
+			bias = Math.max(-1, Math.min(1, bias));
+
+			this.values.fill_level = clamp01(fill);
+			this.values.spill_level = clamp01(spill);
+			this.values.surface_bias = bias;
 		}
 
 		_renderSnow(ctx, canvasW, canvasH, opts) {
@@ -5601,6 +5759,145 @@
 			}
 		}
 
+		_renderSand(ctx, canvasW, canvasH, opts) {
+			opts = opts || {};
+			if (opts.transparent) {
+				ctx.clearRect(0, 0, canvasW, canvasH);
+			} else {
+				const skyTop = hslToRGB((this.cfg.hue - 18 + 360) % 360, clamp01(this.cfg.sat * 0.18), clamp01(this.cfg.lmin * 0.45));
+				const skyMid = hslToRGB((this.cfg.hue - 8 + 360) % 360, clamp01(this.cfg.sat * 0.12), clamp01(this.cfg.lmin + (this.cfg.lmax - this.cfg.lmin) * 0.12));
+				const skyLow = hslToRGB(this.cfg.hue % 360, clamp01(this.cfg.sat * 0.2), clamp01(this.cfg.lmin + (this.cfg.lmax - this.cfg.lmin) * 0.2));
+				const bg = ctx.createLinearGradient(0, 0, 0, canvasH);
+				bg.addColorStop(0, `rgb(${skyTop.r},${skyTop.g},${skyTop.b})`);
+				bg.addColorStop(0.62, `rgb(${skyMid.r},${skyMid.g},${skyMid.b})`);
+				bg.addColorStop(1, `rgb(${skyLow.r},${skyLow.g},${skyLow.b})`);
+				ctx.fillStyle = bg;
+				ctx.fillRect(0, 0, canvasW, canvasH);
+			}
+
+			const sx = canvasW / this.w;
+			const sy = canvasH / this.h;
+			const ceilSx = Math.ceil(sx);
+			const ceilSy = Math.ceil(sy);
+			const floorRow = Math.max(10, Math.min(this.h - 5, Math.floor(this.h * 0.82)));
+			const pipeX = Math.round(this.w * this.cfg.pipe_x);
+			const pipeW = Math.max(4, Math.round(this.cfg.pipe_width));
+			const outletY = Math.max(4, floorRow - Math.round(this.cfg.pipe_drop));
+			let basinCenter = Math.round(this.w * this.cfg.container_x);
+			const maxPipeGap = Math.round(this.w * 0.22);
+			if (Math.abs(basinCenter - pipeX) > maxPipeGap) {
+				basinCenter = pipeX + (basinCenter >= pipeX ? maxPipeGap : -maxPipeGap);
+			}
+			const basinW = Math.max(18, Math.round(this.cfg.container_width));
+			const basinD = Math.max(6, Math.round(this.cfg.container_depth));
+			const sceneRightLimit = Math.max(basinW + 8, Math.floor(this.w * 0.72));
+			const left = Math.max(4, Math.min(Math.min(this.w - basinW - 4, sceneRightLimit - basinW), basinCenter - Math.floor(basinW / 2)));
+			const right = left + basinW - 1;
+			const basinFloor = floorRow - 1;
+			const basinTop = basinFloor - basinD;
+			const fill = clamp01(this.values.fill_level || 0);
+			const spill = clamp01(this.values.spill_level || 0);
+			const surfaceBias = Math.max(-1, Math.min(1, this.values.surface_bias || 0));
+			const flow = this._sandFlowLevel();
+			const motion = clamp01(flow * 2.1 + spill * 0.9 + (this.timers.surge > 0 ? 0.2 : 0));
+			const sandBase = hslToRGB(this.cfg.hue % 360, clamp01(this.cfg.sat * 0.72), clamp01(this.cfg.lmin + (this.cfg.lmax - this.cfg.lmin) * 0.5));
+			const sandShade = hslToRGB((this.cfg.hue - 4 + 360) % 360, clamp01(this.cfg.sat * 0.44), clamp01(this.cfg.lmin + (this.cfg.lmax - this.cfg.lmin) * 0.18));
+			const sandHi = hslToRGB((this.cfg.hue + this.cfg.hue_sp * 0.4) % 360, clamp01(this.cfg.sat * 0.34), clamp01(this.cfg.lmax * 0.98));
+			const metalColor = hslToRGB((this.cfg.hue + 14) % 360, clamp01(this.cfg.sat * 0.1), clamp01(this.cfg.lmin * 0.9));
+			const basinColor = hslToRGB((this.cfg.hue + 18) % 360, clamp01(this.cfg.sat * 0.14), clamp01(this.cfg.lmin * 1.15));
+			const rimColor = hslToRGB((this.cfg.hue + 24) % 360, clamp01(this.cfg.sat * 0.1), clamp01(this.cfg.lmin + (this.cfg.lmax - this.cfg.lmin) * 0.42));
+			const basinInterior = hslToRGB((this.cfg.hue + 10) % 360, clamp01(this.cfg.sat * 0.08), clamp01(this.cfg.lmin * 0.58));
+			const floorColor = hslToRGB((this.cfg.hue - 6 + 360) % 360, clamp01(this.cfg.sat * 0.18), clamp01(this.cfg.lmin * 0.72));
+
+			this._fillCell(ctx, sx, sy, ceilSx, ceilSy, 0, floorRow, this.w, this.h - floorRow, `rgb(${floorColor.r},${floorColor.g},${floorColor.b})`, 1);
+
+			const glow = ctx.createRadialGradient(pipeX * sx, outletY * sy, 0, pipeX * sx, outletY * sy, Math.max(18, 12 * sx));
+			glow.addColorStop(0, `rgba(255, 214, 140, ${clamp01(0.04 + motion * 0.08)})`);
+			glow.addColorStop(1, 'rgba(255, 214, 140, 0)');
+			ctx.fillStyle = glow;
+			ctx.fillRect(Math.floor((pipeX - 8) * sx), Math.floor((outletY - 5) * sy), Math.ceil(16 * sx), Math.ceil(12 * sy));
+
+			this._fillCell(ctx, sx, sy, ceilSx, ceilSy, pipeX - pipeW - 2, outletY - 2, pipeW + 2, 3, `rgb(${metalColor.r},${metalColor.g},${metalColor.b})`, 1);
+			this._fillCell(ctx, sx, sy, ceilSx, ceilSy, pipeX - 2, outletY - 2, 3, 4, `rgb(${metalColor.r},${metalColor.g},${metalColor.b})`, 1);
+			this._fillCell(ctx, sx, sy, ceilSx, ceilSy, pipeX - pipeW - 1, outletY - 1, pipeW, 1, `rgb(${sandHi.r},${sandHi.g},${sandHi.b})`, 0.24);
+
+			this._fillCell(ctx, sx, sy, ceilSx, ceilSy, left, basinTop + 1, basinW, basinD, `rgb(${basinInterior.r},${basinInterior.g},${basinInterior.b})`, 0.35);
+			this._fillCell(ctx, sx, sy, ceilSx, ceilSy, left - 1, basinTop, 2, basinD + 2, `rgb(${basinColor.r},${basinColor.g},${basinColor.b})`, 1);
+			this._fillCell(ctx, sx, sy, ceilSx, ceilSy, right, basinTop, 2, basinD + 2, `rgb(${basinColor.r},${basinColor.g},${basinColor.b})`, 1);
+			this._fillCell(ctx, sx, sy, ceilSx, ceilSy, left - 1, basinFloor, basinW + 2, 2, `rgb(${basinColor.r},${basinColor.g},${basinColor.b})`, 1);
+			this._fillCell(ctx, sx, sy, ceilSx, ceilSy, left - 1, basinTop, 4, 1, `rgb(${rimColor.r},${rimColor.g},${rimColor.b})`, 0.82);
+			this._fillCell(ctx, sx, sy, ceilSx, ceilSy, right - 2, basinTop, 4, 1, `rgb(${rimColor.r},${rimColor.g},${rimColor.b})`, 0.82);
+
+			const surfaceRows = [];
+			for (let x = left + 1; x < right; x++) {
+				const nx = (x - (left + 1)) / Math.max(1, basinW - 3);
+				const peak = 0.5 + surfaceBias * 0.28;
+				const mound = clamp01(1 - Math.abs((nx - peak) / 0.52));
+				const localFill = fill * (0.58 + mound * (0.42 + this.cfg.settle * 0.24));
+				const height = Math.max(0, Math.round(localFill * (basinD - 1)));
+				const surfaceY = basinFloor - height;
+				surfaceRows.push(surfaceY);
+				for (let y = surfaceY; y < basinFloor; y++) {
+					const edge = (y - surfaceY) / Math.max(1, basinFloor - surfaceY);
+					const color = edge < 0.18 ? sandHi : (edge < 0.5 ? sandBase : sandShade);
+					this._fillCell(ctx, sx, sy, ceilSx, ceilSy, x, y, 1, 1, `rgb(${color.r},${color.g},${color.b})`, 0.96);
+				}
+			}
+
+			const impactX = Math.max(left + 2, Math.min(right - 2, pipeX + Math.round(surfaceBias * basinW * 0.18)));
+			const impactIdx = Math.max(0, Math.min(surfaceRows.length - 1, impactX - (left + 1)));
+			const impactY = surfaceRows[impactIdx] || basinFloor - 1;
+
+			if (spill > 0.01) {
+				const dir = surfaceBias < 0 ? -1 : 1;
+				const spillLen = Math.max(3, Math.round(spill * (10 + this.cfg.overflow * 22)));
+				for (let s = 0; s < spillLen; s++) {
+					const height = Math.max(1, Math.round((1 - s / Math.max(1, spillLen - 1)) * (2 + spill * 4)));
+					const x = dir > 0 ? right + s : left - s;
+					const y = basinFloor - height + 1 + Math.round(s * 0.08);
+					this._fillCell(ctx, sx, sy, ceilSx, ceilSy, x, y, 1, height, `rgb(${sandBase.r},${sandBase.g},${sandBase.b})`, 0.92);
+					if (height > 1) this._fillCell(ctx, sx, sy, ceilSx, ceilSy, x, y, 1, 1, `rgb(${sandHi.r},${sandHi.g},${sandHi.b})`, 0.4);
+				}
+			}
+
+			if (flow > 0.01) {
+				const streamW = Math.max(1, Math.round(1 + this.cfg.spread * 1.8 + flow * 2));
+				for (let y = outletY + 2; y <= impactY; y++) {
+					const t = (y - outletY) / Math.max(1, impactY - outletY);
+					const drift = Math.sin(this.tick * 0.04 + y * 0.12) * this.cfg.spread * 0.35 * t;
+					const centerX = pipeX + drift;
+					for (let dx = -Math.floor(streamW / 2); dx <= Math.floor(streamW / 2); dx++) {
+						if ((dx + y + this.tick) % 2 !== 0 && Math.abs(dx) > 0) continue;
+						const alpha = clamp01(0.24 + flow * 0.95 - Math.abs(dx) * 0.09);
+						const color = (y + dx) % 3 === 0 ? sandHi : sandBase;
+						this._fillCell(ctx, sx, sy, ceilSx, ceilSy, Math.round(centerX + dx), y, 1, 1, `rgb(${color.r},${color.g},${color.b})`, alpha);
+					}
+				}
+
+				const splashCount = Math.max(4, Math.round(4 + flow * 14));
+				for (let i = 0; i < splashCount; i++) {
+					const lift = this._hash(36600 + i) * (1.5 + motion * 4);
+					const drift = (this._hash(36700 + i) * 2 - 1) * (1 + this.cfg.spread * 2.4);
+					const x = Math.round(impactX + drift);
+					const y = Math.round(impactY - lift);
+					const alpha = clamp01(0.08 + motion * 0.26);
+					const color = i % 3 === 0 ? sandHi : sandBase;
+					this._fillCell(ctx, sx, sy, ceilSx, ceilSy, x, y, 1, 1, `rgb(${color.r},${color.g},${color.b})`, alpha);
+				}
+			}
+
+			const dustCount = Math.max(8, Math.round((4 + this.cfg.spread * 10) * Math.max(0.2, motion)));
+			for (let i = 0; i < dustCount; i++) {
+				const life = 26 + Math.floor(this._hash(36800 + i) * 22);
+				const age = positiveMod(this.tick + i * 5, life);
+				const t = age / Math.max(1, life - 1);
+				const x = Math.round(impactX + (this._hash(36900 + i) * 2 - 1) * (2 + t * 7));
+				const y = Math.round(impactY - t * (1 + this.cfg.spread * 2.5));
+				const alpha = clamp01((0.05 + motion * 0.12) * (1 - t));
+				this._fillCell(ctx, sx, sy, ceilSx, ceilSy, x, y, 1, 1, `rgb(${sandShade.r},${sandShade.g},${sandShade.b})`, alpha);
+			}
+		}
+
 		_renderAurora(ctx, canvasW, canvasH, opts) {
 			opts = opts || {};
 			if (opts.transparent) {
@@ -5795,6 +6092,12 @@
 		}
 	}
 
+	class Sand extends ProceduralScene {
+		constructor(w, h, cfg, seed) {
+			super('sand', w, h, cfg, seed);
+		}
+	}
+
 	class Aurora extends ProceduralScene {
 		constructor(w, h, cfg, seed) {
 			super('aurora', w, h, cfg, seed);
@@ -5853,7 +6156,7 @@
 	// server's snapshot payload — the client looks up the constructor here
 	// by name so new effects just register themselves and work without
 	// client-side changes.
-	const effects = { rain: Rain, dust: Dust, fireflies: Fireflies, waterfall: Waterfall, 'wheat-field': WheatField, beach: Beach, campfire: Campfire, windmill: Windmill, lighthouse: Lighthouse, rowboat: Rowboat, underwater: Underwater, volcano: Volcano, train: Train, 'mysterious-man': MysteriousMan, 'burning-trees': BurningTrees, aurora: Aurora, snow: Snow, 'autumn-leaves': AutumnLeaves, starfield: Starfield };
+	const effects = { rain: Rain, dust: Dust, fireflies: Fireflies, waterfall: Waterfall, 'wheat-field': WheatField, beach: Beach, campfire: Campfire, windmill: Windmill, lighthouse: Lighthouse, rowboat: Rowboat, underwater: Underwater, volcano: Volcano, train: Train, 'mysterious-man': MysteriousMan, 'burning-trees': BurningTrees, sand: Sand, aurora: Aurora, snow: Snow, 'autumn-leaves': AutumnLeaves, starfield: Starfield };
 	const presets = {
 		'wheat-field': [
 			{
@@ -6825,6 +7128,110 @@
 				},
 			},
 		],
+		sand: [
+			{
+				key: 'small-trickle',
+				label: 'small trickle',
+				config: {
+					intro_trickle: 0.08,
+					intro_fill: 0.01,
+					ending_settle: 0.12,
+					pipe_x: 0.24,
+					pipe_width: 6,
+					pipe_drop: 17,
+					container_x: 0.58,
+					container_width: 30,
+					container_depth: 9,
+					flow: 0.14,
+					spread: 0.5,
+					settle: 0.38,
+					overflow: 0.16,
+					hue: 36,
+					hue_sp: 8,
+					sat: 0.46,
+					lmin: 0.14,
+					lmax: 0.78,
+					calm_p: 0.0012,
+				},
+			},
+			{
+				key: 'steady-pour',
+				label: 'steady pour',
+				config: {
+					intro_trickle: 0.1,
+					intro_fill: 0.02,
+					ending_settle: 0.08,
+					pipe_x: 0.28,
+					pipe_width: 7,
+					pipe_drop: 18,
+					container_x: 0.58,
+					container_width: 34,
+					container_depth: 10,
+					flow: 0.24,
+					spread: 0.9,
+					settle: 0.32,
+					overflow: 0.28,
+					hue: 38,
+					hue_sp: 10,
+					sat: 0.54,
+					lmin: 0.16,
+					lmax: 0.86,
+					surge_p: 0.001,
+				},
+			},
+			{
+				key: 'heavy-fill',
+				label: 'heavy fill',
+				config: {
+					intro_trickle: 0.14,
+					intro_fill: 0.03,
+					ending_settle: 0.06,
+					pipe_x: 0.3,
+					pipe_width: 8,
+					pipe_drop: 19,
+					container_x: 0.6,
+					container_width: 32,
+					container_depth: 9,
+					flow: 0.34,
+					spread: 1.2,
+					settle: 0.28,
+					overflow: 0.36,
+					hue: 40,
+					hue_sp: 12,
+					sat: 0.58,
+					lmin: 0.16,
+					lmax: 0.9,
+					surge_p: 0.0014,
+					surge_mult: 2.2,
+				},
+			},
+			{
+				key: 'overflow-study',
+				label: 'overflow study',
+				config: {
+					intro_trickle: 0.12,
+					intro_fill: 0.05,
+					ending_settle: 0.1,
+					pipe_x: 0.26,
+					pipe_width: 7,
+					pipe_drop: 17,
+					container_x: 0.54,
+					container_width: 24,
+					container_depth: 8,
+					flow: 0.38,
+					spread: 1.1,
+					settle: 0.24,
+					overflow: 0.6,
+					hue: 34,
+					hue_sp: 10,
+					sat: 0.52,
+					lmin: 0.15,
+					lmax: 0.84,
+					surge_p: 0.0012,
+					calm_p: 0.0006,
+				},
+			},
+		],
 		aurora: [
 			{
 				key: 'green-veil',
@@ -7336,5 +7743,5 @@
 		],
 	};
 
-	global.AmbienceSim = { Rain, Dust, Fireflies, Waterfall, WheatField, Beach, Campfire, Windmill, Lighthouse, Rowboat, Underwater, Volcano, Train, MysteriousMan, BurningTrees, Aurora, AutumnLeaves, Snow, Starfield, subscribe, applyDefaults, hslToRGB, effects, presets };
+	global.AmbienceSim = { Rain, Dust, Fireflies, Waterfall, WheatField, Beach, Campfire, Windmill, Lighthouse, Rowboat, Underwater, Volcano, Train, MysteriousMan, BurningTrees, Sand, Aurora, AutumnLeaves, Snow, Starfield, subscribe, applyDefaults, hslToRGB, effects, presets };
 })(window);

--- a/sim/procedural.go
+++ b/sim/procedural.go
@@ -477,6 +477,36 @@ var burningTreesDefaults = ProceduralConfig{
 	"lull_mult":     0.55,
 }
 
+var sandDefaults = ProceduralConfig{
+	"intro_dur":       55,
+	"intro_trickle":   0.10,
+	"intro_fill":      0.02,
+	"ending_dur":      70,
+	"ending_linger":   20,
+	"ending_settle":   0.08,
+	"pipe_x":          0.28,
+	"pipe_width":      7.0,
+	"pipe_drop":       18.0,
+	"container_x":     0.58,
+	"container_width": 34.0,
+	"container_depth": 10.0,
+	"flow":            0.24,
+	"spread":          0.90,
+	"settle":          0.32,
+	"overflow":        0.28,
+	"hue":             38,
+	"hue_sp":          10,
+	"sat":             0.54,
+	"lmin":            0.16,
+	"lmax":            0.86,
+	"surge_p":         0.0,
+	"calm_p":          0.0,
+	"surge_dur":       42,
+	"surge_mult":      2.00,
+	"calm_dur":        60,
+	"calm_mult":       0.42,
+}
+
 func SnowSchema() EffectSchema {
 	return EffectSchema{
 		Name: "snow",
@@ -1369,6 +1399,68 @@ func BurningTreesSchema() EffectSchema {
 	}
 }
 
+func SandSchema() EffectSchema {
+	return EffectSchema{
+		Name: "sand",
+		Knobs: []Knob{
+			{Key: "intro_dur", Label: "intro dur", Slot: SlotSpawn, Group: "introduction", Type: KnobInt, Min: 10, Max: 220, Step: 5, Default: 55, Trigger: "intro",
+				Description: "Ticks spent ramping from a few first grains into the full pour."},
+			{Key: "intro_trickle", Label: "intro trickle", Slot: SlotSpawn, Group: "introduction", Type: KnobFloat, Min: 0.01, Max: 0.4, Step: 0.01, Default: 0.10,
+				Description: "Starting fraction of the full sand flow during the intro."},
+			{Key: "intro_fill", Label: "intro fill", Slot: SlotSpawn, Group: "introduction", Type: KnobFloat, Min: 0, Max: 0.25, Step: 0.01, Default: 0.02,
+				Description: "Initial amount of settled sand in the container when the intro begins."},
+			{Key: "ending_dur", Label: "ending dur", Slot: SlotEnd, Group: "ending", Type: KnobInt, Min: 10, Max: 240, Step: 5, Default: 70, Trigger: "ending",
+				Description: "Ticks spent tapering the source down from a pour to the last grains."},
+			{Key: "ending_linger", Label: "ending linger", Slot: SlotEnd, Group: "ending", Type: KnobInt, Min: 0, Max: 180, Step: 5, Default: 20,
+				Description: "Extra settle ticks after the source cuts off so the pile can quiet down."},
+			{Key: "ending_settle", Label: "ending settle", Slot: SlotEnd, Group: "ending", Type: KnobFloat, Min: 0.01, Max: 0.4, Step: 0.01, Default: 0.08,
+				Description: "Residual settling and trickle level near the end of the outro."},
+			{Key: "pipe_x", Label: "pipe x", Slot: SlotLever, Group: "layout", Type: KnobFloat, Min: 0.08, Max: 0.45, Step: 0.01, Default: 0.28,
+				Description: "Horizontal location of the pipe outlet."},
+			{Key: "pipe_width", Label: "pipe width", Slot: SlotLever, Group: "layout", Type: KnobFloat, Min: 4, Max: 12, Step: 1, Default: 7,
+				Description: "Width of the source pipe silhouette in pixels."},
+			{Key: "pipe_drop", Label: "pipe drop", Slot: SlotLever, Group: "layout", Type: KnobFloat, Min: 8, Max: 28, Step: 1, Default: 18,
+				Description: "Distance from the pipe outlet down to the basin floor."},
+			{Key: "container_x", Label: "basin x", Slot: SlotLever, Group: "layout", Type: KnobFloat, Min: 0.35, Max: 0.78, Step: 0.01, Default: 0.58,
+				Description: "Horizontal center of the receiving container."},
+			{Key: "container_width", Label: "basin width", Slot: SlotLever, Group: "layout", Type: KnobFloat, Min: 18, Max: 56, Step: 1, Default: 34,
+				Description: "Interior width of the receiving basin."},
+			{Key: "container_depth", Label: "basin depth", Slot: SlotLever, Group: "layout", Type: KnobFloat, Min: 6, Max: 18, Step: 1, Default: 10,
+				Description: "Interior depth of the receiving basin."},
+			{Key: "flow", Label: "flow", Slot: SlotLever, Group: "pour", Type: KnobFloat, Min: 0.05, Max: 0.7, Step: 0.01, Default: 0.24,
+				Description: "Baseline sand emission rate from the pipe."},
+			{Key: "spread", Label: "spread", Slot: SlotLever, Group: "pour", Type: KnobFloat, Min: 0.2, Max: 2.5, Step: 0.05, Default: 0.90,
+				Description: "Lateral scatter and plume width of the falling grains."},
+			{Key: "settle", Label: "settle", Slot: SlotLever, Group: "pour", Type: KnobFloat, Min: 0.05, Max: 1.2, Step: 0.05, Default: 0.32,
+				Description: "How quickly the pile redistributes and smooths after impact."},
+			{Key: "overflow", Label: "overflow", Slot: SlotLever, Group: "pour", Type: KnobFloat, Min: 0.05, Max: 1.4, Step: 0.05, Default: 0.28,
+				Description: "How readily excess sand escapes the basin and spills along the floor."},
+			{Key: "hue", Label: "hue", Slot: SlotLever, Group: "palette", Type: KnobFloat, Min: 24, Max: 56, Step: 1, Default: 38,
+				Description: "Base sand hue from pale tan toward warm ochre."},
+			{Key: "hue_sp", Label: "hue spread", Slot: SlotLever, Group: "palette", Type: KnobFloat, Min: 0, Max: 20, Step: 1, Default: 10,
+				Description: "Variation between highlights, shadowed grains, and pipe/basin accents."},
+			{Key: "sat", Label: "saturation", Slot: SlotLever, Group: "palette", Type: KnobFloat, Min: 0.1, Max: 0.9, Step: 0.01, Default: 0.54,
+				Description: "Overall scene saturation."},
+			{Key: "lmin", Label: "light min", Slot: SlotLever, Group: "palette", Type: KnobFloat, Min: 0.05, Max: 0.4, Step: 0.01, Default: 0.16,
+				Description: "Minimum lightness used for the deepest sand shadows and background."},
+			{Key: "lmax", Label: "light max", Slot: SlotLever, Group: "palette", Type: KnobFloat, Min: 0.4, Max: 1, Step: 0.01, Default: 0.86,
+				Description: "Maximum lightness used for highlights and fresh grains."},
+			{Key: "surge_p", Label: "surge", Slot: SlotEvent, Type: KnobFloat, Min: 0, Max: 0.02, Step: 0.0005, Default: 0, Trigger: "surge",
+				Description: "Per-tick chance of the source temporarily pouring harder."},
+			{Key: "calm_p", Label: "calm", Slot: SlotEvent, Type: KnobFloat, Min: 0, Max: 0.02, Step: 0.0005, Default: 0, Trigger: "calm",
+				Description: "Per-tick chance of the source slowing to a softer trickle."},
+			{Key: "surge_dur", Label: "surge dur", Slot: SlotEventMod, Group: "surge", Type: KnobInt, Min: 10, Max: 160, Step: 5, Default: 42,
+				Description: "Duration of the surge window."},
+			{Key: "surge_mult", Label: "surge x", Slot: SlotEventMod, Group: "surge", Type: KnobFloat, Min: 1.05, Max: 3, Step: 0.05, Default: 2.0,
+				Description: "Flow multiplier applied during a surge."},
+			{Key: "calm_dur", Label: "calm dur", Slot: SlotEventMod, Group: "calm", Type: KnobInt, Min: 10, Max: 180, Step: 5, Default: 60,
+				Description: "Duration of the slower calm window."},
+			{Key: "calm_mult", Label: "calm x", Slot: SlotEventMod, Group: "calm", Type: KnobFloat, Min: 0.05, Max: 1, Step: 0.05, Default: 0.42,
+				Description: "Flow multiplier applied during a calm period."},
+		},
+	}
+}
+
 func cloneProceduralConfig(src ProceduralConfig) ProceduralConfig {
 	if src == nil {
 		return ProceduralConfig{}
@@ -1439,6 +1531,8 @@ func proceduralDefaults(kind string) ProceduralConfig {
 		return cloneProceduralConfig(mysteriousManDefaults)
 	case "burning-trees":
 		return cloneProceduralConfig(burningTreesDefaults)
+	case "sand":
+		return cloneProceduralConfig(sandDefaults)
 	default:
 		return ProceduralConfig{}
 	}
@@ -2445,6 +2539,79 @@ func mergeProceduralDefaults(kind string, cfg ProceduralConfig) ProceduralConfig
 		if out["lull_mult"] <= 0 {
 			out["lull_mult"] = burningTreesDefaults["lull_mult"]
 		}
+	case "sand":
+		if out["intro_dur"] <= 0 {
+			out["intro_dur"] = sandDefaults["intro_dur"]
+		}
+		out["intro_trickle"] = clamp01(out["intro_trickle"])
+		out["intro_fill"] = clamp01(out["intro_fill"])
+		if out["ending_dur"] <= 0 {
+			out["ending_dur"] = sandDefaults["ending_dur"]
+		}
+		if out["ending_linger"] < 0 {
+			out["ending_linger"] = 0
+		}
+		out["ending_settle"] = clamp01(out["ending_settle"])
+		if out["pipe_x"] <= 0 {
+			out["pipe_x"] = sandDefaults["pipe_x"]
+		}
+		if out["pipe_width"] <= 0 {
+			out["pipe_width"] = sandDefaults["pipe_width"]
+		}
+		if out["pipe_drop"] <= 0 {
+			out["pipe_drop"] = sandDefaults["pipe_drop"]
+		}
+		if out["container_x"] <= 0 {
+			out["container_x"] = sandDefaults["container_x"]
+		}
+		if out["container_width"] <= 0 {
+			out["container_width"] = sandDefaults["container_width"]
+		}
+		if out["container_depth"] <= 0 {
+			out["container_depth"] = sandDefaults["container_depth"]
+		}
+		if out["flow"] <= 0 {
+			out["flow"] = sandDefaults["flow"]
+		}
+		if out["spread"] <= 0 {
+			out["spread"] = sandDefaults["spread"]
+		}
+		if out["settle"] <= 0 {
+			out["settle"] = sandDefaults["settle"]
+		}
+		if out["overflow"] <= 0 {
+			out["overflow"] = sandDefaults["overflow"]
+		}
+		if out["hue"] <= 0 {
+			out["hue"] = sandDefaults["hue"]
+		}
+		if out["hue_sp"] < 0 {
+			out["hue_sp"] = 0
+		}
+		if out["sat"] <= 0 {
+			out["sat"] = sandDefaults["sat"]
+		}
+		if out["lmin"] <= 0 {
+			out["lmin"] = sandDefaults["lmin"]
+		}
+		if out["lmax"] <= 0 {
+			out["lmax"] = sandDefaults["lmax"]
+		}
+		if out["lmax"] < out["lmin"] {
+			out["lmin"], out["lmax"] = out["lmax"], out["lmin"]
+		}
+		if out["surge_dur"] <= 0 {
+			out["surge_dur"] = sandDefaults["surge_dur"]
+		}
+		if out["surge_mult"] <= 0 {
+			out["surge_mult"] = sandDefaults["surge_mult"]
+		}
+		if out["calm_dur"] <= 0 {
+			out["calm_dur"] = sandDefaults["calm_dur"]
+		}
+		if out["calm_mult"] <= 0 {
+			out["calm_mult"] = sandDefaults["calm_mult"]
+		}
 	}
 	return out
 }
@@ -2837,6 +3004,22 @@ func (p *Procedural) TriggerEvent(name string) bool {
 			return false
 		}
 		return true
+	case "sand":
+		switch name {
+		case "surge":
+			p.startSandSurgeLocked("triggered")
+		case "calm":
+			p.startSandCalmLocked("triggered")
+		case "intro":
+			p.startSandIntroLocked()
+			p.appendLog("intro", fmt.Sprintf("started (dur=%d, trickle=%.2f)", p.timers["intro"], p.cfg["intro_trickle"]))
+		case "ending":
+			p.startSandEndingLocked()
+			p.appendLog("ending", fmt.Sprintf("started (fade=%d, linger=%d)", p.intCfg("ending_dur"), p.intCfg("ending_linger")))
+		default:
+			return false
+		}
+		return true
 	default:
 		return false
 	}
@@ -2902,11 +3085,24 @@ func (p *Procedural) Step() {
 		p.stepMysteriousManLocked()
 	case "burning-trees":
 		p.stepBurningTreesLocked()
+	case "sand":
+		p.stepSandLocked()
 	}
 }
 
 func (p *Procedural) intCfg(key string) int {
 	return int(math.Round(p.cfg[key]))
+}
+
+func proceduralPhaseProgress(total, left int) float64 {
+	if left <= 1 || total <= 1 {
+		return 1
+	}
+	elapsed := total - left
+	if elapsed <= 0 {
+		return 0
+	}
+	return clamp01(float64(elapsed) / float64(max(1, total-1)))
 }
 
 func (p *Procedural) startSnowGustLocked(verb string) {
@@ -4151,5 +4347,150 @@ func (p *Procedural) stepBurningTreesLocked() {
 	}
 	if p.timers["ignite"] > 0 && p.timers["lull"] <= 0 && p.timers["flare"] <= 0 && p.cfg["lull_p"] > 0 && p.rng.Float64() < p.cfg["lull_p"] {
 		p.startBurningTreesLullLocked("started")
+	}
+}
+
+func (p *Procedural) sandFlowLevelLocked() float64 {
+	flow := math.Max(0, p.cfg["flow"])
+	if p.timers["intro"] > 0 {
+		total := int(math.Round(p.values["intro_total"]))
+		progress := proceduralPhaseProgress(total, p.timers["intro"])
+		flow = p.cfg["intro_trickle"] + (flow-p.cfg["intro_trickle"])*progress
+	}
+	if p.timers["ending"] > 0 {
+		total := int(math.Round(p.values["ending_total"]))
+		progress := proceduralPhaseProgress(total, p.timers["ending"])
+		flow *= math.Max(0, 1-progress)
+	}
+	if p.timers["surge"] > 0 {
+		gain := p.values["surge_gain"]
+		if gain <= 0 {
+			gain = p.cfg["surge_mult"]
+		}
+		flow *= gain
+	}
+	if p.timers["calm"] > 0 {
+		gain := p.values["calm_gain"]
+		if gain <= 0 {
+			gain = p.cfg["calm_mult"]
+		}
+		flow *= gain
+	}
+	return math.Max(0, flow)
+}
+
+func (p *Procedural) startSandSurgeLocked(verb string) {
+	p.timers["calm"] = 0
+	p.timers["surge"] = jitterInt(p.rng, p.intCfg("surge_dur"), 0.3)
+	p.values["calm_gain"] = 1
+	p.values["surge_gain"] = p.cfg["surge_mult"] * (0.9 + p.rng.Float64()*0.4)
+	p.appendLog("surge", fmt.Sprintf("%s (dur=%d, x%.2f)", verb, p.timers["surge"], p.values["surge_gain"]))
+}
+
+func (p *Procedural) startSandCalmLocked(verb string) {
+	p.timers["surge"] = 0
+	p.timers["calm"] = jitterInt(p.rng, p.intCfg("calm_dur"), 0.3)
+	p.values["surge_gain"] = 1
+	p.values["calm_gain"] = math.Max(0.08, p.cfg["calm_mult"]*(0.85+p.rng.Float64()*0.25))
+	p.appendLog("calm", fmt.Sprintf("%s (dur=%d, x%.2f)", verb, p.timers["calm"], p.values["calm_gain"]))
+}
+
+func (p *Procedural) startSandIntroLocked() {
+	p.timers["surge"] = 0
+	p.timers["calm"] = 0
+	p.timers["ending"] = 0
+	p.values["surge_gain"] = 1
+	p.values["calm_gain"] = 1
+	p.values["fill_level"] = clamp01(p.cfg["intro_fill"])
+	p.values["spill_level"] = 0
+	p.values["surface_bias"] = 0
+	p.timers["intro"] = p.intCfg("intro_dur")
+	p.values["intro_total"] = float64(p.timers["intro"])
+}
+
+func (p *Procedural) startSandEndingLocked() {
+	p.timers["intro"] = 0
+	p.timers["surge"] = 0
+	p.timers["calm"] = 0
+	p.values["surge_gain"] = 1
+	p.values["calm_gain"] = 1
+	endingTotal := p.intCfg("ending_dur") + max(0, p.intCfg("ending_linger"))
+	if endingTotal < 1 {
+		endingTotal = max(1, p.intCfg("ending_dur"))
+	}
+	p.timers["ending"] = endingTotal
+	p.values["ending_total"] = float64(endingTotal)
+}
+
+func (p *Procedural) stepSandStateLocked() {
+	flow := p.sandFlowLevelLocked()
+	fill := clamp01(p.values["fill_level"])
+	spill := clamp01(p.values["spill_level"])
+	bias := p.values["surface_bias"]
+
+	incoming := flow * (0.02 + p.cfg["spread"]*0.012)
+	fill += incoming * (0.8 + p.cfg["settle"]*0.35)
+	if fill > 1 {
+		spill += (fill - 1) * (0.6 + p.cfg["overflow"]*0.5)
+		fill = 1
+	}
+	if fill > 0.88 {
+		spill += (fill - 0.88) * incoming * (0.4 + p.cfg["overflow"]*0.8)
+	}
+	spill -= (0.004 + p.cfg["settle"]*0.008) * math.Max(0.12, 1-flow*1.2)
+	if p.timers["ending"] > 0 {
+		total := int(math.Round(p.values["ending_total"]))
+		progress := proceduralPhaseProgress(total, p.timers["ending"])
+		spill += p.cfg["ending_settle"] * 0.006 * (1 - progress)
+	}
+
+	targetBias := (p.cfg["pipe_x"] - p.cfg["container_x"]) / 0.22
+	if targetBias < -1 {
+		targetBias = -1
+	} else if targetBias > 1 {
+		targetBias = 1
+	}
+	bias += (targetBias - bias) * (0.04 + flow*0.08 + p.cfg["settle"]*0.04)
+	if spill > 0.02 {
+		dir := 1.0
+		if targetBias < 0 {
+			dir = -1
+		}
+		bias += dir * spill * 0.01
+	}
+	if bias < -1 {
+		bias = -1
+	} else if bias > 1 {
+		bias = 1
+	}
+
+	p.values["fill_level"] = clamp01(fill)
+	p.values["spill_level"] = clamp01(spill)
+	p.values["surface_bias"] = bias
+}
+
+func (p *Procedural) stepSandLocked() {
+	p.stepSandStateLocked()
+	if p.timers["surge"] <= 0 {
+		p.values["surge_gain"] = 1
+	}
+	if p.timers["calm"] <= 0 {
+		p.values["calm_gain"] = 1
+	}
+	if p.timers["intro"] <= 0 {
+		delete(p.values, "intro_total")
+	}
+	if p.timers["ending"] <= 0 {
+		delete(p.values, "ending_total")
+	}
+	if p.timers["intro"] > 0 || p.timers["ending"] > 0 {
+		return
+	}
+	if p.timers["surge"] <= 0 && p.timers["calm"] <= 0 && p.cfg["surge_p"] > 0 && p.rng.Float64() < p.cfg["surge_p"] {
+		p.startSandSurgeLocked("started")
+		return
+	}
+	if p.timers["calm"] <= 0 && p.timers["surge"] <= 0 && p.cfg["calm_p"] > 0 && p.rng.Float64() < p.cfg["calm_p"] {
+		p.startSandCalmLocked("started")
 	}
 }

--- a/sim/procedural_test.go
+++ b/sim/procedural_test.go
@@ -152,6 +152,16 @@ func TestBurningTreesSchema(t *testing.T) {
 	}
 }
 
+func TestSandSchema(t *testing.T) {
+	schema := SandSchema()
+	if schema.Name != "sand" {
+		t.Fatalf("schema name = %q, want sand", schema.Name)
+	}
+	if len(schema.Knobs) == 0 {
+		t.Fatal("expected sand schema knobs")
+	}
+}
+
 func TestProceduralSnowSnapshotRestore(t *testing.T) {
 	p := NewProcedural("snow", 160, 80, 42, nil)
 	if !p.TriggerEvent("gust") {
@@ -676,5 +686,42 @@ func TestProceduralBurningTreesSnapshotRestore(t *testing.T) {
 				t.Fatalf("restored %s = %f, want %f", key, again.Values[key], value)
 			}
 		}
+	}
+}
+
+func TestProceduralSandSnapshotRestore(t *testing.T) {
+	p := NewProcedural("sand", 160, 80, 71, nil)
+	if !p.TriggerEvent("intro") {
+		t.Fatal("expected intro trigger to succeed")
+	}
+	if !p.TriggerEvent("surge") {
+		t.Fatal("expected surge trigger to succeed")
+	}
+	for i := 0; i < 6; i++ {
+		p.Step()
+	}
+
+	snap := p.Snapshot()
+	if snap.Timers["surge"] <= 0 {
+		t.Fatal("expected surge timer in snapshot")
+	}
+	if snap.Values["fill_level"] <= 0 {
+		t.Fatal("expected fill level value in snapshot")
+	}
+	if snap.Values["surface_bias"] == 0 {
+		t.Fatal("expected surface bias value in snapshot")
+	}
+
+	restored := NewProcedural("sand", 160, 80, 7, nil)
+	restored.RestoreSnapshot(snap)
+	again := restored.Snapshot()
+	if again.Timers["surge"] != snap.Timers["surge"] {
+		t.Fatalf("restored surge timer = %d, want %d", again.Timers["surge"], snap.Timers["surge"])
+	}
+	if again.Values["fill_level"] != snap.Values["fill_level"] {
+		t.Fatalf("restored fill level = %f, want %f", again.Values["fill_level"], snap.Values["fill_level"])
+	}
+	if again.Values["surface_bias"] != snap.Values["surface_bias"] {
+		t.Fatalf("restored surface bias = %f, want %f", again.Values["surface_bias"], snap.Values["surface_bias"])
 	}
 }


### PR DESCRIPTION
## Summary
- add the sand procedural dev effect on the Go and browser runtime paths
- model intro/outro, surge/calm flow changes, persistent fill state, and basin overflow so snapshots restore cleanly
- wire the new effect into the dev-session schema/runtime registry with presets and schema-bound randomization coverage

## Testing
- go test ./...
- node --check cmd/ambience/web/sim.js
- powershell -ExecutionPolicy Bypass -File scripts/dev-deploy.ps1 -Component all
- powershell -ExecutionPolicy Bypass -File scripts/dev-loop.ps1 -Once
- visual validation on https://ambience.dev.romaine.life/dev/sand

Refs #3