### PR TITLE
Add the tetris dev effect prototype

### DIFF
--- a/cmd/ambience/dev_random_test.go
+++ b/cmd/ambience/dev_random_test.go
@@ -30,6 +30,7 @@ func TestRandomizedDevConfigStaysWithinSchemaBounds(t *testing.T) {
 		sim.MysteriousManSchema(),
 		sim.BurningTreesSchema(),
 		sim.SandSchema(),
+		sim.TetrisSchema(),
 		sim.WaterPipeSchema(),
 	}
 
@@ -81,6 +82,7 @@ func TestRandomizedDevConfigChangesAtLeastOneKnob(t *testing.T) {
 		sim.MysteriousManSchema(),
 		sim.BurningTreesSchema(),
 		sim.SandSchema(),
+		sim.TetrisSchema(),
 		sim.WaterPipeSchema(),
 	}
 

--- a/cmd/ambience/dev_sessions_test.go
+++ b/cmd/ambience/dev_sessions_test.go
@@ -29,6 +29,7 @@ func TestDevPageEffectFromPath(t *testing.T) {
 		{path: "/dev/mysterious-man", want: "mysterious-man", wantOK: true},
 		{path: "/dev/burning-trees", want: "burning-trees", wantOK: true},
 		{path: "/dev/sand", want: "sand", wantOK: true},
+		{path: "/dev/tetris", want: "tetris", wantOK: true},
 		{path: "/dev/water-pipe", want: "water-pipe", wantOK: true},
 		{path: "/dev/waterfall", want: "waterfall", wantOK: true},
 		{path: "/dev/windmill", want: "windmill", wantOK: true},
@@ -70,6 +71,7 @@ func TestEffectFromSchemaPath(t *testing.T) {
 		{path: "/effects/mysterious-man/schema", want: "mysterious-man", wantOK: true},
 		{path: "/effects/burning-trees/schema", want: "burning-trees", wantOK: true},
 		{path: "/effects/sand/schema", want: "sand", wantOK: true},
+		{path: "/effects/tetris/schema", want: "tetris", wantOK: true},
 		{path: "/effects/water-pipe/schema", want: "water-pipe", wantOK: true},
 		{path: "/effects/waterfall/schema", want: "waterfall", wantOK: true},
 		{path: "/effects/windmill/schema", want: "windmill", wantOK: true},
@@ -272,6 +274,17 @@ func TestNewDevSessionWaterPipeSnapshotType(t *testing.T) {
 	snap := session.snapshot()
 	if snap.Type != "water-pipe" {
 		t.Fatalf("snapshot type = %q, want water-pipe", snap.Type)
+	}
+}
+
+func TestNewDevSessionTetrisSnapshotType(t *testing.T) {
+	session, err := newDevSession("tetris")
+	if err != nil {
+		t.Fatalf("newDevSession: %v", err)
+	}
+	snap := session.snapshot()
+	if snap.Type != "tetris" {
+		t.Fatalf("snapshot type = %q, want tetris", snap.Type)
 	}
 }
 

--- a/cmd/ambience/effects.go
+++ b/cmd/ambience/effects.go
@@ -156,6 +156,11 @@ var effectRegistry = map[string]effectDefinition{
 		Schema:     sim.WaterPipeSchema,
 		NewRuntime: newWaterPipeRuntime,
 	},
+	"tetris": {
+		Type:       "tetris",
+		Schema:     sim.TetrisSchema,
+		NewRuntime: newTetrisRuntime,
+	},
 }
 
 func lookupEffectDefinition(effectType string) (effectDefinition, bool) {
@@ -362,6 +367,10 @@ func newSandRuntime(w, h int, seed int64, cfg json.RawMessage) (effectRuntime, e
 
 func newWaterPipeRuntime(w, h int, seed int64, cfg json.RawMessage) (effectRuntime, error) {
 	return newProceduralRuntime("water-pipe", w, h, seed, cfg)
+}
+
+func newTetrisRuntime(w, h int, seed int64, cfg json.RawMessage) (effectRuntime, error) {
+	return newProceduralRuntime("tetris", w, h, seed, cfg)
 }
 
 func (r *rainRuntime) Type() string { return "rain" }
@@ -806,6 +815,8 @@ func (p *proceduralRuntime) Schema() sim.EffectSchema {
 		return sim.SandSchema()
 	case "water-pipe":
 		return sim.WaterPipeSchema()
+	case "tetris":
+		return sim.TetrisSchema()
 	default:
 		return sim.EffectSchema{}
 	}

--- a/cmd/ambience/web/sim.js
+++ b/cmd/ambience/web/sim.js
@@ -2187,6 +2187,33 @@
 			dry_up_dur: 50,
 			dry_up_mult: 0.35,
 		},
+		tetris: {
+			intro_dur: 60,
+			intro_stack: 0,
+			intro_cadence: 0.55,
+			ending_dur: 70,
+			ending_linger: 28,
+			ending_fill: 0.84,
+			well_x: 0.18,
+			well_y: 0.13,
+			cell_size: 3,
+			spawn_every: 42,
+			fall_every: 8,
+			lock_delay: 4,
+			glow: 0.18,
+			ghost: 0.14,
+			hue: 208,
+			hue_sp: 24,
+			sat: 0.56,
+			lmin: 0.10,
+			lmax: 0.92,
+			new_piece_p: 0,
+			lull_p: 0,
+			new_piece_dur: 14,
+			new_piece_cut: 0.25,
+			lull_dur: 80,
+			lull_mult: 1.8,
+		},
 		starfield: {
 			intro_dur: 50,
 			intro_density: 0.08,
@@ -2611,6 +2638,35 @@
 				if (c.dry_up_dur <= 0) c.dry_up_dur = base.dry_up_dur;
 				if (c.dry_up_mult <= 0) c.dry_up_mult = base.dry_up_mult;
 				break;
+			case 'tetris':
+				if (c.intro_dur <= 0) c.intro_dur = base.intro_dur;
+				if (c.intro_stack < 0) c.intro_stack = 0;
+				if (c.intro_stack > 8) c.intro_stack = 8;
+				c.intro_cadence = clamp01(c.intro_cadence);
+				if (c.intro_cadence < 0.2) c.intro_cadence = base.intro_cadence;
+				if (c.ending_dur <= 0) c.ending_dur = base.ending_dur;
+				if (c.ending_linger < 0) c.ending_linger = 0;
+				c.ending_fill = clamp01(c.ending_fill);
+				if (c.ending_fill < 0.6) c.ending_fill = base.ending_fill;
+				if (c.well_x <= 0) c.well_x = base.well_x;
+				if (c.well_y <= 0) c.well_y = base.well_y;
+				if (c.cell_size <= 0) c.cell_size = base.cell_size;
+				if (c.spawn_every <= 0) c.spawn_every = base.spawn_every;
+				if (c.fall_every <= 0) c.fall_every = base.fall_every;
+				if (c.lock_delay < 1) c.lock_delay = base.lock_delay;
+				if (c.glow <= 0) c.glow = base.glow;
+				if (c.ghost < 0) c.ghost = 0;
+				if (c.hue <= 0) c.hue = base.hue;
+				if (c.hue_sp < 0) c.hue_sp = 0;
+				if (c.sat <= 0) c.sat = base.sat;
+				if (c.lmin <= 0) c.lmin = base.lmin;
+				if (c.lmax <= 0) c.lmax = base.lmax;
+				if (c.lmax < c.lmin) [c.lmin, c.lmax] = [c.lmax, c.lmin];
+				if (c.new_piece_dur <= 0) c.new_piece_dur = base.new_piece_dur;
+				if (c.new_piece_cut <= 0) c.new_piece_cut = base.new_piece_cut;
+				if (c.lull_dur <= 0) c.lull_dur = base.lull_dur;
+				if (c.lull_mult <= 1) c.lull_mult = base.lull_mult;
+				break;
 			case 'aurora':
 				if (c.intro_dur <= 0) c.intro_dur = base.intro_dur;
 				c.intro_glow = clamp01(c.intro_glow);
@@ -2711,6 +2767,53 @@
 		return ((value % mod) + mod) % mod;
 	}
 
+	const TETRIS_COLS = 10;
+	const TETRIS_ROWS = 20;
+	const TETRIS_PIECES = [
+		[
+			[{ x: 0, y: 1 }, { x: 1, y: 1 }, { x: 2, y: 1 }, { x: 3, y: 1 }],
+			[{ x: 2, y: 0 }, { x: 2, y: 1 }, { x: 2, y: 2 }, { x: 2, y: 3 }],
+			[{ x: 0, y: 2 }, { x: 1, y: 2 }, { x: 2, y: 2 }, { x: 3, y: 2 }],
+			[{ x: 1, y: 0 }, { x: 1, y: 1 }, { x: 1, y: 2 }, { x: 1, y: 3 }],
+		],
+		[
+			[{ x: 0, y: 0 }, { x: 0, y: 1 }, { x: 1, y: 1 }, { x: 2, y: 1 }],
+			[{ x: 1, y: 0 }, { x: 2, y: 0 }, { x: 1, y: 1 }, { x: 1, y: 2 }],
+			[{ x: 0, y: 1 }, { x: 1, y: 1 }, { x: 2, y: 1 }, { x: 2, y: 2 }],
+			[{ x: 1, y: 0 }, { x: 1, y: 1 }, { x: 0, y: 2 }, { x: 1, y: 2 }],
+		],
+		[
+			[{ x: 2, y: 0 }, { x: 0, y: 1 }, { x: 1, y: 1 }, { x: 2, y: 1 }],
+			[{ x: 1, y: 0 }, { x: 1, y: 1 }, { x: 1, y: 2 }, { x: 2, y: 2 }],
+			[{ x: 0, y: 1 }, { x: 1, y: 1 }, { x: 2, y: 1 }, { x: 0, y: 2 }],
+			[{ x: 0, y: 0 }, { x: 1, y: 0 }, { x: 1, y: 1 }, { x: 1, y: 2 }],
+		],
+		[
+			[{ x: 0, y: 0 }, { x: 1, y: 0 }, { x: 0, y: 1 }, { x: 1, y: 1 }],
+			[{ x: 0, y: 0 }, { x: 1, y: 0 }, { x: 0, y: 1 }, { x: 1, y: 1 }],
+			[{ x: 0, y: 0 }, { x: 1, y: 0 }, { x: 0, y: 1 }, { x: 1, y: 1 }],
+			[{ x: 0, y: 0 }, { x: 1, y: 0 }, { x: 0, y: 1 }, { x: 1, y: 1 }],
+		],
+		[
+			[{ x: 1, y: 0 }, { x: 2, y: 0 }, { x: 0, y: 1 }, { x: 1, y: 1 }],
+			[{ x: 1, y: 0 }, { x: 1, y: 1 }, { x: 2, y: 1 }, { x: 2, y: 2 }],
+			[{ x: 1, y: 1 }, { x: 2, y: 1 }, { x: 0, y: 2 }, { x: 1, y: 2 }],
+			[{ x: 0, y: 0 }, { x: 0, y: 1 }, { x: 1, y: 1 }, { x: 1, y: 2 }],
+		],
+		[
+			[{ x: 1, y: 0 }, { x: 0, y: 1 }, { x: 1, y: 1 }, { x: 2, y: 1 }],
+			[{ x: 1, y: 0 }, { x: 1, y: 1 }, { x: 2, y: 1 }, { x: 1, y: 2 }],
+			[{ x: 0, y: 1 }, { x: 1, y: 1 }, { x: 2, y: 1 }, { x: 1, y: 2 }],
+			[{ x: 1, y: 0 }, { x: 0, y: 1 }, { x: 1, y: 1 }, { x: 1, y: 2 }],
+		],
+		[
+			[{ x: 0, y: 0 }, { x: 1, y: 0 }, { x: 1, y: 1 }, { x: 2, y: 1 }],
+			[{ x: 2, y: 0 }, { x: 1, y: 1 }, { x: 2, y: 1 }, { x: 1, y: 2 }],
+			[{ x: 0, y: 1 }, { x: 1, y: 1 }, { x: 1, y: 2 }, { x: 2, y: 2 }],
+			[{ x: 1, y: 0 }, { x: 0, y: 1 }, { x: 1, y: 1 }, { x: 0, y: 2 }],
+		],
+	];
+
 	class ProceduralScene {
 		constructor(kind, w, h, cfg, seed) {
 			this.kind = kind;
@@ -2772,6 +2875,8 @@
 					return this._triggerSand(name);
 				case 'water-pipe':
 					return this._triggerWaterPipe(name);
+				case 'tetris':
+					return this._triggerTetris(name);
 				case 'aurora':
 					return this._triggerAurora(name);
 				case 'starfield':
@@ -2933,6 +3038,9 @@
 				if (!this.timers.intro || this.timers.intro <= 0) delete this.values.intro_total;
 				if (!this.timers.ending || this.timers.ending <= 0) delete this.values.ending_total;
 			}
+			if (this.kind === 'tetris') {
+				this._stepTetrisState();
+			}
 		}
 
 		render(ctx, canvasW, canvasH, opts) {
@@ -2963,6 +3071,8 @@
 					return this._renderSand(ctx, canvasW, canvasH, opts);
 				case 'water-pipe':
 					return this._renderWaterPipe(ctx, canvasW, canvasH, opts);
+				case 'tetris':
+					return this._renderTetris(ctx, canvasW, canvasH, opts);
 				case 'aurora':
 					return this._renderAurora(ctx, canvasW, canvasH, opts);
 				case 'starfield':
@@ -3656,6 +3766,44 @@
 			return false;
 		}
 
+		_triggerTetris(name) {
+			const rng = this._eventRng(name.length + 173);
+			switch (name) {
+				case 'new-piece':
+					this.timers.lull = 0;
+					this.timers['new-piece'] = jitterInt(rng, this.cfg.new_piece_dur, 0.25);
+					this.values.lull_gain = 1;
+					this.values.new_piece_cut = Math.max(0.05, this.cfg.new_piece_cut * (0.8 + rng() * 0.35));
+					if ((this.values.piece_alive || 0) > 0.5) {
+						if ((this.values.fall_cd || 0) > 1) this.values.fall_cd = 1;
+						if ((this.values.lock_cd || 0) > 1) this.values.lock_cd = 1;
+					} else {
+						const spawn = Math.round(this.values.spawn_cd || 0);
+						if (spawn > 1) this.values.spawn_cd = Math.max(1, Math.round(spawn * this.values.new_piece_cut));
+					}
+					return true;
+				case 'lull':
+					this.timers['new-piece'] = 0;
+					this.timers.lull = jitterInt(rng, this.cfg.lull_dur, 0.25);
+					this.values.new_piece_cut = this.cfg.new_piece_cut;
+					this.values.lull_gain = Math.max(1.05, this.cfg.lull_mult * (0.9 + rng() * 0.3));
+					if ((this.values.piece_alive || 0) <= 0.5) {
+						let delay = Math.round(this.values.spawn_cd || 0);
+						if (delay < 1) delay = Math.round(this.cfg.spawn_every);
+						const target = Math.round(delay * this.values.lull_gain);
+						if (target > delay) this.values.spawn_cd = target;
+					}
+					return true;
+				case 'intro':
+					this._startTetrisIntro();
+					return true;
+				case 'ending':
+					this._startTetrisEnding();
+					return true;
+			}
+			return false;
+		}
+
 		_triggerAurora(name) {
 			const rng = this._eventRng(name.length + 53);
 			switch (name) {
@@ -4126,6 +4274,247 @@
 			this.values.spill_level = clamp01(spill);
 			this.values.surface_bias = bias;
 			this.values.ripple_phase = ripplePhase;
+		}
+
+		_tetrisRng(key) {
+			return makeRNG(((this.seed >>> 0) ^ (((key >>> 0) * 2654435761) >>> 0)) >>> 0);
+		}
+
+		_tetrisCellKey(row, col) {
+			return `cell_${String(row).padStart(2, '0')}_${String(col).padStart(2, '0')}`;
+		}
+
+		_tetrisGetCell(row, col) {
+			if (row < 0 || row >= TETRIS_ROWS || col < 0 || col >= TETRIS_COLS) return 0;
+			return Math.round(this.values[this._tetrisCellKey(row, col)] || 0);
+		}
+
+		_tetrisSetCell(row, col, value) {
+			if (row < 0 || row >= TETRIS_ROWS || col < 0 || col >= TETRIS_COLS) return;
+			const key = this._tetrisCellKey(row, col);
+			if (value <= 0) {
+				delete this.values[key];
+				return;
+			}
+			this.values[key] = value;
+		}
+
+		_tetrisClearBoard() {
+			for (let row = 0; row < TETRIS_ROWS; row++) {
+				for (let col = 0; col < TETRIS_COLS; col++) {
+					delete this.values[this._tetrisCellKey(row, col)];
+				}
+			}
+		}
+
+		_tetrisSeedIntroStack() {
+			const rows = Math.max(0, Math.round(this.cfg.intro_stack || 0));
+			if (rows <= 0) return;
+			for (let col = 0; col < TETRIS_COLS; col++) {
+				const rng = this._tetrisRng(400 + col * 7);
+				let height = rows - 1 + Math.floor(rng() * 3);
+				height = Math.max(0, Math.min(rows, height));
+				for (let depth = 0; depth < height; depth++) {
+					const row = TETRIS_ROWS - 1 - depth;
+					const kind = 1 + (col + depth + Math.floor(rng() * TETRIS_PIECES.length)) % TETRIS_PIECES.length;
+					this._tetrisSetCell(row, col, kind);
+				}
+			}
+		}
+
+		_tetrisClearCurrentPiece() {
+			this.values.piece_alive = 0;
+			delete this.values.piece_kind;
+			delete this.values.piece_rot;
+			delete this.values.piece_x;
+			delete this.values.piece_y;
+			delete this.values.fall_cd;
+			delete this.values.lock_cd;
+		}
+
+		_tetrisCurrentPiece() {
+			const alive = (this.values.piece_alive || 0) > 0.5;
+			if (!alive) return { alive: false, kind: 0, rot: 0, x: 0, y: 0 };
+			return {
+				alive: true,
+				kind: Math.round(this.values.piece_kind || 0),
+				rot: Math.round(this.values.piece_rot || 0),
+				x: Math.round(this.values.piece_x || 0),
+				y: Math.round(this.values.piece_y || 0),
+			};
+		}
+
+		_tetrisSetCurrentPiece(kind, rot, x, y) {
+			this.values.piece_alive = 1;
+			this.values.piece_kind = kind;
+			this.values.piece_rot = rot;
+			this.values.piece_x = x;
+			this.values.piece_y = y;
+		}
+
+		_tetrisPiecePoints(kind, rot) {
+			const rotations = TETRIS_PIECES[Math.round(kind) - 1] || [];
+			if (!rotations.length) return [];
+			return rotations[positiveMod(Math.round(rot), rotations.length)];
+		}
+
+		_tetrisCollision(kind, rot, x, y) {
+			for (const pt of this._tetrisPiecePoints(kind, rot)) {
+				const col = x + pt.x;
+				const row = y + pt.y;
+				if (col < 0 || col >= TETRIS_COLS || row < 0 || row >= TETRIS_ROWS) return true;
+				if (this._tetrisGetCell(row, col) > 0) return true;
+			}
+			return false;
+		}
+
+		_tetrisLockPiece(kind, rot, x, y) {
+			for (const pt of this._tetrisPiecePoints(kind, rot)) {
+				this._tetrisSetCell(y + pt.y, x + pt.x, kind);
+			}
+		}
+
+		_tetrisUpdateBoardStats() {
+			let filled = 0;
+			let top = TETRIS_ROWS;
+			for (let row = 0; row < TETRIS_ROWS; row++) {
+				for (let col = 0; col < TETRIS_COLS; col++) {
+					if (this._tetrisGetCell(row, col) <= 0) continue;
+					filled++;
+					if (row < top) top = row;
+				}
+			}
+			this.values.fill_ratio = filled / (TETRIS_COLS * TETRIS_ROWS);
+			this.values.stack_height = filled > 0 ? (TETRIS_ROWS - top) : 0;
+		}
+
+		_tetrisSpawnDelay() {
+			let delay = Math.max(1, Math.round(this.cfg.spawn_every));
+			if (this.timers.intro > 0) {
+				const total = this.values.intro_total || this.cfg.intro_dur;
+				const progress = this._phaseProgress(total, this.timers.intro);
+				const cadence = this.cfg.intro_cadence + (1 - this.cfg.intro_cadence) * progress;
+				delay = Math.max(1, Math.round(delay * Math.max(0.2, cadence)));
+			}
+			if (this.timers.lull > 0) {
+				const gain = (this.values.lull_gain || 0) > 1 ? this.values.lull_gain : this.cfg.lull_mult;
+				delay = Math.max(1, Math.round(delay * Math.max(1.05, gain)));
+			}
+			if (this.timers['new-piece'] > 0) {
+				const cut = (this.values.new_piece_cut || 0) > 0 ? this.values.new_piece_cut : this.cfg.new_piece_cut;
+				delay = Math.max(1, Math.round(delay * Math.max(0.05, cut)));
+			}
+			return delay;
+		}
+
+		_tetrisFallDelay() {
+			let delay = Math.max(1, Math.round(this.cfg.fall_every));
+			if (this.timers['new-piece'] > 0) delay = Math.max(1, Math.round(delay * 0.6));
+			return delay;
+		}
+
+		_startTetrisIntro() {
+			this.timers['new-piece'] = 0;
+			this.timers.lull = 0;
+			this.timers.ending = 0;
+			this.values.lull_gain = 1;
+			this.values.new_piece_cut = this.cfg.new_piece_cut;
+			delete this.values.ended;
+			delete this.values.ending_total;
+			this._tetrisClearCurrentPiece();
+			this._tetrisClearBoard();
+			this._tetrisSeedIntroStack();
+			this.values.piece_counter = 0;
+			this.timers.intro = Math.max(1, Math.round(this.cfg.intro_dur));
+			this.values.intro_total = this.timers.intro;
+			this.values.spawn_cd = Math.max(1, Math.round(this.cfg.spawn_every * Math.max(0.2, this.cfg.intro_cadence)));
+			this._tetrisUpdateBoardStats();
+		}
+
+		_startTetrisEnding() {
+			this.timers.intro = 0;
+			this.timers['new-piece'] = 0;
+			this.timers.lull = 0;
+			this.values.lull_gain = 1;
+			delete this.values.intro_total;
+			this._tetrisClearCurrentPiece();
+			this.timers.ending = Math.max(1, Math.round(this.cfg.ending_dur + Math.max(0, this.cfg.ending_linger)));
+			this.values.ending_total = this.timers.ending;
+			this.values.ended = 1;
+			this._tetrisUpdateBoardStats();
+		}
+
+		_spawnTetrisPiece() {
+			const counter = Math.round(this.values.piece_counter || 0);
+			const rng = this._tetrisRng(800 + counter * 17);
+			const kind = 1 + Math.floor(rng() * TETRIS_PIECES.length);
+			const rot = Math.floor(rng() * 4);
+			const x = 3;
+			const y = 0;
+			if (this._tetrisCollision(kind, rot, x, y)) {
+				this._startTetrisEnding();
+				return false;
+			}
+			this.values.piece_counter = counter + 1;
+			this._tetrisSetCurrentPiece(kind, rot, x, y);
+			this.values.fall_cd = this._tetrisFallDelay();
+			this.values.lock_cd = Math.max(1, Math.round(this.cfg.lock_delay));
+			this.values.spawn_cd = 0;
+			if (this.timers['new-piece'] > 0) this.timers['new-piece'] = 0;
+			return true;
+		}
+
+		_stepTetrisState() {
+			if (!this.timers.lull || this.timers.lull <= 0) this.values.lull_gain = 1;
+			if (!this.timers['new-piece'] || this.timers['new-piece'] <= 0) delete this.values.new_piece_cut;
+			if (!this.timers.intro || this.timers.intro <= 0) delete this.values.intro_total;
+			if (!this.timers.ending || this.timers.ending <= 0) {
+				delete this.values.ending_total;
+				if ((this.values.ended || 0) > 0.5) {
+					this._startTetrisIntro();
+					return;
+				}
+			}
+			if (this.timers.ending > 0) {
+				this._tetrisUpdateBoardStats();
+				return;
+			}
+
+			const piece = this._tetrisCurrentPiece();
+			if (!piece.alive) {
+				let spawnCD = Math.round(this.values.spawn_cd || 0);
+				if (spawnCD > 0) {
+					spawnCD--;
+					this.values.spawn_cd = spawnCD;
+				}
+				if (spawnCD <= 0) this._spawnTetrisPiece();
+			} else {
+				let fallCD = Math.round(this.values.fall_cd || 0);
+				let lockCD = Math.round(this.values.lock_cd || 0);
+				if (this.timers['new-piece'] > 0 && fallCD > 1) fallCD = 1;
+				if (fallCD > 0) {
+					fallCD--;
+					this.values.fall_cd = fallCD;
+				} else if (!this._tetrisCollision(piece.kind, piece.rot, piece.x, piece.y + 1)) {
+					this.values.piece_y = piece.y + 1;
+					this.values.fall_cd = this._tetrisFallDelay();
+					this.values.lock_cd = Math.max(1, Math.round(this.cfg.lock_delay));
+				} else if (lockCD > 0) {
+					lockCD--;
+					this.values.lock_cd = lockCD;
+				} else {
+					this._tetrisLockPiece(piece.kind, piece.rot, piece.x, piece.y);
+					this._tetrisClearCurrentPiece();
+					this.values.spawn_cd = this._tetrisSpawnDelay();
+					this._tetrisUpdateBoardStats();
+					if ((this.values.fill_ratio || 0) >= Math.max(0.6, this.cfg.ending_fill)) {
+						this._startTetrisEnding();
+						return;
+					}
+				}
+			}
+
+			this._tetrisUpdateBoardStats();
 		}
 
 		_renderSnow(ctx, canvasW, canvasH, opts) {
@@ -6231,6 +6620,132 @@
 			}
 		}
 
+		_renderTetris(ctx, canvasW, canvasH, opts) {
+			opts = opts || {};
+			if (opts.transparent) {
+				ctx.clearRect(0, 0, canvasW, canvasH);
+			} else {
+				const skyTop = hslToRGB((this.cfg.hue - 24 + 360) % 360, clamp01(this.cfg.sat * 0.24), clamp01(this.cfg.lmin * 0.35));
+				const skyMid = hslToRGB((this.cfg.hue - 8 + 360) % 360, clamp01(this.cfg.sat * 0.18), clamp01(this.cfg.lmin + (this.cfg.lmax - this.cfg.lmin) * 0.06));
+				const skyLow = hslToRGB(this.cfg.hue % 360, clamp01(this.cfg.sat * 0.24), clamp01(this.cfg.lmin + (this.cfg.lmax - this.cfg.lmin) * 0.14));
+				const bg = ctx.createLinearGradient(0, 0, 0, canvasH);
+				bg.addColorStop(0, `rgb(${skyTop.r},${skyTop.g},${skyTop.b})`);
+				bg.addColorStop(0.62, `rgb(${skyMid.r},${skyMid.g},${skyMid.b})`);
+				bg.addColorStop(1, `rgb(${skyLow.r},${skyLow.g},${skyLow.b})`);
+				ctx.fillStyle = bg;
+				ctx.fillRect(0, 0, canvasW, canvasH);
+			}
+
+			const sx = canvasW / this.w;
+			const sy = canvasH / this.h;
+			const ceilSx = Math.ceil(sx);
+			const ceilSy = Math.ceil(sy);
+			const cell = Math.max(2, Math.round(this.cfg.cell_size));
+			const boardW = TETRIS_COLS * cell;
+			const boardH = TETRIS_ROWS * cell;
+			const left = Math.max(4, Math.min(this.w - boardW - 6, Math.round(this.w * this.cfg.well_x)));
+			const top = Math.max(4, Math.min(this.h - boardH - 6, Math.round(this.h * this.cfg.well_y)));
+			const right = left + boardW;
+			const bottom = top + boardH;
+			const fillRatio = clamp01(this.values.fill_ratio || 0);
+			const stackHeight = clamp01((this.values.stack_height || 0) / TETRIS_ROWS);
+			let sceneLevel = 1;
+			if (this.timers.intro > 0) {
+				const total = this.values.intro_total || this.cfg.intro_dur;
+				const progress = this._phaseProgress(total, this.timers.intro);
+				sceneLevel *= 0.35 + 0.65 * progress;
+			}
+			if (this.timers.ending > 0) {
+				const total = this.values.ending_total || (this.cfg.ending_dur + this.cfg.ending_linger);
+				const progress = this._phaseProgress(total, this.timers.ending);
+				sceneLevel *= 1 - 0.55 * progress;
+			}
+
+			const floorColor = hslToRGB((this.cfg.hue + 10) % 360, clamp01(this.cfg.sat * 0.14), clamp01(this.cfg.lmin * 0.72));
+			const frameColor = hslToRGB((this.cfg.hue + 14) % 360, clamp01(this.cfg.sat * 0.16), clamp01(this.cfg.lmin + (this.cfg.lmax - this.cfg.lmin) * 0.26));
+			const innerColor = hslToRGB((this.cfg.hue + 4) % 360, clamp01(this.cfg.sat * 0.1), clamp01(this.cfg.lmin * 0.42));
+			const lineColor = hslToRGB((this.cfg.hue + 20) % 360, clamp01(this.cfg.sat * 0.08), clamp01(this.cfg.lmin + (this.cfg.lmax - this.cfg.lmin) * 0.18));
+			const capColor = hslToRGB((this.cfg.hue + 34) % 360, clamp01(this.cfg.sat * 0.22), clamp01(this.cfg.lmax * 0.94));
+
+			this._fillCell(ctx, sx, sy, ceilSx, ceilSy, 0, bottom - 2, this.w, this.h - bottom + 2, `rgb(${floorColor.r},${floorColor.g},${floorColor.b})`, 1);
+
+			const glow = ctx.createRadialGradient((left + boardW * 0.5) * sx, (top + boardH * 0.58) * sy, 0, (left + boardW * 0.5) * sx, (top + boardH * 0.58) * sy, Math.max(30, boardW * sx * 0.8));
+			glow.addColorStop(0, `rgba(110, 196, 255, ${clamp01((this.cfg.glow * 0.65 + fillRatio * 0.14) * sceneLevel)})`);
+			glow.addColorStop(1, 'rgba(110, 196, 255, 0)');
+			ctx.fillStyle = glow;
+			ctx.fillRect(Math.floor((left - 8) * sx), Math.floor((top - 6) * sy), Math.ceil((boardW + 16) * sx), Math.ceil((boardH + 12) * sy));
+
+			this._fillCell(ctx, sx, sy, ceilSx, ceilSy, left - 2, top - 2, boardW + 4, boardH + 4, `rgb(${frameColor.r},${frameColor.g},${frameColor.b})`, 0.96);
+			this._fillCell(ctx, sx, sy, ceilSx, ceilSy, left, top, boardW, boardH, `rgb(${innerColor.r},${innerColor.g},${innerColor.b})`, 1);
+			this._fillCell(ctx, sx, sy, ceilSx, ceilSy, left, top - 1, boardW, 1, `rgb(${capColor.r},${capColor.g},${capColor.b})`, clamp01((0.18 + fillRatio * 0.26) * sceneLevel));
+
+			for (let c = 1; c < TETRIS_COLS; c++) {
+				this._fillCell(ctx, sx, sy, ceilSx, ceilSy, left + c * cell, top, 1, boardH, `rgb(${lineColor.r},${lineColor.g},${lineColor.b})`, 0.14 * sceneLevel);
+			}
+			for (let r = 1; r < TETRIS_ROWS; r++) {
+				this._fillCell(ctx, sx, sy, ceilSx, ceilSy, left, top + r * cell, boardW, 1, `rgb(${lineColor.r},${lineColor.g},${lineColor.b})`, 0.12 * sceneLevel);
+			}
+
+			const hueOffsets = [0, 18, 36, 62, 118, 156, 196];
+			const hueScale = Math.max(0.4, this.cfg.hue_sp / 24);
+			const blockPalette = (kind, active) => {
+				const offset = hueOffsets[Math.max(0, Math.min(hueOffsets.length - 1, Math.round(kind) - 1))] || 0;
+				const hue = positiveMod(this.cfg.hue + offset * hueScale, 360);
+				const base = hslToRGB(hue, clamp01(this.cfg.sat * (active ? 1.04 : 0.92)), clamp01(this.cfg.lmin + (this.cfg.lmax - this.cfg.lmin) * (active ? 0.72 : 0.6)));
+				const hi = hslToRGB(positiveMod(hue - 6, 360), clamp01(this.cfg.sat * 0.42), clamp01(Math.min(1, this.cfg.lmax * (active ? 1 : 0.96))));
+				const shade = hslToRGB(positiveMod(hue + 10, 360), clamp01(this.cfg.sat * 0.72), clamp01(this.cfg.lmin + (this.cfg.lmax - this.cfg.lmin) * 0.18));
+				return { base, hi, shade };
+			};
+
+			const drawBlock = (col, row, kind, active, alpha) => {
+				const x = left + col * cell;
+				const y = top + row * cell;
+				const palette = blockPalette(kind, active);
+				this._fillCell(ctx, sx, sy, ceilSx, ceilSy, x, y, cell, cell, `rgb(${palette.base.r},${palette.base.g},${palette.base.b})`, alpha);
+				this._fillCell(ctx, sx, sy, ceilSx, ceilSy, x, y, cell, 1, `rgb(${palette.hi.r},${palette.hi.g},${palette.hi.b})`, alpha * 0.48);
+				this._fillCell(ctx, sx, sy, ceilSx, ceilSy, x, y, 1, cell, `rgb(${palette.hi.r},${palette.hi.g},${palette.hi.b})`, alpha * 0.22);
+				this._fillCell(ctx, sx, sy, ceilSx, ceilSy, x, y + cell - 1, cell, 1, `rgb(${palette.shade.r},${palette.shade.g},${palette.shade.b})`, alpha * 0.34);
+				this._fillCell(ctx, sx, sy, ceilSx, ceilSy, x + cell - 1, y, 1, cell, `rgb(${palette.shade.r},${palette.shade.g},${palette.shade.b})`, alpha * 0.2);
+			};
+
+			for (let row = 0; row < TETRIS_ROWS; row++) {
+				for (let col = 0; col < TETRIS_COLS; col++) {
+					const kind = this._tetrisGetCell(row, col);
+					if (kind <= 0) continue;
+					const alpha = clamp01((0.86 + (1 - row / TETRIS_ROWS) * 0.08) * sceneLevel);
+					drawBlock(col, row, kind, false, alpha);
+				}
+			}
+
+			const piece = this._tetrisCurrentPiece();
+			if (piece.alive) {
+				let ghostY = piece.y;
+				while (!this._tetrisCollision(piece.kind, piece.rot, piece.x, ghostY + 1)) ghostY++;
+				if (ghostY > piece.y && this.cfg.ghost > 0) {
+					for (const pt of this._tetrisPiecePoints(piece.kind, piece.rot)) {
+						drawBlock(piece.x + pt.x, ghostY + pt.y, piece.kind, false, clamp01(this.cfg.ghost * sceneLevel));
+					}
+				}
+				for (const pt of this._tetrisPiecePoints(piece.kind, piece.rot)) {
+					drawBlock(piece.x + pt.x, piece.y + pt.y, piece.kind, true, clamp01(0.98 * sceneLevel));
+				}
+			}
+
+			if ((this.values.ended || 0) > 0.5 || this.timers.ending > 0) {
+				const shade = ctx.createLinearGradient(0, top * sy, 0, bottom * sy);
+				shade.addColorStop(0, `rgba(8, 10, 14, ${clamp01(0.08 + (1 - sceneLevel) * 0.32)})`);
+				shade.addColorStop(1, `rgba(8, 10, 14, ${clamp01(0.22 + (1 - sceneLevel) * 0.28)})`);
+				ctx.fillStyle = shade;
+				ctx.fillRect(Math.floor(left * sx), Math.floor(top * sy), Math.ceil(boardW * sx), Math.ceil(boardH * sy));
+			}
+
+			const dangerAlpha = clamp01((stackHeight - 0.6) * 1.8);
+			if (dangerAlpha > 0.02) {
+				const danger = hslToRGB(8, 0.78, 0.64);
+				this._fillCell(ctx, sx, sy, ceilSx, ceilSy, left, top + cell, boardW, 1, `rgb(${danger.r},${danger.g},${danger.b})`, dangerAlpha * 0.5);
+			}
+		}
+
 		_renderAurora(ctx, canvasW, canvasH, opts) {
 			opts = opts || {};
 			if (opts.transparent) {
@@ -6437,6 +6952,12 @@
 		}
 	}
 
+	class Tetris extends ProceduralScene {
+		constructor(w, h, cfg, seed) {
+			super('tetris', w, h, cfg, seed);
+		}
+	}
+
 	class Aurora extends ProceduralScene {
 		constructor(w, h, cfg, seed) {
 			super('aurora', w, h, cfg, seed);
@@ -6495,7 +7016,7 @@
 	// server's snapshot payload — the client looks up the constructor here
 	// by name so new effects just register themselves and work without
 	// client-side changes.
-	const effects = { rain: Rain, dust: Dust, fireflies: Fireflies, waterfall: Waterfall, 'wheat-field': WheatField, beach: Beach, campfire: Campfire, windmill: Windmill, lighthouse: Lighthouse, rowboat: Rowboat, underwater: Underwater, volcano: Volcano, train: Train, 'mysterious-man': MysteriousMan, 'burning-trees': BurningTrees, sand: Sand, 'water-pipe': WaterPipe, aurora: Aurora, snow: Snow, 'autumn-leaves': AutumnLeaves, starfield: Starfield };
+	const effects = { rain: Rain, dust: Dust, fireflies: Fireflies, waterfall: Waterfall, 'wheat-field': WheatField, beach: Beach, campfire: Campfire, windmill: Windmill, lighthouse: Lighthouse, rowboat: Rowboat, underwater: Underwater, volcano: Volcano, train: Train, 'mysterious-man': MysteriousMan, 'burning-trees': BurningTrees, sand: Sand, 'water-pipe': WaterPipe, tetris: Tetris, aurora: Aurora, snow: Snow, 'autumn-leaves': AutumnLeaves, starfield: Starfield };
 	const presets = {
 		'wheat-field': [
 			{
@@ -7764,6 +8285,126 @@
 				},
 			},
 		],
+		tetris: [
+			{
+				key: 'museum-pace',
+				label: 'museum pace',
+				config: {
+					intro_dur: 72,
+					intro_stack: 0,
+					intro_cadence: 0.48,
+					ending_dur: 88,
+					ending_linger: 34,
+					ending_fill: 0.8,
+					well_x: 0.17,
+					well_y: 0.12,
+					cell_size: 3,
+					spawn_every: 56,
+					fall_every: 10,
+					lock_delay: 5,
+					glow: 0.14,
+					ghost: 0.1,
+					hue: 220,
+					hue_sp: 18,
+					sat: 0.42,
+					lmin: 0.08,
+					lmax: 0.84,
+					lull_p: 0.0012,
+					lull_dur: 104,
+					lull_mult: 2.35,
+				},
+			},
+			{
+				key: 'steady-build',
+				label: 'steady build',
+				config: {
+					intro_dur: 60,
+					intro_stack: 1,
+					intro_cadence: 0.58,
+					ending_dur: 74,
+					ending_linger: 28,
+					ending_fill: 0.84,
+					well_x: 0.18,
+					well_y: 0.12,
+					cell_size: 3,
+					spawn_every: 42,
+					fall_every: 8,
+					lock_delay: 4,
+					glow: 0.18,
+					ghost: 0.14,
+					hue: 208,
+					hue_sp: 24,
+					sat: 0.56,
+					lmin: 0.1,
+					lmax: 0.92,
+					new_piece_p: 0.0008,
+					new_piece_dur: 16,
+					new_piece_cut: 0.22,
+					lull_p: 0.0005,
+					lull_dur: 76,
+					lull_mult: 1.75,
+				},
+			},
+			{
+				key: 'dense-stack',
+				label: 'dense stack',
+				config: {
+					intro_dur: 46,
+					intro_stack: 4,
+					intro_cadence: 0.72,
+					ending_dur: 66,
+					ending_linger: 24,
+					ending_fill: 0.76,
+					well_x: 0.18,
+					well_y: 0.11,
+					cell_size: 3,
+					spawn_every: 34,
+					fall_every: 7,
+					lock_delay: 4,
+					glow: 0.2,
+					ghost: 0.12,
+					hue: 198,
+					hue_sp: 28,
+					sat: 0.6,
+					lmin: 0.1,
+					lmax: 0.9,
+					new_piece_p: 0.0009,
+					new_piece_dur: 15,
+					new_piece_cut: 0.2,
+					lull_p: 0.0003,
+				},
+			},
+			{
+				key: 'late-game',
+				label: 'late game',
+				config: {
+					intro_dur: 34,
+					intro_stack: 6,
+					intro_cadence: 0.84,
+					ending_dur: 58,
+					ending_linger: 22,
+					ending_fill: 0.9,
+					well_x: 0.18,
+					well_y: 0.1,
+					cell_size: 3,
+					spawn_every: 26,
+					fall_every: 5,
+					lock_delay: 3,
+					glow: 0.24,
+					ghost: 0.16,
+					hue: 192,
+					hue_sp: 30,
+					sat: 0.66,
+					lmin: 0.12,
+					lmax: 0.94,
+					new_piece_p: 0.0012,
+					new_piece_dur: 18,
+					new_piece_cut: 0.18,
+					lull_p: 0.0002,
+					lull_mult: 1.5,
+				},
+			},
+		],
 		starfield: [
 			{
 				key: 'still-night',
@@ -8190,5 +8831,5 @@
 		],
 	};
 
-	global.AmbienceSim = { Rain, Dust, Fireflies, Waterfall, WheatField, Beach, Campfire, Windmill, Lighthouse, Rowboat, Underwater, Volcano, Train, MysteriousMan, BurningTrees, Sand, WaterPipe, Aurora, AutumnLeaves, Snow, Starfield, subscribe, applyDefaults, hslToRGB, effects, presets };
+	global.AmbienceSim = { Rain, Dust, Fireflies, Waterfall, WheatField, Beach, Campfire, Windmill, Lighthouse, Rowboat, Underwater, Volcano, Train, MysteriousMan, BurningTrees, Sand, WaterPipe, Tetris, Aurora, AutumnLeaves, Snow, Starfield, subscribe, applyDefaults, hslToRGB, effects, presets };
 })(window);

--- a/sim/procedural.go
+++ b/sim/procedural.go
@@ -38,6 +38,7 @@ type Procedural struct {
 	W, H int
 	Grid [][]Pixel
 
+	seed   int64
 	rng    *rngutil.RNG
 	cfg    ProceduralConfig
 	tick   int
@@ -1630,6 +1631,8 @@ func proceduralDefaults(kind string) ProceduralConfig {
 		return cloneProceduralConfig(sandDefaults)
 	case "water-pipe":
 		return cloneProceduralConfig(waterPipeDefaults)
+	case "tetris":
+		return cloneProceduralConfig(tetrisDefaults)
 	default:
 		return ProceduralConfig{}
 	}
@@ -2785,6 +2788,8 @@ func mergeProceduralDefaults(kind string, cfg ProceduralConfig) ProceduralConfig
 		if out["dry_up_mult"] <= 0 {
 			out["dry_up_mult"] = waterPipeDefaults["dry_up_mult"]
 		}
+	case "tetris":
+		out = mergeTetrisDefaults(out)
 	}
 	return out
 }
@@ -2799,6 +2804,7 @@ func NewProcedural(kind string, w, h int, seed int64, cfg ProceduralConfig) *Pro
 		W:      w,
 		H:      h,
 		Grid:   grid,
+		seed:   seed,
 		rng:    rngutil.New(seed),
 		cfg:    mergeProceduralDefaults(kind, cfg),
 		timers: make(map[string]int),
@@ -3209,6 +3215,21 @@ func (p *Procedural) TriggerEvent(name string) bool {
 			return false
 		}
 		return true
+	case "tetris":
+		switch name {
+		case "new-piece":
+			p.startTetrisNewPieceLocked("triggered")
+		case "lull":
+			p.startTetrisLullLocked("triggered")
+		case "intro":
+			p.startTetrisIntroLocked()
+			p.appendLog("intro", fmt.Sprintf("started (dur=%d, stack=%.0f)", p.timers["intro"], p.cfg["intro_stack"]))
+		case "ending":
+			p.startTetrisEndingLocked(fmt.Sprintf("started (fade=%d, linger=%d)", p.intCfg("ending_dur"), p.intCfg("ending_linger")))
+		default:
+			return false
+		}
+		return true
 	default:
 		return false
 	}
