### PR TITLE
Add the water pipe dev effect prototype

### DIFF
--- a/cmd/ambience/dev_random_test.go
+++ b/cmd/ambience/dev_random_test.go
@@ -30,6 +30,7 @@ func TestRandomizedDevConfigStaysWithinSchemaBounds(t *testing.T) {
 		sim.MysteriousManSchema(),
 		sim.BurningTreesSchema(),
 		sim.SandSchema(),
+		sim.WaterPipeSchema(),
 	}
 
 	for i, schema := range schemas {
@@ -80,6 +81,7 @@ func TestRandomizedDevConfigChangesAtLeastOneKnob(t *testing.T) {
 		sim.MysteriousManSchema(),
 		sim.BurningTreesSchema(),
 		sim.SandSchema(),
+		sim.WaterPipeSchema(),
 	}
 
 	for i, schema := range schemas {

--- a/cmd/ambience/dev_sessions_test.go
+++ b/cmd/ambience/dev_sessions_test.go
@@ -29,6 +29,7 @@ func TestDevPageEffectFromPath(t *testing.T) {
 		{path: "/dev/mysterious-man", want: "mysterious-man", wantOK: true},
 		{path: "/dev/burning-trees", want: "burning-trees", wantOK: true},
 		{path: "/dev/sand", want: "sand", wantOK: true},
+		{path: "/dev/water-pipe", want: "water-pipe", wantOK: true},
 		{path: "/dev/waterfall", want: "waterfall", wantOK: true},
 		{path: "/dev/windmill", want: "windmill", wantOK: true},
 		{path: "/dev/wheat-field", want: "wheat-field", wantOK: true},
@@ -69,6 +70,7 @@ func TestEffectFromSchemaPath(t *testing.T) {
 		{path: "/effects/mysterious-man/schema", want: "mysterious-man", wantOK: true},
 		{path: "/effects/burning-trees/schema", want: "burning-trees", wantOK: true},
 		{path: "/effects/sand/schema", want: "sand", wantOK: true},
+		{path: "/effects/water-pipe/schema", want: "water-pipe", wantOK: true},
 		{path: "/effects/waterfall/schema", want: "waterfall", wantOK: true},
 		{path: "/effects/windmill/schema", want: "windmill", wantOK: true},
 		{path: "/effects/wheat-field/schema", want: "wheat-field", wantOK: true},
@@ -259,6 +261,17 @@ func TestNewDevSessionSandSnapshotType(t *testing.T) {
 	snap := session.snapshot()
 	if snap.Type != "sand" {
 		t.Fatalf("snapshot type = %q, want sand", snap.Type)
+	}
+}
+
+func TestNewDevSessionWaterPipeSnapshotType(t *testing.T) {
+	session, err := newDevSession("water-pipe")
+	if err != nil {
+		t.Fatalf("newDevSession: %v", err)
+	}
+	snap := session.snapshot()
+	if snap.Type != "water-pipe" {
+		t.Fatalf("snapshot type = %q, want water-pipe", snap.Type)
 	}
 }
 

--- a/cmd/ambience/effects.go
+++ b/cmd/ambience/effects.go
@@ -151,6 +151,11 @@ var effectRegistry = map[string]effectDefinition{
 		Schema:     sim.SandSchema,
 		NewRuntime: newSandRuntime,
 	},
+	"water-pipe": {
+		Type:       "water-pipe",
+		Schema:     sim.WaterPipeSchema,
+		NewRuntime: newWaterPipeRuntime,
+	},
 }
 
 func lookupEffectDefinition(effectType string) (effectDefinition, bool) {
@@ -353,6 +358,10 @@ func newBurningTreesRuntime(w, h int, seed int64, cfg json.RawMessage) (effectRu
 
 func newSandRuntime(w, h int, seed int64, cfg json.RawMessage) (effectRuntime, error) {
 	return newProceduralRuntime("sand", w, h, seed, cfg)
+}
+
+func newWaterPipeRuntime(w, h int, seed int64, cfg json.RawMessage) (effectRuntime, error) {
+	return newProceduralRuntime("water-pipe", w, h, seed, cfg)
 }
 
 func (r *rainRuntime) Type() string { return "rain" }
@@ -795,6 +804,8 @@ func (p *proceduralRuntime) Schema() sim.EffectSchema {
 		return sim.BurningTreesSchema()
 	case "sand":
 		return sim.SandSchema()
+	case "water-pipe":
+		return sim.WaterPipeSchema()
 	default:
 		return sim.EffectSchema{}
 	}

--- a/cmd/ambience/web/sim.js
+++ b/cmd/ambience/web/sim.js
@@ -2157,6 +2157,36 @@
 			calm_dur: 60,
 			calm_mult: 0.42,
 		},
+		'water-pipe': {
+			intro_dur: 55,
+			intro_flow: 0.10,
+			intro_pool: 0.08,
+			ending_dur: 70,
+			ending_linger: 22,
+			ending_ripple: 0.08,
+			pipe_x: 0.22,
+			pipe_width: 7,
+			pipe_drop: 17,
+			basin_x: 0.40,
+			basin_width: 30,
+			basin_depth: 9,
+			flow: 0.24,
+			stream: 1.05,
+			ripple: 0.38,
+			overflow: 0.30,
+			foam: 0.22,
+			hue: 196,
+			hue_sp: 18,
+			sat: 0.56,
+			lmin: 0.12,
+			lmax: 0.92,
+			surge_p: 0,
+			dry_up_p: 0,
+			surge_dur: 36,
+			surge_mult: 1.90,
+			dry_up_dur: 50,
+			dry_up_mult: 0.35,
+		},
 		starfield: {
 			intro_dur: 50,
 			intro_density: 0.08,
@@ -2552,6 +2582,35 @@
 				if (c.calm_dur <= 0) c.calm_dur = base.calm_dur;
 				if (c.calm_mult <= 0) c.calm_mult = base.calm_mult;
 				break;
+			case 'water-pipe':
+				if (c.intro_dur <= 0) c.intro_dur = base.intro_dur;
+				c.intro_flow = clamp01(c.intro_flow);
+				c.intro_pool = clamp01(c.intro_pool);
+				if (c.ending_dur <= 0) c.ending_dur = base.ending_dur;
+				if (c.ending_linger < 0) c.ending_linger = 0;
+				c.ending_ripple = clamp01(c.ending_ripple);
+				if (c.pipe_x <= 0) c.pipe_x = base.pipe_x;
+				if (c.pipe_width <= 0) c.pipe_width = base.pipe_width;
+				if (c.pipe_drop <= 0) c.pipe_drop = base.pipe_drop;
+				if (c.basin_x <= 0) c.basin_x = base.basin_x;
+				if (c.basin_width <= 0) c.basin_width = base.basin_width;
+				if (c.basin_depth <= 0) c.basin_depth = base.basin_depth;
+				if (c.flow <= 0) c.flow = base.flow;
+				if (c.stream <= 0) c.stream = base.stream;
+				if (c.ripple <= 0) c.ripple = base.ripple;
+				if (c.overflow <= 0) c.overflow = base.overflow;
+				if (c.foam <= 0) c.foam = base.foam;
+				if (c.hue <= 0) c.hue = base.hue;
+				if (c.hue_sp < 0) c.hue_sp = 0;
+				if (c.sat <= 0) c.sat = base.sat;
+				if (c.lmin <= 0) c.lmin = base.lmin;
+				if (c.lmax <= 0) c.lmax = base.lmax;
+				if (c.lmax < c.lmin) [c.lmin, c.lmax] = [c.lmax, c.lmin];
+				if (c.surge_dur <= 0) c.surge_dur = base.surge_dur;
+				if (c.surge_mult <= 0) c.surge_mult = base.surge_mult;
+				if (c.dry_up_dur <= 0) c.dry_up_dur = base.dry_up_dur;
+				if (c.dry_up_mult <= 0) c.dry_up_mult = base.dry_up_mult;
+				break;
 			case 'aurora':
 				if (c.intro_dur <= 0) c.intro_dur = base.intro_dur;
 				c.intro_glow = clamp01(c.intro_glow);
@@ -2711,6 +2770,8 @@
 					return this._triggerBurningTrees(name);
 				case 'sand':
 					return this._triggerSand(name);
+				case 'water-pipe':
+					return this._triggerWaterPipe(name);
 				case 'aurora':
 					return this._triggerAurora(name);
 				case 'starfield':
@@ -2865,6 +2926,13 @@
 				if (!this.timers.intro || this.timers.intro <= 0) delete this.values.intro_total;
 				if (!this.timers.ending || this.timers.ending <= 0) delete this.values.ending_total;
 			}
+			if (this.kind === 'water-pipe') {
+				this._stepWaterPipeState();
+				if (!this.timers.surge || this.timers.surge <= 0) this.values.surge_gain = 1;
+				if (!this.timers['dry-up'] || this.timers['dry-up'] <= 0) this.values.dry_up_gain = 1;
+				if (!this.timers.intro || this.timers.intro <= 0) delete this.values.intro_total;
+				if (!this.timers.ending || this.timers.ending <= 0) delete this.values.ending_total;
+			}
 		}
 
 		render(ctx, canvasW, canvasH, opts) {
@@ -2893,6 +2961,8 @@
 					return this._renderBurningTrees(ctx, canvasW, canvasH, opts);
 				case 'sand':
 					return this._renderSand(ctx, canvasW, canvasH, opts);
+				case 'water-pipe':
+					return this._renderWaterPipe(ctx, canvasW, canvasH, opts);
 				case 'aurora':
 					return this._renderAurora(ctx, canvasW, canvasH, opts);
 				case 'starfield':
@@ -3545,6 +3615,47 @@
 			return false;
 		}
 
+		_triggerWaterPipe(name) {
+			const rng = this._eventRng(name.length + 157);
+			switch (name) {
+				case 'surge':
+					this.timers['dry-up'] = 0;
+					this.timers.surge = jitterInt(rng, this.cfg.surge_dur, 0.3);
+					this.values.dry_up_gain = 1;
+					this.values.surge_gain = this.cfg.surge_mult * (0.9 + rng() * 0.35);
+					return true;
+				case 'dry-up':
+					this.timers.surge = 0;
+					this.timers['dry-up'] = jitterInt(rng, this.cfg.dry_up_dur, 0.3);
+					this.values.surge_gain = 1;
+					this.values.dry_up_gain = Math.max(0.08, this.cfg.dry_up_mult * (0.85 + rng() * 0.25));
+					return true;
+				case 'intro':
+					this.timers.surge = 0;
+					this.timers['dry-up'] = 0;
+					this.timers.ending = 0;
+					this.values.surge_gain = 1;
+					this.values.dry_up_gain = 1;
+					this.values.fill_level = clamp01(this.cfg.intro_pool);
+					this.values.spill_level = 0;
+					this.values.surface_bias = 0;
+					this.values.ripple_phase = 0;
+					this.timers.intro = Math.max(1, Math.round(this.cfg.intro_dur));
+					this.values.intro_total = this.timers.intro;
+					return true;
+				case 'ending':
+					this.timers.intro = 0;
+					this.timers.surge = 0;
+					this.timers['dry-up'] = 0;
+					this.values.surge_gain = 1;
+					this.values.dry_up_gain = 1;
+					this.timers.ending = Math.max(1, Math.round(this.cfg.ending_dur + Math.max(0, this.cfg.ending_linger)));
+					this.values.ending_total = this.timers.ending;
+					return true;
+			}
+			return false;
+		}
+
 		_triggerAurora(name) {
 			const rng = this._eventRng(name.length + 53);
 			switch (name) {
@@ -3961,6 +4072,60 @@
 			this.values.fill_level = clamp01(fill);
 			this.values.spill_level = clamp01(spill);
 			this.values.surface_bias = bias;
+		}
+
+		_waterPipeFlowLevel() {
+			let flow = Math.max(0, this.cfg.flow);
+			if (this.timers.intro > 0) {
+				const total = this.values.intro_total || this.cfg.intro_dur;
+				const progress = this._phaseProgress(total, this.timers.intro);
+				flow = this.cfg.intro_flow + (flow - this.cfg.intro_flow) * progress;
+			}
+			if (this.timers.ending > 0) {
+				const total = this.values.ending_total || (this.cfg.ending_dur + this.cfg.ending_linger);
+				const progress = this._phaseProgress(total, this.timers.ending);
+				flow *= Math.max(0, 1 - progress);
+			}
+			if (this.timers.surge > 0) flow *= this.values.surge_gain || this.cfg.surge_mult;
+			if (this.timers['dry-up'] > 0) flow *= this.values.dry_up_gain || this.cfg.dry_up_mult;
+			return Math.max(0, flow);
+		}
+
+		_stepWaterPipeState() {
+			const flow = this._waterPipeFlowLevel();
+			let fill = clamp01(this.values.fill_level || 0);
+			let spill = clamp01(this.values.spill_level || 0);
+			let bias = this.values.surface_bias || 0;
+			let ripplePhase = this.values.ripple_phase || 0;
+
+			const incoming = flow * (0.016 + this.cfg.stream * 0.010);
+			fill += incoming * (0.72 + this.cfg.ripple * 0.2);
+			if (fill > 1) {
+				spill += (fill - 1) * (0.7 + this.cfg.overflow * 0.45);
+				fill = 1;
+			}
+			if (fill > 0.9) {
+				spill += (fill - 0.9) * incoming * (0.3 + this.cfg.overflow * 0.9);
+			}
+			spill -= (0.002 + this.cfg.overflow * 0.006) * Math.max(0.1, 1 - flow * 0.9);
+			if (this.timers.ending > 0) {
+				const total = this.values.ending_total || (this.cfg.ending_dur + this.cfg.ending_linger);
+				const progress = this._phaseProgress(total, this.timers.ending);
+				spill += this.cfg.ending_ripple * 0.004 * (1 - progress);
+			}
+
+			let targetBias = (this.cfg.pipe_x - this.cfg.basin_x) / 0.24;
+			targetBias = Math.max(-1, Math.min(1, targetBias));
+			bias += (targetBias - bias) * (0.03 + flow * 0.05 + this.cfg.ripple * 0.03);
+			bias = Math.max(-1, Math.min(1, bias));
+
+			ripplePhase += 0.12 + flow * (0.8 + this.cfg.stream * 0.4) + spill * 0.4;
+			if (ripplePhase > Math.PI * 200) ripplePhase = positiveMod(ripplePhase, Math.PI * 2);
+
+			this.values.fill_level = clamp01(fill);
+			this.values.spill_level = clamp01(spill);
+			this.values.surface_bias = bias;
+			this.values.ripple_phase = ripplePhase;
 		}
 
 		_renderSnow(ctx, canvasW, canvasH, opts) {
@@ -5898,6 +6063,174 @@
 			}
 		}
 
+		_renderWaterPipe(ctx, canvasW, canvasH, opts) {
+			opts = opts || {};
+			if (opts.transparent) {
+				ctx.clearRect(0, 0, canvasW, canvasH);
+			} else {
+				const skyTop = hslToRGB((this.cfg.hue - 24 + 360) % 360, clamp01(this.cfg.sat * 0.28), clamp01(this.cfg.lmin * 0.42));
+				const skyMid = hslToRGB((this.cfg.hue - 10 + 360) % 360, clamp01(this.cfg.sat * 0.2), clamp01(this.cfg.lmin + (this.cfg.lmax - this.cfg.lmin) * 0.08));
+				const skyLow = hslToRGB(this.cfg.hue % 360, clamp01(this.cfg.sat * 0.24), clamp01(this.cfg.lmin + (this.cfg.lmax - this.cfg.lmin) * 0.18));
+				const bg = ctx.createLinearGradient(0, 0, 0, canvasH);
+				bg.addColorStop(0, `rgb(${skyTop.r},${skyTop.g},${skyTop.b})`);
+				bg.addColorStop(0.65, `rgb(${skyMid.r},${skyMid.g},${skyMid.b})`);
+				bg.addColorStop(1, `rgb(${skyLow.r},${skyLow.g},${skyLow.b})`);
+				ctx.fillStyle = bg;
+				ctx.fillRect(0, 0, canvasW, canvasH);
+			}
+
+			const sx = canvasW / this.w;
+			const sy = canvasH / this.h;
+			const ceilSx = Math.ceil(sx);
+			const ceilSy = Math.ceil(sy);
+			const floorRow = Math.max(10, Math.min(this.h - 5, Math.floor(this.h * 0.82)));
+			const pipeX = Math.round(this.w * this.cfg.pipe_x);
+			const pipeW = Math.max(4, Math.round(this.cfg.pipe_width));
+			const outletY = Math.max(4, floorRow - Math.round(this.cfg.pipe_drop));
+			let basinCenter = Math.round(this.w * this.cfg.basin_x);
+			const maxPipeGap = Math.round(this.w * 0.22);
+			if (Math.abs(basinCenter - pipeX) > maxPipeGap) {
+				basinCenter = pipeX + (basinCenter >= pipeX ? maxPipeGap : -maxPipeGap);
+			}
+			const basinW = Math.max(18, Math.round(this.cfg.basin_width));
+			const basinD = Math.max(6, Math.round(this.cfg.basin_depth));
+			const sceneRightLimit = Math.max(basinW + 8, Math.floor(this.w * 0.74));
+			const left = Math.max(4, Math.min(Math.min(this.w - basinW - 4, sceneRightLimit - basinW), basinCenter - Math.floor(basinW / 2)));
+			const right = left + basinW - 1;
+			const basinFloor = floorRow - 1;
+			const basinTop = basinFloor - basinD;
+			const fill = clamp01(this.values.fill_level || 0);
+			const spill = clamp01(this.values.spill_level || 0);
+			const surfaceBias = Math.max(-1, Math.min(1, this.values.surface_bias || 0));
+			const ripplePhase = this.values.ripple_phase || 0;
+			const flow = this._waterPipeFlowLevel();
+			const motion = clamp01(flow * 2.2 + spill * 1.1 + (this.timers.surge > 0 ? 0.18 : 0));
+			const wallColor = hslToRGB((this.cfg.hue + 22) % 360, clamp01(this.cfg.sat * 0.1), clamp01(this.cfg.lmin * 0.62));
+			const floorColor = hslToRGB((this.cfg.hue + 10) % 360, clamp01(this.cfg.sat * 0.16), clamp01(this.cfg.lmin * 0.78));
+			const seamColor = hslToRGB((this.cfg.hue + 8) % 360, clamp01(this.cfg.sat * 0.08), clamp01(this.cfg.lmin * 1.12));
+			const pipeColor = hslToRGB((this.cfg.hue + 16) % 360, clamp01(this.cfg.sat * 0.08), clamp01(this.cfg.lmin * 0.96));
+			const pipeEdge = hslToRGB((this.cfg.hue + 24) % 360, clamp01(this.cfg.sat * 0.06), clamp01(this.cfg.lmin + (this.cfg.lmax - this.cfg.lmin) * 0.38));
+			const basinColor = hslToRGB((this.cfg.hue + 14) % 360, clamp01(this.cfg.sat * 0.1), clamp01(this.cfg.lmin * 0.86));
+			const basinInterior = hslToRGB((this.cfg.hue + 8) % 360, clamp01(this.cfg.sat * 0.08), clamp01(this.cfg.lmin * 0.54));
+			const rimColor = hslToRGB((this.cfg.hue + 28) % 360, clamp01(this.cfg.sat * 0.08), clamp01(this.cfg.lmin + (this.cfg.lmax - this.cfg.lmin) * 0.42));
+			const waterDeep = hslToRGB((this.cfg.hue - this.cfg.hue_sp * 0.35 + 360) % 360, clamp01(this.cfg.sat * 0.84), clamp01(this.cfg.lmin + (this.cfg.lmax - this.cfg.lmin) * 0.18));
+			const waterMid = hslToRGB(this.cfg.hue % 360, clamp01(this.cfg.sat * 0.78), clamp01(this.cfg.lmin + (this.cfg.lmax - this.cfg.lmin) * 0.42));
+			const waterHi = hslToRGB((this.cfg.hue + this.cfg.hue_sp * 0.24) % 360, clamp01(this.cfg.sat * 0.62), clamp01(this.cfg.lmin + (this.cfg.lmax - this.cfg.lmin) * 0.74));
+			const foamColor = hslToRGB((this.cfg.hue + this.cfg.hue_sp * 0.5) % 360, clamp01(this.cfg.sat * 0.18), clamp01(Math.min(1, this.cfg.lmax * 0.99)));
+
+			this._fillCell(ctx, sx, sy, ceilSx, ceilSy, 0, 0, this.w, floorRow, `rgb(${wallColor.r},${wallColor.g},${wallColor.b})`, 0.18);
+			this._fillCell(ctx, sx, sy, ceilSx, ceilSy, 0, floorRow, this.w, this.h - floorRow, `rgb(${floorColor.r},${floorColor.g},${floorColor.b})`, 1);
+			this._fillCell(ctx, sx, sy, ceilSx, ceilSy, 0, floorRow, this.w, 1, `rgb(${seamColor.r},${seamColor.g},${seamColor.b})`, 0.42);
+
+			const glow = ctx.createRadialGradient(pipeX * sx, outletY * sy, 0, pipeX * sx, outletY * sy, Math.max(22, 16 * sx));
+			glow.addColorStop(0, `rgba(${waterHi.r},${waterHi.g},${waterHi.b}, ${clamp01(0.12 + motion * 0.14)})`);
+			glow.addColorStop(1, `rgba(${waterHi.r},${waterHi.g},${waterHi.b}, 0)`);
+			ctx.fillStyle = glow;
+			ctx.fillRect(Math.floor((pipeX - 10) * sx), Math.floor((outletY - 7) * sy), Math.ceil(20 * sx), Math.ceil(15 * sy));
+
+			this._fillCell(ctx, sx, sy, ceilSx, ceilSy, pipeX - pipeW - 3, outletY - 3, pipeW + 3, 4, `rgb(${pipeColor.r},${pipeColor.g},${pipeColor.b})`, 1);
+			this._fillCell(ctx, sx, sy, ceilSx, ceilSy, pipeX - 2, outletY - 3, 3, 5, `rgb(${pipeColor.r},${pipeColor.g},${pipeColor.b})`, 1);
+			this._fillCell(ctx, sx, sy, ceilSx, ceilSy, pipeX - pipeW - 2, outletY - 2, pipeW + 1, 1, `rgb(${pipeEdge.r},${pipeEdge.g},${pipeEdge.b})`, 0.72);
+			this._fillCell(ctx, sx, sy, ceilSx, ceilSy, pipeX - 1, outletY - 2, 1, 4, `rgb(${pipeEdge.r},${pipeEdge.g},${pipeEdge.b})`, 0.72);
+
+			this._fillCell(ctx, sx, sy, ceilSx, ceilSy, left, basinTop + 1, basinW, basinD, `rgb(${basinInterior.r},${basinInterior.g},${basinInterior.b})`, 0.5);
+			this._fillCell(ctx, sx, sy, ceilSx, ceilSy, left - 1, basinTop, 2, basinD + 2, `rgb(${basinColor.r},${basinColor.g},${basinColor.b})`, 1);
+			this._fillCell(ctx, sx, sy, ceilSx, ceilSy, right, basinTop, 2, basinD + 2, `rgb(${basinColor.r},${basinColor.g},${basinColor.b})`, 1);
+			this._fillCell(ctx, sx, sy, ceilSx, ceilSy, left - 1, basinFloor, basinW + 2, 2, `rgb(${basinColor.r},${basinColor.g},${basinColor.b})`, 1);
+			this._fillCell(ctx, sx, sy, ceilSx, ceilSy, left - 1, basinTop, basinW + 2, 1, `rgb(${rimColor.r},${rimColor.g},${rimColor.b})`, 0.8);
+
+			const surfaceRows = [];
+			const peak = 0.5 + surfaceBias * 0.18;
+			const rippleAmp = (0.15 + motion * 0.45 + this.cfg.ripple * 0.3) * Math.max(0.2, fill);
+			for (let x = left + 1; x < right; x++) {
+				const nx = (x - (left + 1)) / Math.max(1, basinW - 3);
+				const bowl = clamp01(1 - Math.abs((nx - peak) / 0.58));
+				const wave = Math.sin(ripplePhase + nx * Math.PI * (2.8 + this.cfg.ripple * 1.1)) * rippleAmp;
+				const localFill = fill * (0.88 + bowl * 0.16);
+				const height = Math.max(0, Math.round(localFill * (basinD - 1) + wave));
+				const surfaceY = basinFloor - height;
+				surfaceRows.push(surfaceY);
+				for (let y = surfaceY; y < basinFloor; y++) {
+					const depth = (y - surfaceY) / Math.max(1, basinFloor - surfaceY);
+					const color = depth < 0.18 ? waterHi : (depth < 0.48 ? waterMid : waterDeep);
+					this._fillCell(ctx, sx, sy, ceilSx, ceilSy, x, y, 1, 1, `rgb(${color.r},${color.g},${color.b})`, 0.94);
+				}
+				if (height > 0) {
+					const shimmer = Math.max(0, Math.sin(ripplePhase * 0.7 + nx * Math.PI * 4.5));
+					const alpha = clamp01(0.12 + this.cfg.foam * 0.16 + shimmer * 0.12);
+					this._fillCell(ctx, sx, sy, ceilSx, ceilSy, x, surfaceY, 1, 1, `rgb(${foamColor.r},${foamColor.g},${foamColor.b})`, alpha);
+				}
+			}
+
+			const impactX = Math.max(left + 2, Math.min(right - 2, pipeX + Math.round(surfaceBias * basinW * 0.18)));
+			const impactIdx = Math.max(0, Math.min(surfaceRows.length - 1, impactX - (left + 1)));
+			const impactY = surfaceRows[impactIdx] || basinFloor - 1;
+
+			if (spill > 0.01) {
+				const dir = surfaceBias < 0 ? -1 : 1;
+				const spillLen = Math.max(4, Math.round(spill * (10 + this.cfg.overflow * 22)));
+				for (let s = 0; s < spillLen; s++) {
+					const taper = 1 - s / Math.max(1, spillLen - 1);
+					const height = Math.max(1, Math.round(1 + taper * (1.5 + spill * 3)));
+					const x = dir > 0 ? right + s : left - s;
+					const y = basinFloor - height + 1 + Math.round(s * 0.06);
+					this._fillCell(ctx, sx, sy, ceilSx, ceilSy, x, y, 1, height, `rgb(${waterMid.r},${waterMid.g},${waterMid.b})`, 0.9);
+					this._fillCell(ctx, sx, sy, ceilSx, ceilSy, x, y, 1, 1, `rgb(${foamColor.r},${foamColor.g},${foamColor.b})`, clamp01(0.16 + taper * this.cfg.foam * 0.3));
+				}
+				const puddleLen = Math.max(3, Math.round(spill * (6 + this.cfg.overflow * 12)));
+				const puddleStart = dir > 0 ? right + spillLen - 1 : left - spillLen + 1;
+				for (let i = 0; i < puddleLen; i++) {
+					const x = dir > 0 ? puddleStart + i : puddleStart - i;
+					const alpha = clamp01(0.16 + spill * 0.22 - i * 0.012);
+					if (alpha <= 0.02) continue;
+					this._fillCell(ctx, sx, sy, ceilSx, ceilSy, x, basinFloor, 1, 1, `rgb(${waterDeep.r},${waterDeep.g},${waterDeep.b})`, alpha);
+					if ((i + this.tick) % 3 === 0) {
+						this._fillCell(ctx, sx, sy, ceilSx, ceilSy, x, basinFloor, 1, 1, `rgb(${foamColor.r},${foamColor.g},${foamColor.b})`, alpha * 0.42);
+					}
+				}
+			}
+
+			if (flow > 0.01) {
+				const streamW = Math.max(1, Math.round(1 + this.cfg.stream * 1.2 + flow * 1.6));
+				for (let y = outletY + 2; y <= impactY; y++) {
+					const t = (y - outletY) / Math.max(1, impactY - outletY);
+					const sway = Math.sin(this.tick * 0.05 + y * 0.16) * this.cfg.stream * 0.12;
+					const centerX = pipeX + surfaceBias * t * basinW * 0.06 + sway;
+					for (let dx = -Math.floor(streamW / 2); dx <= Math.floor(streamW / 2); dx++) {
+						const edge = Math.abs(dx) / Math.max(1, streamW / 2);
+						const alpha = clamp01(0.18 + flow * 0.9 - edge * 0.24);
+						if (alpha <= 0.02) continue;
+						const color = edge < 0.35 ? waterHi : waterMid;
+						this._fillCell(ctx, sx, sy, ceilSx, ceilSy, Math.round(centerX + dx), y, 1, 1, `rgb(${color.r},${color.g},${color.b})`, alpha);
+					}
+				}
+
+				const splashCount = Math.max(5, Math.round(5 + flow * 16 + this.cfg.foam * 10));
+				for (let i = 0; i < splashCount; i++) {
+					const lift = this._hash(37000 + i) * (1.5 + motion * 4.4);
+					const drift = (this._hash(37100 + i) * 2 - 1) * (1 + this.cfg.stream * 1.8);
+					const x = Math.round(impactX + drift);
+					const y = Math.round(impactY - lift);
+					const alpha = clamp01(0.08 + motion * 0.22 + this.cfg.foam * 0.14);
+					const color = i % 2 === 0 ? foamColor : waterHi;
+					this._fillCell(ctx, sx, sy, ceilSx, ceilSy, x, y, 1, 1, `rgb(${color.r},${color.g},${color.b})`, alpha);
+				}
+			}
+
+			if (fill > 0.02) {
+				for (let x = left + 2; x < right - 1; x++) {
+					const idx = x - (left + 1);
+					const surfaceY = surfaceRows[Math.max(0, Math.min(surfaceRows.length - 1, idx))];
+					if (surfaceY >= basinFloor) continue;
+					const nx = (x - left) / Math.max(1, basinW);
+					const wave = Math.sin(ripplePhase * 1.1 + nx * Math.PI * (5 + this.cfg.ripple * 2) + (x - impactX) * 0.15);
+					const alpha = clamp01((0.05 + this.cfg.foam * 0.1 + motion * 0.08) * Math.max(0, wave));
+					if (alpha <= 0.02) continue;
+					this._fillCell(ctx, sx, sy, ceilSx, ceilSy, x, surfaceY, 1, 1, `rgb(${foamColor.r},${foamColor.g},${foamColor.b})`, alpha);
+				}
+			}
+		}
+
 		_renderAurora(ctx, canvasW, canvasH, opts) {
 			opts = opts || {};
 			if (opts.transparent) {
@@ -6098,6 +6431,12 @@
 		}
 	}
 
+	class WaterPipe extends ProceduralScene {
+		constructor(w, h, cfg, seed) {
+			super('water-pipe', w, h, cfg, seed);
+		}
+	}
+
 	class Aurora extends ProceduralScene {
 		constructor(w, h, cfg, seed) {
 			super('aurora', w, h, cfg, seed);
@@ -6156,7 +6495,7 @@
 	// server's snapshot payload — the client looks up the constructor here
 	// by name so new effects just register themselves and work without
 	// client-side changes.
-	const effects = { rain: Rain, dust: Dust, fireflies: Fireflies, waterfall: Waterfall, 'wheat-field': WheatField, beach: Beach, campfire: Campfire, windmill: Windmill, lighthouse: Lighthouse, rowboat: Rowboat, underwater: Underwater, volcano: Volcano, train: Train, 'mysterious-man': MysteriousMan, 'burning-trees': BurningTrees, sand: Sand, aurora: Aurora, snow: Snow, 'autumn-leaves': AutumnLeaves, starfield: Starfield };
+	const effects = { rain: Rain, dust: Dust, fireflies: Fireflies, waterfall: Waterfall, 'wheat-field': WheatField, beach: Beach, campfire: Campfire, windmill: Windmill, lighthouse: Lighthouse, rowboat: Rowboat, underwater: Underwater, volcano: Volcano, train: Train, 'mysterious-man': MysteriousMan, 'burning-trees': BurningTrees, sand: Sand, 'water-pipe': WaterPipe, aurora: Aurora, snow: Snow, 'autumn-leaves': AutumnLeaves, starfield: Starfield };
 	const presets = {
 		'wheat-field': [
 			{
@@ -7317,6 +7656,114 @@
 				},
 			},
 		],
+		'water-pipe': [
+			{
+				key: 'small-trickle',
+				label: 'small trickle',
+				config: {
+					intro_flow: 0.08,
+					intro_pool: 0.02,
+					ending_ripple: 0.1,
+					pipe_x: 0.18,
+					pipe_width: 6,
+					pipe_drop: 16,
+					basin_x: 0.36,
+					basin_width: 28,
+					basin_depth: 9,
+					flow: 0.12,
+					stream: 0.55,
+					ripple: 0.24,
+					overflow: 0.14,
+					foam: 0.12,
+					hue: 194,
+					hue_sp: 14,
+					sat: 0.44,
+					lmin: 0.12,
+					lmax: 0.82,
+					dry_up_p: 0.0011,
+				},
+			},
+			{
+				key: 'steady-pool',
+				label: 'steady pool',
+				config: {
+					intro_flow: 0.1,
+					intro_pool: 0.08,
+					ending_ripple: 0.08,
+					pipe_x: 0.22,
+					pipe_width: 7,
+					pipe_drop: 17,
+					basin_x: 0.4,
+					basin_width: 30,
+					basin_depth: 9,
+					flow: 0.24,
+					stream: 1.05,
+					ripple: 0.38,
+					overflow: 0.3,
+					foam: 0.22,
+					hue: 196,
+					hue_sp: 18,
+					sat: 0.56,
+					lmin: 0.12,
+					lmax: 0.92,
+					surge_p: 0.0008,
+				},
+			},
+			{
+				key: 'heavy-spill',
+				label: 'heavy spill',
+				config: {
+					intro_flow: 0.14,
+					intro_pool: 0.12,
+					ending_ripple: 0.06,
+					pipe_x: 0.24,
+					pipe_width: 8,
+					pipe_drop: 18,
+					basin_x: 0.42,
+					basin_width: 28,
+					basin_depth: 8,
+					flow: 0.34,
+					stream: 1.25,
+					ripple: 0.44,
+					overflow: 0.42,
+					foam: 0.24,
+					hue: 200,
+					hue_sp: 20,
+					sat: 0.58,
+					lmin: 0.12,
+					lmax: 0.92,
+					surge_p: 0.0012,
+					surge_mult: 2.15,
+				},
+			},
+			{
+				key: 'edge-runoff',
+				label: 'edge runoff',
+				config: {
+					intro_flow: 0.12,
+					intro_pool: 0.05,
+					ending_ripple: 0.12,
+					pipe_x: 0.28,
+					pipe_width: 7,
+					pipe_drop: 17,
+					basin_x: 0.38,
+					basin_width: 22,
+					basin_depth: 7,
+					flow: 0.28,
+					stream: 1.05,
+					ripple: 0.36,
+					overflow: 0.56,
+					foam: 0.22,
+					hue: 192,
+					hue_sp: 16,
+					sat: 0.5,
+					lmin: 0.11,
+					lmax: 0.88,
+					surge_p: 0.001,
+					dry_up_p: 0.0005,
+				},
+			},
+		],
 		starfield: [
 			{
 				key: 'still-night',
@@ -7743,5 +8190,5 @@
 		],
 	};
 
-	global.AmbienceSim = { Rain, Dust, Fireflies, Waterfall, WheatField, Beach, Campfire, Windmill, Lighthouse, Rowboat, Underwater, Volcano, Train, MysteriousMan, BurningTrees, Sand, Aurora, AutumnLeaves, Snow, Starfield, subscribe, applyDefaults, hslToRGB, effects, presets };
+	global.AmbienceSim = { Rain, Dust, Fireflies, Waterfall, WheatField, Beach, Campfire, Windmill, Lighthouse, Rowboat, Underwater, Volcano, Train, MysteriousMan, BurningTrees, Sand, WaterPipe, Aurora, AutumnLeaves, Snow, Starfield, subscribe, applyDefaults, hslToRGB, effects, presets };
 })(window);

--- a/sim/procedural.go
+++ b/sim/procedural.go
@@ -507,6 +507,37 @@ var sandDefaults = ProceduralConfig{
 	"calm_mult":       0.42,
 }
 
+var waterPipeDefaults = ProceduralConfig{
+	"intro_dur":     55,
+	"intro_flow":    0.10,
+	"intro_pool":    0.08,
+	"ending_dur":    70,
+	"ending_linger": 22,
+	"ending_ripple": 0.08,
+	"pipe_x":        0.22,
+	"pipe_width":    7.0,
+	"pipe_drop":     17.0,
+	"basin_x":       0.40,
+	"basin_width":   30.0,
+	"basin_depth":   9.0,
+	"flow":          0.24,
+	"stream":        1.05,
+	"ripple":        0.38,
+	"overflow":      0.30,
+	"foam":          0.22,
+	"hue":           196,
+	"hue_sp":        18,
+	"sat":           0.56,
+	"lmin":          0.12,
+	"lmax":          0.92,
+	"surge_p":       0.0,
+	"dry_up_p":      0.0,
+	"surge_dur":     36,
+	"surge_mult":    1.90,
+	"dry_up_dur":    50,
+	"dry_up_mult":   0.35,
+}
+
 func SnowSchema() EffectSchema {
 	return EffectSchema{
 		Name: "snow",
@@ -1461,6 +1492,70 @@ func SandSchema() EffectSchema {
 	}
 }
 
+func WaterPipeSchema() EffectSchema {
+	return EffectSchema{
+		Name: "water-pipe",
+		Knobs: []Knob{
+			{Key: "intro_dur", Label: "intro dur", Slot: SlotSpawn, Group: "introduction", Type: KnobInt, Min: 10, Max: 220, Step: 5, Default: 55, Trigger: "intro",
+				Description: "Ticks spent ramping from a drip into the full water pour."},
+			{Key: "intro_flow", Label: "intro flow", Slot: SlotSpawn, Group: "introduction", Type: KnobFloat, Min: 0.01, Max: 0.4, Step: 0.01, Default: 0.10,
+				Description: "Starting fraction of the full water flow during the intro."},
+			{Key: "intro_pool", Label: "intro pool", Slot: SlotSpawn, Group: "introduction", Type: KnobFloat, Min: 0, Max: 0.4, Step: 0.01, Default: 0.08,
+				Description: "Initial pool depth already resting in the basin when the intro begins."},
+			{Key: "ending_dur", Label: "ending dur", Slot: SlotEnd, Group: "ending", Type: KnobInt, Min: 10, Max: 240, Step: 5, Default: 70, Trigger: "ending",
+				Description: "Ticks spent tapering the source from a pour back toward stillness."},
+			{Key: "ending_linger", Label: "ending linger", Slot: SlotEnd, Group: "ending", Type: KnobInt, Min: 0, Max: 180, Step: 5, Default: 22,
+				Description: "Extra quiet ticks for ripples and runoff to settle after the source cuts off."},
+			{Key: "ending_ripple", Label: "ending ripple", Slot: SlotEnd, Group: "ending", Type: KnobFloat, Min: 0.01, Max: 0.4, Step: 0.01, Default: 0.08,
+				Description: "Residual ripple and overflow motion remaining near the end of the outro."},
+			{Key: "pipe_x", Label: "pipe x", Slot: SlotLever, Group: "layout", Type: KnobFloat, Min: 0.08, Max: 0.45, Step: 0.01, Default: 0.22,
+				Description: "Horizontal location of the pipe outlet."},
+			{Key: "pipe_width", Label: "pipe width", Slot: SlotLever, Group: "layout", Type: KnobFloat, Min: 4, Max: 12, Step: 1, Default: 7,
+				Description: "Width of the source pipe silhouette in pixels."},
+			{Key: "pipe_drop", Label: "pipe drop", Slot: SlotLever, Group: "layout", Type: KnobFloat, Min: 8, Max: 28, Step: 1, Default: 17,
+				Description: "Distance from the pipe outlet down to the basin floor."},
+			{Key: "basin_x", Label: "basin x", Slot: SlotLever, Group: "layout", Type: KnobFloat, Min: 0.35, Max: 0.78, Step: 0.01, Default: 0.40,
+				Description: "Horizontal center of the receiving basin."},
+			{Key: "basin_width", Label: "basin width", Slot: SlotLever, Group: "layout", Type: KnobFloat, Min: 18, Max: 56, Step: 1, Default: 30,
+				Description: "Interior width of the receiving basin."},
+			{Key: "basin_depth", Label: "basin depth", Slot: SlotLever, Group: "layout", Type: KnobFloat, Min: 6, Max: 18, Step: 1, Default: 9,
+				Description: "Interior depth of the receiving basin."},
+			{Key: "flow", Label: "flow", Slot: SlotLever, Group: "water", Type: KnobFloat, Min: 0.05, Max: 0.7, Step: 0.01, Default: 0.24,
+				Description: "Baseline inflow rate from the pipe."},
+			{Key: "stream", Label: "stream", Slot: SlotLever, Group: "water", Type: KnobFloat, Min: 0.2, Max: 2.5, Step: 0.05, Default: 1.05,
+				Description: "Thickness and cohesion of the falling stream."},
+			{Key: "ripple", Label: "ripple", Slot: SlotLever, Group: "water", Type: KnobFloat, Min: 0.05, Max: 1.2, Step: 0.05, Default: 0.38,
+				Description: "Amount of surface motion and splash ripple in the basin."},
+			{Key: "overflow", Label: "overflow", Slot: SlotLever, Group: "water", Type: KnobFloat, Min: 0.05, Max: 1.4, Step: 0.05, Default: 0.30,
+				Description: "How readily excess water spills out and runs along the floor."},
+			{Key: "foam", Label: "foam", Slot: SlotLever, Group: "water", Type: KnobFloat, Min: 0.02, Max: 0.8, Step: 0.01, Default: 0.22,
+				Description: "Amount of bright splash foam and edge highlights."},
+			{Key: "hue", Label: "hue", Slot: SlotLever, Group: "palette", Type: KnobFloat, Min: 170, Max: 220, Step: 1, Default: 196,
+				Description: "Base water hue from muted teal toward cool blue."},
+			{Key: "hue_sp", Label: "hue spread", Slot: SlotLever, Group: "palette", Type: KnobFloat, Min: 0, Max: 30, Step: 1, Default: 18,
+				Description: "Variation between deep pool tones, highlights, and foam."},
+			{Key: "sat", Label: "saturation", Slot: SlotLever, Group: "palette", Type: KnobFloat, Min: 0.1, Max: 0.9, Step: 0.01, Default: 0.56,
+				Description: "Overall scene saturation."},
+			{Key: "lmin", Label: "light min", Slot: SlotLever, Group: "palette", Type: KnobFloat, Min: 0.05, Max: 0.4, Step: 0.01, Default: 0.12,
+				Description: "Minimum lightness used for the deepest pool shadows and background."},
+			{Key: "lmax", Label: "light max", Slot: SlotLever, Group: "palette", Type: KnobFloat, Min: 0.4, Max: 1, Step: 0.01, Default: 0.92,
+				Description: "Maximum lightness used for splash foam and top-surface highlights."},
+			{Key: "surge_p", Label: "surge", Slot: SlotEvent, Type: KnobFloat, Min: 0, Max: 0.02, Step: 0.0005, Default: 0, Trigger: "surge",
+				Description: "Per-tick chance of the source temporarily pouring harder."},
+			{Key: "dry_up_p", Label: "dry up", Slot: SlotEvent, Type: KnobFloat, Min: 0, Max: 0.02, Step: 0.0005, Default: 0, Trigger: "dry-up",
+				Description: "Per-tick chance of the source reducing to a weaker trickle or pause."},
+			{Key: "surge_dur", Label: "surge dur", Slot: SlotEventMod, Group: "surge", Type: KnobInt, Min: 10, Max: 160, Step: 5, Default: 36,
+				Description: "Duration of the surge window."},
+			{Key: "surge_mult", Label: "surge x", Slot: SlotEventMod, Group: "surge", Type: KnobFloat, Min: 1.05, Max: 3, Step: 0.05, Default: 1.9,
+				Description: "Flow multiplier applied during a surge."},
+			{Key: "dry_up_dur", Label: "dry up dur", Slot: SlotEventMod, Group: "dry-up", Type: KnobInt, Min: 10, Max: 180, Step: 5, Default: 50,
+				Description: "Duration of the reduced-flow dry-up window."},
+			{Key: "dry_up_mult", Label: "dry up x", Slot: SlotEventMod, Group: "dry-up", Type: KnobFloat, Min: 0.05, Max: 1, Step: 0.05, Default: 0.35,
+				Description: "Flow multiplier applied while dry-up is active."},
+		},
+	}
+}
+
 func cloneProceduralConfig(src ProceduralConfig) ProceduralConfig {
 	if src == nil {
 		return ProceduralConfig{}
@@ -1533,6 +1628,8 @@ func proceduralDefaults(kind string) ProceduralConfig {
 		return cloneProceduralConfig(burningTreesDefaults)
 	case "sand":
 		return cloneProceduralConfig(sandDefaults)
+	case "water-pipe":
+		return cloneProceduralConfig(waterPipeDefaults)
 	default:
 		return ProceduralConfig{}
 	}
@@ -2612,6 +2709,82 @@ func mergeProceduralDefaults(kind string, cfg ProceduralConfig) ProceduralConfig
 		if out["calm_mult"] <= 0 {
 			out["calm_mult"] = sandDefaults["calm_mult"]
 		}
+	case "water-pipe":
+		if out["intro_dur"] <= 0 {
+			out["intro_dur"] = waterPipeDefaults["intro_dur"]
+		}
+		out["intro_flow"] = clamp01(out["intro_flow"])
+		out["intro_pool"] = clamp01(out["intro_pool"])
+		if out["ending_dur"] <= 0 {
+			out["ending_dur"] = waterPipeDefaults["ending_dur"]
+		}
+		if out["ending_linger"] < 0 {
+			out["ending_linger"] = 0
+		}
+		out["ending_ripple"] = clamp01(out["ending_ripple"])
+		if out["pipe_x"] <= 0 {
+			out["pipe_x"] = waterPipeDefaults["pipe_x"]
+		}
+		if out["pipe_width"] <= 0 {
+			out["pipe_width"] = waterPipeDefaults["pipe_width"]
+		}
+		if out["pipe_drop"] <= 0 {
+			out["pipe_drop"] = waterPipeDefaults["pipe_drop"]
+		}
+		if out["basin_x"] <= 0 {
+			out["basin_x"] = waterPipeDefaults["basin_x"]
+		}
+		if out["basin_width"] <= 0 {
+			out["basin_width"] = waterPipeDefaults["basin_width"]
+		}
+		if out["basin_depth"] <= 0 {
+			out["basin_depth"] = waterPipeDefaults["basin_depth"]
+		}
+		if out["flow"] <= 0 {
+			out["flow"] = waterPipeDefaults["flow"]
+		}
+		if out["stream"] <= 0 {
+			out["stream"] = waterPipeDefaults["stream"]
+		}
+		if out["ripple"] <= 0 {
+			out["ripple"] = waterPipeDefaults["ripple"]
+		}
+		if out["overflow"] <= 0 {
+			out["overflow"] = waterPipeDefaults["overflow"]
+		}
+		if out["foam"] <= 0 {
+			out["foam"] = waterPipeDefaults["foam"]
+		}
+		if out["hue"] <= 0 {
+			out["hue"] = waterPipeDefaults["hue"]
+		}
+		if out["hue_sp"] < 0 {
+			out["hue_sp"] = 0
+		}
+		if out["sat"] <= 0 {
+			out["sat"] = waterPipeDefaults["sat"]
+		}
+		if out["lmin"] <= 0 {
+			out["lmin"] = waterPipeDefaults["lmin"]
+		}
+		if out["lmax"] <= 0 {
+			out["lmax"] = waterPipeDefaults["lmax"]
+		}
+		if out["lmax"] < out["lmin"] {
+			out["lmin"], out["lmax"] = out["lmax"], out["lmin"]
+		}
+		if out["surge_dur"] <= 0 {
+			out["surge_dur"] = waterPipeDefaults["surge_dur"]
+		}
+		if out["surge_mult"] <= 0 {
+			out["surge_mult"] = waterPipeDefaults["surge_mult"]
+		}
+		if out["dry_up_dur"] <= 0 {
+			out["dry_up_dur"] = waterPipeDefaults["dry_up_dur"]
+		}
+		if out["dry_up_mult"] <= 0 {
+			out["dry_up_mult"] = waterPipeDefaults["dry_up_mult"]
+		}
 	}
 	return out
 }
@@ -3020,6 +3193,22 @@ func (p *Procedural) TriggerEvent(name string) bool {
 			return false
 		}
 		return true
+	case "water-pipe":
+		switch name {
+		case "surge":
+			p.startWaterPipeSurgeLocked("triggered")
+		case "dry-up":
+			p.startWaterPipeDryUpLocked("triggered")
+		case "intro":
+			p.startWaterPipeIntroLocked()
+			p.appendLog("intro", fmt.Sprintf("started (dur=%d, flow=%.2f)", p.timers["intro"], p.cfg["intro_flow"]))
+		case "ending":
+			p.startWaterPipeEndingLocked()
+			p.appendLog("ending", fmt.Sprintf("started (fade=%d, linger=%d)", p.intCfg("ending_dur"), p.intCfg("ending_linger")))
+		default:
+			return false
+		}
+		return true
 	default:
 		return false
 	}
@@ -3087,6 +3276,8 @@ func (p *Procedural) Step() {
 		p.stepBurningTreesLocked()
 	case "sand":
 		p.stepSandLocked()
+	case "water-pipe":
+		p.stepWaterPipeLocked()
 	}
 }
 
@@ -4492,5 +4683,151 @@ func (p *Procedural) stepSandLocked() {
 	}
 	if p.timers["calm"] <= 0 && p.timers["surge"] <= 0 && p.cfg["calm_p"] > 0 && p.rng.Float64() < p.cfg["calm_p"] {
 		p.startSandCalmLocked("started")
+	}
+}
+
+func (p *Procedural) waterPipeFlowLevelLocked() float64 {
+	flow := math.Max(0, p.cfg["flow"])
+	if p.timers["intro"] > 0 {
+		total := int(math.Round(p.values["intro_total"]))
+		progress := proceduralPhaseProgress(total, p.timers["intro"])
+		flow = p.cfg["intro_flow"] + (flow-p.cfg["intro_flow"])*progress
+	}
+	if p.timers["ending"] > 0 {
+		total := int(math.Round(p.values["ending_total"]))
+		progress := proceduralPhaseProgress(total, p.timers["ending"])
+		flow *= math.Max(0, 1-progress)
+	}
+	if p.timers["surge"] > 0 {
+		gain := p.values["surge_gain"]
+		if gain <= 0 {
+			gain = p.cfg["surge_mult"]
+		}
+		flow *= gain
+	}
+	if p.timers["dry-up"] > 0 {
+		gain := p.values["dry_up_gain"]
+		if gain <= 0 {
+			gain = p.cfg["dry_up_mult"]
+		}
+		flow *= gain
+	}
+	return math.Max(0, flow)
+}
+
+func (p *Procedural) startWaterPipeSurgeLocked(verb string) {
+	p.timers["dry-up"] = 0
+	p.timers["surge"] = jitterInt(p.rng, p.intCfg("surge_dur"), 0.3)
+	p.values["dry_up_gain"] = 1
+	p.values["surge_gain"] = p.cfg["surge_mult"] * (0.9 + p.rng.Float64()*0.35)
+	p.appendLog("surge", fmt.Sprintf("%s (dur=%d, x%.2f)", verb, p.timers["surge"], p.values["surge_gain"]))
+}
+
+func (p *Procedural) startWaterPipeDryUpLocked(verb string) {
+	p.timers["surge"] = 0
+	p.timers["dry-up"] = jitterInt(p.rng, p.intCfg("dry_up_dur"), 0.3)
+	p.values["surge_gain"] = 1
+	p.values["dry_up_gain"] = math.Max(0.08, p.cfg["dry_up_mult"]*(0.85+p.rng.Float64()*0.25))
+	p.appendLog("dry-up", fmt.Sprintf("%s (dur=%d, x%.2f)", verb, p.timers["dry-up"], p.values["dry_up_gain"]))
+}
+
+func (p *Procedural) startWaterPipeIntroLocked() {
+	p.timers["surge"] = 0
+	p.timers["dry-up"] = 0
+	p.timers["ending"] = 0
+	p.values["surge_gain"] = 1
+	p.values["dry_up_gain"] = 1
+	p.values["fill_level"] = clamp01(p.cfg["intro_pool"])
+	p.values["spill_level"] = 0
+	p.values["surface_bias"] = 0
+	p.values["ripple_phase"] = 0
+	p.timers["intro"] = p.intCfg("intro_dur")
+	p.values["intro_total"] = float64(p.timers["intro"])
+}
+
+func (p *Procedural) startWaterPipeEndingLocked() {
+	p.timers["intro"] = 0
+	p.timers["surge"] = 0
+	p.timers["dry-up"] = 0
+	p.values["surge_gain"] = 1
+	p.values["dry_up_gain"] = 1
+	endingTotal := p.intCfg("ending_dur") + max(0, p.intCfg("ending_linger"))
+	if endingTotal < 1 {
+		endingTotal = max(1, p.intCfg("ending_dur"))
+	}
+	p.timers["ending"] = endingTotal
+	p.values["ending_total"] = float64(endingTotal)
+}
+
+func (p *Procedural) stepWaterPipeStateLocked() {
+	flow := p.waterPipeFlowLevelLocked()
+	fill := clamp01(p.values["fill_level"])
+	spill := clamp01(p.values["spill_level"])
+	bias := p.values["surface_bias"]
+	ripplePhase := p.values["ripple_phase"]
+
+	incoming := flow * (0.016 + p.cfg["stream"]*0.010)
+	fill += incoming * (0.72 + p.cfg["ripple"]*0.2)
+	if fill > 1 {
+		spill += (fill - 1) * (0.7 + p.cfg["overflow"]*0.45)
+		fill = 1
+	}
+	if fill > 0.9 {
+		spill += (fill - 0.9) * incoming * (0.3 + p.cfg["overflow"]*0.9)
+	}
+	spill -= (0.002 + p.cfg["overflow"]*0.006) * math.Max(0.1, 1-flow*0.9)
+	if p.timers["ending"] > 0 {
+		total := int(math.Round(p.values["ending_total"]))
+		progress := proceduralPhaseProgress(total, p.timers["ending"])
+		spill += p.cfg["ending_ripple"] * 0.004 * (1 - progress)
+	}
+
+	targetBias := (p.cfg["pipe_x"] - p.cfg["basin_x"]) / 0.24
+	if targetBias < -1 {
+		targetBias = -1
+	} else if targetBias > 1 {
+		targetBias = 1
+	}
+	bias += (targetBias - bias) * (0.03 + flow*0.05 + p.cfg["ripple"]*0.03)
+	if bias < -1 {
+		bias = -1
+	} else if bias > 1 {
+		bias = 1
+	}
+
+	ripplePhase += 0.12 + flow*(0.8+p.cfg["stream"]*0.4) + spill*0.4
+	if ripplePhase > math.Pi*200 {
+		ripplePhase = math.Mod(ripplePhase, math.Pi*2)
+	}
+
+	p.values["fill_level"] = clamp01(fill)
+	p.values["spill_level"] = clamp01(spill)
+	p.values["surface_bias"] = bias
+	p.values["ripple_phase"] = ripplePhase
+}
+
+func (p *Procedural) stepWaterPipeLocked() {
+	p.stepWaterPipeStateLocked()
+	if p.timers["surge"] <= 0 {
+		p.values["surge_gain"] = 1
+	}
+	if p.timers["dry-up"] <= 0 {
+		p.values["dry_up_gain"] = 1
+	}
+	if p.timers["intro"] <= 0 {
+		delete(p.values, "intro_total")
+	}
+	if p.timers["ending"] <= 0 {
+		delete(p.values, "ending_total")
+	}
+	if p.timers["intro"] > 0 || p.timers["ending"] > 0 {
+		return
+	}
+	if p.timers["surge"] <= 0 && p.timers["dry-up"] <= 0 && p.cfg["surge_p"] > 0 && p.rng.Float64() < p.cfg["surge_p"] {
+		p.startWaterPipeSurgeLocked("started")
+		return
+	}
+	if p.timers["dry-up"] <= 0 && p.timers["surge"] <= 0 && p.cfg["dry_up_p"] > 0 && p.rng.Float64() < p.cfg["dry_up_p"] {
+		p.startWaterPipeDryUpLocked("started")
 	}
 }

--- a/sim/procedural_test.go
+++ b/sim/procedural_test.go
@@ -162,6 +162,16 @@ func TestSandSchema(t *testing.T) {
 	}
 }
 
+func TestWaterPipeSchema(t *testing.T) {
+	schema := WaterPipeSchema()
+	if schema.Name != "water-pipe" {
+		t.Fatalf("schema name = %q, want water-pipe", schema.Name)
+	}
+	if len(schema.Knobs) == 0 {
+		t.Fatal("expected water-pipe schema knobs")
+	}
+}
+
 func TestProceduralSnowSnapshotRestore(t *testing.T) {
 	p := NewProcedural("snow", 160, 80, 42, nil)
 	if !p.TriggerEvent("gust") {
@@ -723,5 +733,48 @@ func TestProceduralSandSnapshotRestore(t *testing.T) {
 	}
 	if again.Values["surface_bias"] != snap.Values["surface_bias"] {
 		t.Fatalf("restored surface bias = %f, want %f", again.Values["surface_bias"], snap.Values["surface_bias"])
+	}
+}
+
+func TestProceduralWaterPipeSnapshotRestore(t *testing.T) {
+	p := NewProcedural("water-pipe", 160, 80, 83, nil)
+	if !p.TriggerEvent("intro") {
+		t.Fatal("expected intro trigger to succeed")
+	}
+	if !p.TriggerEvent("dry-up") {
+		t.Fatal("expected dry-up trigger to succeed")
+	}
+	for i := 0; i < 6; i++ {
+		p.Step()
+	}
+
+	snap := p.Snapshot()
+	if snap.Timers["dry-up"] <= 0 {
+		t.Fatal("expected dry-up timer in snapshot")
+	}
+	if snap.Values["fill_level"] <= 0 {
+		t.Fatal("expected fill level value in snapshot")
+	}
+	if snap.Values["surface_bias"] == 0 {
+		t.Fatal("expected surface bias value in snapshot")
+	}
+	if snap.Values["ripple_phase"] <= 0 {
+		t.Fatal("expected ripple phase value in snapshot")
+	}
+
+	restored := NewProcedural("water-pipe", 160, 80, 7, nil)
+	restored.RestoreSnapshot(snap)
+	again := restored.Snapshot()
+	if again.Timers["dry-up"] != snap.Timers["dry-up"] {
+		t.Fatalf("restored dry-up timer = %d, want %d", again.Timers["dry-up"], snap.Timers["dry-up"])
+	}
+	if again.Values["fill_level"] != snap.Values["fill_level"] {
+		t.Fatalf("restored fill level = %f, want %f", again.Values["fill_level"], snap.Values["fill_level"])
+	}
+	if again.Values["surface_bias"] != snap.Values["surface_bias"] {
+		t.Fatalf("restored surface bias = %f, want %f", again.Values["surface_bias"], snap.Values["surface_bias"])
+	}
+	if again.Values["ripple_phase"] != snap.Values["ripple_phase"] {
+		t.Fatalf("restored ripple phase = %f, want %f", again.Values["ripple_phase"], snap.Values["ripple_phase"])
 	}
 }


### PR DESCRIPTION
## Summary
- add the water-pipe procedural dev effect on the Go and browser sides
- register the effect in the dev/runtime/schema plumbing with snapshot + randomization coverage
- tune the default layout so the basin and runoff stay readable beside the dev control panel

## Validation
- go test ./...
- node --check cmd/ambience/web/sim.js
- powershell -ExecutionPolicy Bypass -File scripts/dev-deploy.ps1 -Component all
- verified https://ambience.dev.romaine.life/dev/water-pipe
- captured live dev screenshots for intro, surge, and dry up states