@@ -3278,6 +3299,8 @@ func (p *Procedural) Step() {
 		p.stepSandLocked()
 	case "water-pipe":
 		p.stepWaterPipeLocked()
+	case "tetris":
+		p.stepTetrisLocked()
 	}
 }
 

--- a/sim/procedural_test.go
+++ b/sim/procedural_test.go
@@ -172,6 +172,16 @@ func TestWaterPipeSchema(t *testing.T) {
 	}
 }
 
+func TestTetrisSchema(t *testing.T) {
+	schema := TetrisSchema()
+	if schema.Name != "tetris" {
+		t.Fatalf("schema name = %q, want tetris", schema.Name)
+	}
+	if len(schema.Knobs) == 0 {
+		t.Fatal("expected tetris schema knobs")
+	}
+}
+
 func TestProceduralSnowSnapshotRestore(t *testing.T) {
 	p := NewProcedural("snow", 160, 80, 42, nil)
 	if !p.TriggerEvent("gust") {
@@ -776,5 +786,45 @@ func TestProceduralWaterPipeSnapshotRestore(t *testing.T) {
 	}
 	if again.Values["ripple_phase"] != snap.Values["ripple_phase"] {
 		t.Fatalf("restored ripple phase = %f, want %f", again.Values["ripple_phase"], snap.Values["ripple_phase"])
+	}
+}
+
+func TestProceduralTetrisSnapshotRestore(t *testing.T) {
+	p := NewProcedural("tetris", 160, 80, 95, nil)
+	if !p.TriggerEvent("intro") {
+		t.Fatal("expected intro trigger to succeed")
+	}
+	if !p.TriggerEvent("new-piece") {
+		t.Fatal("expected new-piece trigger to succeed")
+	}
+	for i := 0; i < 18; i++ {
+		p.Step()
+	}
+
+	snap := p.Snapshot()
+	if snap.Timers["intro"] <= 0 {
+		t.Fatal("expected intro timer in snapshot")
+	}
+	if snap.Values["piece_kind"] <= 0 && snap.Values["fill_ratio"] <= 0 {
+		t.Fatal("expected either an active piece or a settled stack in snapshot")
+	}
+	if snap.Values["fill_ratio"] < 0 {
+		t.Fatal("expected fill ratio value in snapshot")
+	}
+
+	restored := NewProcedural("tetris", 160, 80, 7, nil)
+	restored.RestoreSnapshot(snap)
+	again := restored.Snapshot()
+	if again.Timers["intro"] != snap.Timers["intro"] {
+		t.Fatalf("restored intro timer = %d, want %d", again.Timers["intro"], snap.Timers["intro"])
+	}
+	if again.Values["fill_ratio"] != snap.Values["fill_ratio"] {
+		t.Fatalf("restored fill ratio = %f, want %f", again.Values["fill_ratio"], snap.Values["fill_ratio"])
+	}
+	if again.Values["stack_height"] != snap.Values["stack_height"] {
+		t.Fatalf("restored stack height = %f, want %f", again.Values["stack_height"], snap.Values["stack_height"])
+	}
+	if again.Values["piece_kind"] != snap.Values["piece_kind"] {
+		t.Fatalf("restored piece kind = %f, want %f", again.Values["piece_kind"], snap.Values["piece_kind"])
 	}
 }

--- a/sim/procedural_tetris.go
+++ b/sim/procedural_tetris.go
@@ -1,0 +1,610 @@
+package sim
+
+import (
+	"fmt"
+	"math"
+)
+
+const (
+	tetrisBoardCols = 10
+	tetrisBoardRows = 20
+)
+
+type tetrisPoint struct {
+	X int
+	Y int
+}
+
+var tetrisDefaults = ProceduralConfig{
+	"intro_dur":     60,
+	"intro_stack":   0,
+	"intro_cadence": 0.55,
+	"ending_dur":    70,
+	"ending_linger": 28,
+	"ending_fill":   0.84,
+	"well_x":        0.18,
+	"well_y":        0.13,
+	"cell_size":     3,
+	"spawn_every":   42,
+	"fall_every":    8,
+	"lock_delay":    4,
+	"glow":          0.18,
+	"ghost":         0.14,
+	"hue":           208,
+	"hue_sp":        24,
+	"sat":           0.56,
+	"lmin":          0.10,
+	"lmax":          0.92,
+	"new_piece_p":   0.0,
+	"lull_p":        0.0,
+	"new_piece_dur": 14,
+	"new_piece_cut": 0.25,
+	"lull_dur":      80,
+	"lull_mult":     1.8,
+}
+
+var tetrisPieceNames = []string{"I", "J", "L", "O", "S", "T", "Z"}
+
+var tetrisPieceRotations = [][][]tetrisPoint{
+	{
+		{{0, 1}, {1, 1}, {2, 1}, {3, 1}},
+		{{2, 0}, {2, 1}, {2, 2}, {2, 3}},
+		{{0, 2}, {1, 2}, {2, 2}, {3, 2}},
+		{{1, 0}, {1, 1}, {1, 2}, {1, 3}},
+	},
+	{
+		{{0, 0}, {0, 1}, {1, 1}, {2, 1}},
+		{{1, 0}, {2, 0}, {1, 1}, {1, 2}},
+		{{0, 1}, {1, 1}, {2, 1}, {2, 2}},
+		{{1, 0}, {1, 1}, {0, 2}, {1, 2}},
+	},
+	{
+		{{2, 0}, {0, 1}, {1, 1}, {2, 1}},
+		{{1, 0}, {1, 1}, {1, 2}, {2, 2}},
+		{{0, 1}, {1, 1}, {2, 1}, {0, 2}},
+		{{0, 0}, {1, 0}, {1, 1}, {1, 2}},
+	},
+	{
+		{{0, 0}, {1, 0}, {0, 1}, {1, 1}},
+		{{0, 0}, {1, 0}, {0, 1}, {1, 1}},
+		{{0, 0}, {1, 0}, {0, 1}, {1, 1}},
+		{{0, 0}, {1, 0}, {0, 1}, {1, 1}},
+	},
+	{
+		{{1, 0}, {2, 0}, {0, 1}, {1, 1}},
+		{{1, 0}, {1, 1}, {2, 1}, {2, 2}},
+		{{1, 1}, {2, 1}, {0, 2}, {1, 2}},
+		{{0, 0}, {0, 1}, {1, 1}, {1, 2}},
+	},
+	{
+		{{1, 0}, {0, 1}, {1, 1}, {2, 1}},
+		{{1, 0}, {1, 1}, {2, 1}, {1, 2}},
+		{{0, 1}, {1, 1}, {2, 1}, {1, 2}},
+		{{1, 0}, {0, 1}, {1, 1}, {1, 2}},
+	},
+	{
+		{{0, 0}, {1, 0}, {1, 1}, {2, 1}},
+		{{2, 0}, {1, 1}, {2, 1}, {1, 2}},
+		{{0, 1}, {1, 1}, {1, 2}, {2, 2}},
+		{{1, 0}, {0, 1}, {1, 1}, {0, 2}},
+	},
+}
+
+func TetrisSchema() EffectSchema {
+	return EffectSchema{
+		Name: "tetris",
+		Knobs: []Knob{
+			{Key: "intro_dur", Label: "intro dur", Slot: SlotSpawn, Group: "introduction", Type: KnobInt, Min: 10, Max: 220, Step: 5, Default: 60, Trigger: "intro",
+				Description: "Ticks spent easing from an empty well into the normal spawn rhythm."},
+			{Key: "intro_stack", Label: "intro stack", Slot: SlotSpawn, Group: "introduction", Type: KnobInt, Min: 0, Max: 8, Step: 1, Default: 0,
+				Description: "Approximate starting stack height in rows before the first active piece appears."},
+			{Key: "intro_cadence", Label: "intro cadence", Slot: SlotSpawn, Group: "introduction", Type: KnobFloat, Min: 0.2, Max: 1, Step: 0.05, Default: 0.55,
+				Description: "Fraction of the normal piece cadence used near the start of the intro."},
+			{Key: "ending_dur", Label: "ending dur", Slot: SlotEnd, Group: "ending", Type: KnobInt, Min: 10, Max: 220, Step: 5, Default: 70, Trigger: "ending",
+				Description: "Ticks spent dimming the board after it reaches a quiet lose-state."},
+			{Key: "ending_linger", Label: "ending linger", Slot: SlotEnd, Group: "ending", Type: KnobInt, Min: 0, Max: 180, Step: 5, Default: 28,
+				Description: "Extra quiet ticks where the filled board remains on screen before restart."},
+			{Key: "ending_fill", Label: "ending fill", Slot: SlotEnd, Group: "ending", Type: KnobFloat, Min: 0.6, Max: 0.98, Step: 0.01, Default: 0.84,
+				Description: "Board-fill ratio that triggers the ambient lose-state even before a blocked spawn."},
+			{Key: "well_x", Label: "well x", Slot: SlotLever, Group: "layout", Type: KnobFloat, Min: 0.08, Max: 0.4, Step: 0.01, Default: 0.18,
+				Description: "Horizontal placement of the Tetris well in the scene."},
+			{Key: "well_y", Label: "well y", Slot: SlotLever, Group: "layout", Type: KnobFloat, Min: 0.05, Max: 0.25, Step: 0.01, Default: 0.13,
+				Description: "Vertical placement of the well's top edge in the scene."},
+			{Key: "cell_size", Label: "cell size", Slot: SlotLever, Group: "layout", Type: KnobFloat, Min: 2, Max: 4, Step: 0.25, Default: 3,
+				Description: "Rendered size of each board cell in scene-grid units."},
+			{Key: "spawn_every", Label: "spawn every", Slot: SlotLever, Group: "cadence", Type: KnobInt, Min: 16, Max: 160, Step: 2, Default: 42,
+				Description: "Base pause between settled pieces before the next tetromino appears."},
+			{Key: "fall_every", Label: "fall every", Slot: SlotLever, Group: "cadence", Type: KnobInt, Min: 3, Max: 20, Step: 1, Default: 8,
+				Description: "Ticks between each downward step of the active tetromino."},
+			{Key: "lock_delay", Label: "lock delay", Slot: SlotLever, Group: "cadence", Type: KnobInt, Min: 1, Max: 12, Step: 1, Default: 4,
+				Description: "Extra ticks a resting piece waits before it settles into the stack."},
+			{Key: "glow", Label: "glow", Slot: SlotLever, Group: "palette", Type: KnobFloat, Min: 0.05, Max: 0.6, Step: 0.01, Default: 0.18,
+				Description: "Strength of the board halo and settled-stack atmosphere."},
+			{Key: "ghost", Label: "ghost", Slot: SlotLever, Group: "palette", Type: KnobFloat, Min: 0, Max: 0.5, Step: 0.01, Default: 0.14,
+				Description: "Opacity of the landing ghost beneath the active tetromino."},
+			{Key: "hue", Label: "hue", Slot: SlotLever, Group: "palette", Type: KnobFloat, Min: 180, Max: 260, Step: 1, Default: 208,
+				Description: "Base palette anchor for the cool neon board background."},
+			{Key: "hue_sp", Label: "hue spread", Slot: SlotLever, Group: "palette", Type: KnobFloat, Min: 8, Max: 40, Step: 1, Default: 24,
+				Description: "How far the tetromino colors spread away from the base hue."},
+			{Key: "sat", Label: "saturation", Slot: SlotLever, Group: "palette", Type: KnobFloat, Min: 0.2, Max: 0.8, Step: 0.01, Default: 0.56,
+				Description: "Overall saturation of the board, blocks, and glow."},
+			{Key: "lmin", Label: "light min", Slot: SlotLever, Group: "palette", Type: KnobFloat, Min: 0.05, Max: 0.4, Step: 0.01, Default: 0.10,
+				Description: "Minimum lightness used for the well interior and background."},
+			{Key: "lmax", Label: "light max", Slot: SlotLever, Group: "palette", Type: KnobFloat, Min: 0.4, Max: 1, Step: 0.01, Default: 0.92,
+				Description: "Maximum lightness used for active-piece highlights and board accents."},
+			{Key: "new_piece_p", Label: "new piece", Slot: SlotEvent, Type: KnobFloat, Min: 0, Max: 0.02, Step: 0.0005, Default: 0, Trigger: "new-piece",
+				Description: "Per-tick chance of shortening the wait until the next tetromino arrives."},
+			{Key: "lull_p", Label: "lull", Slot: SlotEvent, Type: KnobFloat, Min: 0, Max: 0.02, Step: 0.0005, Default: 0, Trigger: "lull",
+				Description: "Per-tick chance of a longer-than-usual pause between pieces."},
+			{Key: "new_piece_dur", Label: "new piece dur", Slot: SlotEventMod, Group: "new-piece", Type: KnobInt, Min: 4, Max: 40, Step: 1, Default: 14,
+				Description: "Duration of the shortened-spawn window created by a new-piece event."},
+			{Key: "new_piece_cut", Label: "new piece x", Slot: SlotEventMod, Group: "new-piece", Type: KnobFloat, Min: 0.05, Max: 1, Step: 0.05, Default: 0.25,
+				Description: "Fraction of the normal spawn delay kept while a new-piece window is active."},
+			{Key: "lull_dur", Label: "lull dur", Slot: SlotEventMod, Group: "lull", Type: KnobInt, Min: 20, Max: 200, Step: 5, Default: 80,
+				Description: "Duration of the extended ambient pause."},
+			{Key: "lull_mult", Label: "lull x", Slot: SlotEventMod, Group: "lull", Type: KnobFloat, Min: 1.05, Max: 3, Step: 0.05, Default: 1.8,
+				Description: "Spawn-delay multiplier applied while a lull is active."},
+		},
+	}
+}
+
+func mergeTetrisDefaults(cfg ProceduralConfig) ProceduralConfig {
+	out := cloneProceduralConfig(tetrisDefaults)
+	for k, v := range cfg {
+		out[k] = v
+	}
+	if out["intro_dur"] <= 0 {
+		out["intro_dur"] = tetrisDefaults["intro_dur"]
+	}
+	if out["intro_stack"] < 0 {
+		out["intro_stack"] = 0
+	}
+	if out["intro_stack"] > 8 {
+		out["intro_stack"] = 8
+	}
+	out["intro_cadence"] = clamp01(out["intro_cadence"])
+	if out["intro_cadence"] < 0.2 {
+		out["intro_cadence"] = tetrisDefaults["intro_cadence"]
+	}
+	if out["ending_dur"] <= 0 {
+		out["ending_dur"] = tetrisDefaults["ending_dur"]
+	}
+	if out["ending_linger"] < 0 {
+		out["ending_linger"] = 0
+	}
+	out["ending_fill"] = clamp01(out["ending_fill"])
+	if out["ending_fill"] < 0.6 {
+		out["ending_fill"] = tetrisDefaults["ending_fill"]
+	}
+	if out["well_x"] <= 0 {
+		out["well_x"] = tetrisDefaults["well_x"]
+	}
+	if out["well_y"] <= 0 {
+		out["well_y"] = tetrisDefaults["well_y"]
+	}
+	if out["cell_size"] <= 0 {
+		out["cell_size"] = tetrisDefaults["cell_size"]
+	}
+	if out["spawn_every"] <= 0 {
+		out["spawn_every"] = tetrisDefaults["spawn_every"]
+	}
+	if out["fall_every"] <= 0 {
+		out["fall_every"] = tetrisDefaults["fall_every"]
+	}
+	if out["lock_delay"] < 1 {
+		out["lock_delay"] = tetrisDefaults["lock_delay"]
+	}
+	if out["glow"] <= 0 {
+		out["glow"] = tetrisDefaults["glow"]
+	}
+	if out["ghost"] < 0 {
+		out["ghost"] = 0
+	}
+	if out["hue"] <= 0 {
+		out["hue"] = tetrisDefaults["hue"]
+	}
+	if out["hue_sp"] < 0 {
+		out["hue_sp"] = 0
+	}
+	if out["sat"] <= 0 {
+		out["sat"] = tetrisDefaults["sat"]
+	}
+	if out["lmin"] <= 0 {
+		out["lmin"] = tetrisDefaults["lmin"]
+	}
+	if out["lmax"] <= 0 {
+		out["lmax"] = tetrisDefaults["lmax"]
+	}
+	if out["lmax"] < out["lmin"] {
+		out["lmin"], out["lmax"] = out["lmax"], out["lmin"]
+	}
+	if out["new_piece_dur"] <= 0 {
+		out["new_piece_dur"] = tetrisDefaults["new_piece_dur"]
+	}
+	if out["new_piece_cut"] <= 0 {
+		out["new_piece_cut"] = tetrisDefaults["new_piece_cut"]
+	}
+	if out["lull_dur"] <= 0 {
+		out["lull_dur"] = tetrisDefaults["lull_dur"]
+	}
+	if out["lull_mult"] <= 1 {
+		out["lull_mult"] = tetrisDefaults["lull_mult"]
+	}
+	return out
+}
+
+func tetrisMakeRNG(seed uint32) func() float64 {
+	state := seed
+	return func() float64 {
+		state += 0x6D2B79F5
+		t := state
+		t = uint32(int32(t^(t>>15)) * int32(t|1))
+		t ^= t + uint32(int32(t^(t>>7))*int32(t|61))
+		return float64((t^(t>>14))>>0) / 4294967296.0
+	}
+}
+
+func tetrisJitterInt(rng func() float64, base int, spread float64) int {
+	f := float64(base) * (1 + spread*(rng()*2-1))
+	return max(1, int(math.Round(f)))
+}
+
+func (p *Procedural) tetrisSeededRNGLocked(key int) func() float64 {
+	seed := uint32(p.seed) ^ uint32(uint32(key)*2654435761)
+	return tetrisMakeRNG(seed)
+}
+
+func (p *Procedural) tetrisEventRNGLocked(salt int) func() float64 {
+	return p.tetrisSeededRNGLocked(p.tick + salt)
+}
+
+func tetrisPieceName(kind int) string {
+	if kind < 1 || kind > len(tetrisPieceNames) {
+		return "?"
+	}
+	return tetrisPieceNames[kind-1]
+}
+
+func tetrisCellKey(row, col int) string {
+	return fmt.Sprintf("cell_%02d_%02d", row, col)
+}
+
+func tetrisPiecePoints(kind, rot int) []tetrisPoint {
+	if kind < 1 || kind > len(tetrisPieceRotations) {
+		return nil
+	}
+	rots := tetrisPieceRotations[kind-1]
+	if len(rots) == 0 {
+		return nil
+	}
+	rot = ((rot % len(rots)) + len(rots)) % len(rots)
+	return rots[rot]
+}
+
+func (p *Procedural) tetrisGetCellLocked(row, col int) int {
+	if row < 0 || row >= tetrisBoardRows || col < 0 || col >= tetrisBoardCols {
+		return 0
+	}
+	return int(math.Round(p.values[tetrisCellKey(row, col)]))
+}
+
+func (p *Procedural) tetrisSetCellLocked(row, col, value int) {
+	if row < 0 || row >= tetrisBoardRows || col < 0 || col >= tetrisBoardCols {
+		return
+	}
+	key := tetrisCellKey(row, col)
+	if value <= 0 {
+		delete(p.values, key)
+		return
+	}
+	p.values[key] = float64(value)
+}
+
+func (p *Procedural) tetrisClearBoardLocked() {
+	for row := 0; row < tetrisBoardRows; row++ {
+		for col := 0; col < tetrisBoardCols; col++ {
+			delete(p.values, tetrisCellKey(row, col))
+		}
+	}
+}
+
+func (p *Procedural) tetrisSeedIntroStackLocked() {
+	rows := p.intCfg("intro_stack")
+	if rows <= 0 {
+		return
+	}
+	for col := 0; col < tetrisBoardCols; col++ {
+		rng := p.tetrisSeededRNGLocked(400 + col*7)
+		height := rows - 1 + int(math.Floor(rng()*3))
+		if height < 0 {
+			height = 0
+		}
+		if height > rows {
+			height = rows
+		}
+		for depth := 0; depth < height; depth++ {
+			row := tetrisBoardRows - 1 - depth
+			kind := 1 + (col+depth+int(math.Floor(rng()*float64(len(tetrisPieceRotations)))))%len(tetrisPieceRotations)
+			p.tetrisSetCellLocked(row, col, kind)
+		}
+	}
+}
+
+func (p *Procedural) tetrisClearCurrentPieceLocked() {
+	p.values["piece_alive"] = 0
+	delete(p.values, "piece_kind")
+	delete(p.values, "piece_rot")
+	delete(p.values, "piece_x")
+	delete(p.values, "piece_y")
+	delete(p.values, "fall_cd")
+	delete(p.values, "lock_cd")
+}
+
+func (p *Procedural) tetrisCurrentPieceLocked() (kind, rot, x, y int, alive bool) {
+	alive = p.values["piece_alive"] > 0.5
+	if !alive {
+		return 0, 0, 0, 0, false
+	}
+	kind = int(math.Round(p.values["piece_kind"]))
+	rot = int(math.Round(p.values["piece_rot"]))
+	x = int(math.Round(p.values["piece_x"]))
+	y = int(math.Round(p.values["piece_y"]))
+	return kind, rot, x, y, true
+}
+
+func (p *Procedural) tetrisSetCurrentPieceLocked(kind, rot, x, y int) {
+	p.values["piece_alive"] = 1
+	p.values["piece_kind"] = float64(kind)
+	p.values["piece_rot"] = float64(rot)
+	p.values["piece_x"] = float64(x)
+	p.values["piece_y"] = float64(y)
+}
+
+func (p *Procedural) tetrisCollisionLocked(kind, rot, x, y int) bool {
+	for _, pt := range tetrisPiecePoints(kind, rot) {
+		col := x + pt.X
+		row := y + pt.Y
+		if col < 0 || col >= tetrisBoardCols || row < 0 || row >= tetrisBoardRows {
+			return true
+		}
+		if p.tetrisGetCellLocked(row, col) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func (p *Procedural) tetrisLockPieceLocked(kind, rot, x, y int) {
+	for _, pt := range tetrisPiecePoints(kind, rot) {
+		p.tetrisSetCellLocked(y+pt.Y, x+pt.X, kind)
+	}
+}
+
+func (p *Procedural) tetrisBoardStatsLocked() (filled, stack int) {
+	top := tetrisBoardRows
+	for row := 0; row < tetrisBoardRows; row++ {
+		for col := 0; col < tetrisBoardCols; col++ {
+			if p.tetrisGetCellLocked(row, col) <= 0 {
+				continue
+			}
+			filled++
+			if row < top {
+				top = row
+			}
+		}
+	}
+	if filled == 0 {
+		return 0, 0
+	}
+	return filled, tetrisBoardRows - top
+}
+
+func (p *Procedural) tetrisUpdateBoardStatsLocked() {
+	filled, stack := p.tetrisBoardStatsLocked()
+	p.values["fill_ratio"] = float64(filled) / float64(tetrisBoardCols*tetrisBoardRows)
+	p.values["stack_height"] = float64(stack)
+}
+
+func (p *Procedural) tetrisSpawnDelayLocked() int {
+	delay := max(1, p.intCfg("spawn_every"))
+	if p.timers["intro"] > 0 {
+		total := int(math.Round(p.values["intro_total"]))
+		progress := proceduralPhaseProgress(total, p.timers["intro"])
+		cadence := p.cfg["intro_cadence"] + (1-p.cfg["intro_cadence"])*progress
+		delay = max(1, int(math.Round(float64(delay)*math.Max(0.2, cadence))))
+	}
+	if p.timers["lull"] > 0 {
+		gain := p.values["lull_gain"]
+		if gain <= 1 {
+			gain = p.cfg["lull_mult"]
+		}
+		delay = max(1, int(math.Round(float64(delay)*math.Max(1.05, gain))))
+	}
+	if p.timers["new-piece"] > 0 {
+		cut := p.values["new_piece_cut"]
+		if cut <= 0 {
+			cut = p.cfg["new_piece_cut"]
+		}
+		delay = max(1, int(math.Round(float64(delay)*math.Max(0.05, cut))))
+	}
+	return delay
+}
+
+func (p *Procedural) tetrisFallDelayLocked() int {
+	delay := max(1, p.intCfg("fall_every"))
+	if p.timers["new-piece"] > 0 {
+		delay = max(1, int(math.Round(float64(delay)*0.6)))
+	}
+	return delay
+}
+
+func (p *Procedural) startTetrisNewPieceLocked(verb string) {
+	rng := p.tetrisEventRNGLocked(182)
+	p.timers["lull"] = 0
+	p.timers["new-piece"] = tetrisJitterInt(rng, p.intCfg("new_piece_dur"), 0.25)
+	p.values["lull_gain"] = 1
+	p.values["new_piece_cut"] = math.Max(0.05, p.cfg["new_piece_cut"]*(0.8+rng()*0.35))
+	if _, _, _, _, alive := p.tetrisCurrentPieceLocked(); alive {
+		if fall := int(math.Round(p.values["fall_cd"])); fall > 1 {
+			p.values["fall_cd"] = 1
+		}
+		if lock := int(math.Round(p.values["lock_cd"])); lock > 1 {
+			p.values["lock_cd"] = 1
+		}
+	} else if spawn := int(math.Round(p.values["spawn_cd"])); spawn > 1 {
+		p.values["spawn_cd"] = float64(max(1, int(math.Round(float64(spawn)*p.values["new_piece_cut"]))))
+	}
+	p.appendLog("new-piece", fmt.Sprintf("%s (dur=%d, x%.2f)", verb, p.timers["new-piece"], p.values["new_piece_cut"]))
+}
+
+func (p *Procedural) startTetrisLullLocked(verb string) {
+	rng := p.tetrisEventRNGLocked(177)
+	p.timers["new-piece"] = 0
+	p.timers["lull"] = tetrisJitterInt(rng, p.intCfg("lull_dur"), 0.25)
+	p.values["new_piece_cut"] = p.cfg["new_piece_cut"]
+	p.values["lull_gain"] = math.Max(1.05, p.cfg["lull_mult"]*(0.9+rng()*0.3))
+	if _, _, _, _, alive := p.tetrisCurrentPieceLocked(); !alive {
+		delay := int(math.Round(p.values["spawn_cd"]))
+		if delay < 1 {
+			delay = p.intCfg("spawn_every")
+		}
+		target := int(math.Round(float64(delay) * p.values["lull_gain"]))
+		if target > delay {
+			p.values["spawn_cd"] = float64(target)
+		}
+	}
+	p.appendLog("lull", fmt.Sprintf("%s (dur=%d, x%.2f)", verb, p.timers["lull"], p.values["lull_gain"]))
+}
+
+func (p *Procedural) startTetrisIntroLocked() {
+	p.timers["new-piece"] = 0
+	p.timers["lull"] = 0
+	p.timers["ending"] = 0
+	p.values["lull_gain"] = 1
+	p.values["new_piece_cut"] = p.cfg["new_piece_cut"]
+	delete(p.values, "ended")
+	delete(p.values, "ending_total")
+	p.tetrisClearCurrentPieceLocked()
+	p.tetrisClearBoardLocked()
+	p.tetrisSeedIntroStackLocked()
+	p.values["piece_counter"] = 0
+	p.timers["intro"] = p.intCfg("intro_dur")
+	p.values["intro_total"] = float64(p.timers["intro"])
+	p.values["spawn_cd"] = float64(max(1, int(math.Round(float64(p.intCfg("spawn_every"))*math.Max(0.2, p.cfg["intro_cadence"])))))
+	p.tetrisUpdateBoardStatsLocked()
+}
+
+func (p *Procedural) startTetrisEndingLocked(reason string) {
+	p.timers["intro"] = 0
+	p.timers["new-piece"] = 0
+	p.timers["lull"] = 0
+	p.values["lull_gain"] = 1
+	delete(p.values, "intro_total")
+	p.tetrisClearCurrentPieceLocked()
+	endingTotal := p.intCfg("ending_dur") + max(0, p.intCfg("ending_linger"))
+	if endingTotal < 1 {
+		endingTotal = max(1, p.intCfg("ending_dur"))
+	}
+	p.timers["ending"] = endingTotal
+	p.values["ending_total"] = float64(endingTotal)
+	p.values["ended"] = 1
+	p.tetrisUpdateBoardStatsLocked()
+	if reason != "" {
+		p.appendLog("ending", reason)
+	}
+}
+
+func (p *Procedural) tetrisSpawnPieceLocked(verb string) bool {
+	counter := int(math.Round(p.values["piece_counter"]))
+	rng := p.tetrisSeededRNGLocked(800 + counter*17)
+	kind := 1 + int(math.Floor(rng()*float64(len(tetrisPieceRotations))))
+	rot := int(math.Floor(rng() * 4))
+	x := 3
+	y := 0
+	if p.tetrisCollisionLocked(kind, rot, x, y) {
+		p.startTetrisEndingLocked("started (board blocked)")
+		return false
+	}
+	p.values["piece_counter"] = float64(counter + 1)
+	p.tetrisSetCurrentPieceLocked(kind, rot, x, y)
+	p.values["fall_cd"] = float64(p.tetrisFallDelayLocked())
+	p.values["lock_cd"] = float64(max(1, p.intCfg("lock_delay")))
+	p.values["spawn_cd"] = 0
+	if p.timers["new-piece"] > 0 {
+		p.timers["new-piece"] = 0
+	}
+	p.appendLog("new-piece", fmt.Sprintf("%s (%s)", verb, tetrisPieceName(kind)))
+	return true
+}
+
+func (p *Procedural) stepTetrisLocked() {
+	if p.timers["lull"] <= 0 {
+		p.values["lull_gain"] = 1
+	}
+	if p.timers["new-piece"] <= 0 {
+		delete(p.values, "new_piece_cut")
+	}
+	if p.timers["intro"] <= 0 {
+		delete(p.values, "intro_total")
+	}
+	if p.timers["ending"] <= 0 {
+		delete(p.values, "ending_total")
+		if p.values["ended"] > 0.5 {
+			p.startTetrisIntroLocked()
+			p.appendLog("intro", "restarted after lose-state")
+			return
+		}
+	}
+	if p.timers["ending"] > 0 {
+		p.tetrisUpdateBoardStatsLocked()
+		return
+	}
+
+	kind, rot, x, y, alive := p.tetrisCurrentPieceLocked()
+	if !alive {
+		spawnCD := int(math.Round(p.values["spawn_cd"]))
+		if spawnCD > 0 {
+			spawnCD--
+			p.values["spawn_cd"] = float64(spawnCD)
+		}
+		if spawnCD <= 0 {
+			p.tetrisSpawnPieceLocked("spawned")
+		}
+	} else {
+		fallCD := int(math.Round(p.values["fall_cd"]))
+		lockCD := int(math.Round(p.values["lock_cd"]))
+		if p.timers["new-piece"] > 0 && fallCD > 1 {
+			fallCD = 1
+		}
+		if fallCD > 0 {
+			fallCD--
+			p.values["fall_cd"] = float64(fallCD)
+		} else if !p.tetrisCollisionLocked(kind, rot, x, y+1) {
+			y++
+			p.values["piece_y"] = float64(y)
+			p.values["fall_cd"] = float64(p.tetrisFallDelayLocked())
+			p.values["lock_cd"] = float64(max(1, p.intCfg("lock_delay")))
+		} else if lockCD > 0 {
+			lockCD--
+			p.values["lock_cd"] = float64(lockCD)
+		} else {
+			p.tetrisLockPieceLocked(kind, rot, x, y)
+			p.tetrisClearCurrentPieceLocked()
+			p.values["spawn_cd"] = float64(p.tetrisSpawnDelayLocked())
+			p.tetrisUpdateBoardStatsLocked()
+			if p.values["fill_ratio"] >= math.Max(0.6, p.cfg["ending_fill"]) {
+				p.startTetrisEndingLocked(fmt.Sprintf("started (fill=%.2f)", p.values["fill_ratio"]))
+				return
+			}
+		}
+	}
+
+	p.tetrisUpdateBoardStatsLocked()
+	if p.timers["new-piece"] <= 0 && p.timers["lull"] <= 0 && p.cfg["new_piece_p"] > 0 && p.rng.Float64() < p.cfg["new_piece_p"] {
+		p.startTetrisNewPieceLocked("started")
+		return
+	}
+	if p.timers["lull"] <= 0 && p.timers["new-piece"] <= 0 && p.cfg["lull_p"] > 0 && p.rng.Float64() < p.cfg["lull_p"] {
+		p.startTetrisLullLocked("started")
+	}
+}


### PR DESCRIPTION
## Summary
- add a full Tetris procedural runtime for dev atmospheres, including schema, snapshot/restore state, deterministic piece sequencing, intro/ending lifecycle, and manual `new-piece` / `lull` triggers
- register the effect end to end so `/dev/tetris` and `/effects/tetris/schema` work through the shared effect plumbing
- add browser-side rendering plus issue-aligned presets (`museum pace`, `steady build`, `dense stack`, `late game`) for live tuning on the dev page

## Validation
- `node --check cmd/ambience/web/sim.js`
- `go test ./...`
- `powershell -ExecutionPolicy Bypass -File scripts/dev-deploy.ps1 -Component all`
- `curl.exe -I https://ambience.dev.romaine.life/dev/tetris`
- `curl.exe -I https://ambience.dev.romaine.life/effects/tetris/schema`
- visually validated `https://ambience.dev.romaine.life/dev/tetris` via headless Chrome screenshots for intro / new-piece / lull interactions

Closes #5.