### PR TITLE
Add SSE-driven cross-effect transitions

### DIFF
--- a/cmd/ambience/atmosphere.go
+++ b/cmd/ambience/atmosphere.go
@@ -78,13 +78,14 @@ type atmosphere struct {
 	mu sync.Mutex
 	// Sim + explicit scene RNG. Entropy POSTs flow into both so future event
 	// rolls and future generated scenes survive restarts coherently.
-	effect       effectRuntime
-	cfg          sim.Config
-	seed         int64
-	sceneRNG     *rngutil.RNG
-	current      Scene
-	next         Scene
-	entropyBytes int64 // cumulative entropy bytes received since boot
+	effect        effectRuntime
+	effectVersion int64
+	cfg           sim.Config
+	seed          int64
+	sceneRNG      *rngutil.RNG
+	current       Scene
+	next          Scene
+	entropyBytes  int64 // cumulative entropy bytes received since boot
 	// Transition state: when a scene rotates, we don't apply the new config
 	// instantly. Instead we LERP from transitionFrom to transitionTo over
 	// transitionDur ticks starting at transitionStart. transitionDur == 0
@@ -105,21 +106,22 @@ func newAtmosphere(_ sim.Config) *atmosphere {
 	// generated scene, so the argument is ignored. Kept in the signature to
 	// avoid a cascading change in callers (dev atmospheres, tests).
 	seed := time.Now().UnixNano()
-	sceneRNG := rngutil.New(seed ^ 0x6d0f27bd0b5a3c11)
+	sceneRNG := rngutil.New(seed ^ sceneSeedMix)
 	first := generateScene(sceneRNG, 0)
 	// Pre-generate the next scene too — the "single-slot lookahead" model.
 	// StartedAtTick is set when it's promoted to current.
 	nxt := generateScene(sceneRNG, 0)
 	cfgData, _ := json.Marshal(first.Config)
 	return &atmosphere{
-		effect:    mustNewEffectRuntime("rain", gridW, gridH, seed, cfgData),
-		cfg:       first.Config,
-		seed:      seed,
-		sceneRNG:  sceneRNG,
-		current:   first,
-		next:      nxt,
-		listeners: make(map[chan Command]struct{}),
-		lastSeen:  time.Now(),
+		effect:        mustNewEffectRuntime("rain", gridW, gridH, seed, cfgData),
+		effectVersion: 1,
+		cfg:           first.Config,
+		seed:          seed,
+		sceneRNG:      sceneRNG,
+		current:       first,
+		next:          nxt,
+		listeners:     make(map[chan Command]struct{}),
+		lastSeen:      time.Now(),
 	}
 }
 
@@ -141,22 +143,35 @@ func (a *atmosphere) run(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-t.C:
-			a.effect.Step()
-			cur := a.effect.CurrentTick()
+			effect, version := a.currentEffectRuntime()
+			effect.Step()
+			if !a.effectVersionIs(version) {
+				continue
+			}
+			cur := effect.CurrentTick()
 
 			a.applyTransition(cur)
+			if !a.effectVersionIs(version) {
+				continue
+			}
 
 			a.mu.Lock()
-			expired := cur >= a.current.StartedAtTick+a.current.DurationTicks
+			expired := a.current.DurationTicks > 0 && cur >= a.current.StartedAtTick+a.current.DurationTicks
 			a.mu.Unlock()
 			if expired {
 				a.rotateScene(cur)
+				if !a.effectVersionIs(version) {
+					continue
+				}
 			}
 			if cur%metricBroadcastEvery == 0 {
 				a.broadcastMetric(cur)
 			}
 
-			for _, e := range a.effect.DrainLog() {
+			for _, e := range effect.DrainLog() {
+				if !a.effectVersionIs(version) {
+					break
+				}
 				a.broadcast(Command{
 					Kind:  "trigger",
 					Tick:  e.Tick,
@@ -179,6 +194,7 @@ func (a *atmosphere) applyTransition(cur int) {
 		a.mu.Unlock()
 		return
 	}
+	effect := a.effect
 	elapsed := cur - a.transitionStart
 	if elapsed >= a.transitionDur {
 		final := a.transitionTo
@@ -187,7 +203,7 @@ func (a *atmosphere) applyTransition(cur int) {
 		a.cfg = final
 		a.mu.Unlock()
 		data, _ := json.Marshal(final)
-		_ = a.effect.ApplyConfig(data)
+		_ = effect.ApplyConfig(data)
 		a.broadcast(Command{Kind: "config", Tick: cur, Data: data})
 		return
 	}
@@ -199,7 +215,7 @@ func (a *atmosphere) applyTransition(cur int) {
 	progress := easeInOutCubic(float64(elapsed) / float64(dur))
 	lerped := lerpConfig(from, to, progress)
 	data, _ := json.Marshal(lerped)
-	_ = a.effect.ApplyConfig(data)
+	_ = effect.ApplyConfig(data)
 	if elapsed%transitionBroadcastEvery == 0 {
 		a.broadcast(Command{Kind: "config", Tick: cur, Data: data})
 	}
@@ -378,17 +394,30 @@ func (a *atmosphere) currentCommandID() string {
 	return strconv.FormatInt(a.commandSeq, 10)
 }
 
+func (a *atmosphere) currentEffectRuntime() (effectRuntime, int64) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.effect, a.effectVersion
+}
+
+func (a *atmosphere) effectVersionIs(version int64) bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.effectVersion == version
+}
+
 func (a *atmosphere) snapshot() snapshotData {
 	a.mu.Lock()
+	effect := a.effect
 	seed := a.seed
 	current := a.current
 	next := a.next
 	entropyBytes := a.entropyBytes
 	a.mu.Unlock()
-	effectSnap, err := a.effect.Snapshot()
+	effectSnap, err := effect.Snapshot()
 	if err != nil {
 		return snapshotData{
-			Type:           a.effect.Type(),
+			Type:           effect.Type(),
 			Seed:           seed,
 			CurrentScene:   current,
 			NextScene:      next,
@@ -428,8 +457,9 @@ func (a *atmosphere) AddEntropy(b []byte) {
 	a.seed ^= acc
 	a.entropyBytes += int64(len(b))
 	a.sceneRNG.Mix(acc)
+	effect := a.effect
 	a.mu.Unlock()
-	a.effect.AddEntropy(acc)
+	effect.AddEntropy(acc)
 	// Push a metric broadcast on every entropy event so the / live monitor's
 	// counter updates immediately (no 30 s polling cadence needed). Sub-
 	// second latency matches the client-side entropy buffer flush (2 s).
@@ -437,10 +467,11 @@ func (a *atmosphere) AddEntropy(b []byte) {
 }
 
 func (a *atmosphere) setConfigRaw(data json.RawMessage) error {
-	if err := a.effect.ApplyConfig(data); err != nil {
+	effect, _ := a.currentEffectRuntime()
+	if err := effect.ApplyConfig(data); err != nil {
 		return err
 	}
-	effectType := a.effect.Type()
+	effectType := effect.Type()
 	var cfg sim.Config
 	hasRainConfig := effectType == "rain" && json.Unmarshal(data, &cfg) == nil
 	if hasRainConfig {
@@ -458,7 +489,7 @@ func (a *atmosphere) setConfigRaw(data json.RawMessage) error {
 	a.mu.Unlock()
 	a.broadcast(Command{
 		Kind: "config",
-		Tick: a.effect.CurrentTick(),
+		Tick: effect.CurrentTick(),
 		Data: cloneRaw(data),
 	})
 	return nil
@@ -466,5 +497,6 @@ func (a *atmosphere) setConfigRaw(data json.RawMessage) error {
 
 func (a *atmosphere) triggerEvent(event string) bool {
 	// TriggerEvent writes to the log; the run loop picks it up and broadcasts.
-	return a.effect.Trigger(event)
+	effect, _ := a.currentEffectRuntime()
+	return effect.Trigger(event)
 }

--- a/cmd/ambience/dev_sessions.go
+++ b/cmd/ambience/dev_sessions.go
@@ -26,15 +26,16 @@ type devSnapshotData struct {
 type devSession struct {
 	mu sync.Mutex
 
-	seed       int64
-	effect     effectRuntime
-	commandSeq int64
-	listeners  map[chan Command]struct{}
-	lastSeen   time.Time
-	cancel     context.CancelFunc
+	seed          int64
+	effect        effectRuntime
+	effectVersion int64
+	commandSeq    int64
+	listeners     map[chan Command]struct{}
+	lastSeen      time.Time
+	cancel        context.CancelFunc
 }
 
-var devSessions sync.Map // key "<effect>\n<session>" => *devSession
+var devSessions sync.Map // key "<session>" => *devSession
 
 func normalizeDevEffect(effect string) string {
 	effect = strings.TrimSpace(strings.ToLower(effect))
@@ -96,23 +97,21 @@ func serveEffectSchema(w http.ResponseWriter, req *http.Request) {
 
 func newDevSession(effectType string) (*devSession, error) {
 	effectType = normalizeDevEffect(effectType)
-	seed := time.Now().UnixNano()
-	effect, err := newEffectRuntime(effectType, gridW, gridH, seed, nil)
+	seed := deriveEffectSeed(time.Now().UnixNano(), 0, effectType)
+	cfg, err := randomizedEffectConfig(effectType, seed)
 	if err != nil {
 		return nil, err
 	}
-	cfg, err := randomizedDevConfig(effect.Schema(), seed)
+	effect, err := newEffectRuntime(effectType, gridW, gridH, seed, cfg)
 	if err != nil {
-		return nil, err
-	}
-	if err := effect.ApplyConfig(cfg); err != nil {
 		return nil, err
 	}
 	return &devSession{
-		seed:      seed,
-		effect:    effect,
-		listeners: make(map[chan Command]struct{}),
-		lastSeen:  time.Now(),
+		seed:          seed,
+		effect:        effect,
+		effectVersion: 1,
+		listeners:     make(map[chan Command]struct{}),
+		lastSeen:      time.Now(),
 	}, nil
 }
 
@@ -129,7 +128,8 @@ func configsEqualJSON(left, right json.RawMessage) bool {
 }
 
 func devSessionKey(effectType, sessionID string) string {
-	return normalizeDevEffect(effectType) + "\n" + sessionID
+	_ = effectType
+	return strings.TrimSpace(sessionID)
 }
 
 func getOrCreateDevSession(effectType, sessionID string) (*devSession, error) {
@@ -190,8 +190,15 @@ func (s *devSession) run(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			s.effect.Step()
-			for _, entry := range s.effect.DrainLog() {
+			effect, version := s.currentEffectRuntime()
+			effect.Step()
+			if !s.effectVersionIs(version) {
+				continue
+			}
+			for _, entry := range effect.DrainLog() {
+				if !s.effectVersionIs(version) {
+					break
+				}
 				s.broadcast(Command{
 					Kind:  "trigger",
 					Tick:  entry.Tick,
@@ -241,20 +248,33 @@ func (s *devSession) currentCommandID() string {
 	return strconv.FormatInt(s.commandSeq, 10)
 }
 
+func (s *devSession) currentEffectRuntime() (effectRuntime, int64) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.effect, s.effectVersion
+}
+
+func (s *devSession) effectVersionIs(version int64) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.effectVersion == version
+}
+
 func (s *devSession) snapshot() devSnapshotData {
 	s.mu.Lock()
 	seed := s.seed
+	effect := s.effect
 	s.mu.Unlock()
 
-	effectSnap, err := s.effect.Snapshot()
+	effectSnap, err := effect.Snapshot()
 	if err != nil {
 		return devSnapshotData{
-			Type: s.effect.Type(),
+			Type: effect.Type(),
 			Seed: seed,
 		}
 	}
 	return devSnapshotData{
-		Type:   s.effect.Type(),
+		Type:   effect.Type(),
 		Tick:   effectSnap.Tick,
 		Config: cloneRaw(effectSnap.Config),
 		State:  cloneRaw(effectSnap.State),
@@ -273,24 +293,26 @@ func (s *devSession) setConfigQuery(values url.Values) error {
 }
 
 func (s *devSession) applyConfig(data json.RawMessage) error {
-	if err := s.effect.ApplyConfig(data); err != nil {
+	effect, _ := s.currentEffectRuntime()
+	if err := effect.ApplyConfig(data); err != nil {
 		return err
 	}
 	s.broadcast(Command{
 		Kind: "config",
-		Tick: s.effect.CurrentTick(),
+		Tick: effect.CurrentTick(),
 		Data: cloneRaw(data),
 	})
 	return nil
 }
 
 func (s *devSession) randomizeConfig(seed int64) (json.RawMessage, error) {
-	current, err := s.effect.Snapshot()
+	effect, _ := s.currentEffectRuntime()
+	current, err := effect.Snapshot()
 	if err != nil {
 		return nil, err
 	}
 	for attempt := range 6 {
-		cfg, err := randomizedDevConfig(s.effect.Schema(), seed+int64(attempt)*7919)
+		cfg, err := randomizedDevConfig(effect.Schema(), seed+int64(attempt)*7919)
 		if err != nil {
 			return nil, err
 		}
@@ -305,15 +327,17 @@ func (s *devSession) randomizeConfig(seed int64) (json.RawMessage, error) {
 }
 
 func (s *devSession) triggerEvent(event string) bool {
-	return s.effect.Trigger(event)
+	effect, _ := s.currentEffectRuntime()
+	return effect.Trigger(event)
 }
 
 func writeDevSnapshotFrame(w http.ResponseWriter, flusher http.Flusher, s *devSession) error {
 	data, _ := json.Marshal(s.snapshot())
+	effect, _ := s.currentEffectRuntime()
 	return writeCommand(w, flusher, Command{
 		ID:   s.currentCommandID(),
 		Kind: "snapshot",
-		Tick: s.effect.CurrentTick(),
+		Tick: effect.CurrentTick(),
 		Data: data,
 	})
 }
@@ -440,6 +464,28 @@ func serveDevSessionTrigger(w http.ResponseWriter, req *http.Request) {
 	}
 	if !s.triggerEvent(event) {
 		http.Error(w, "unknown event: "+event, http.StatusBadRequest)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func serveDevSessionEffect(w http.ResponseWriter, req *http.Request) {
+	if req.Method != http.MethodPost {
+		http.Error(w, "POST required", http.StatusMethodNotAllowed)
+		return
+	}
+	rawEffect := strings.TrimSpace(req.URL.Query().Get("effect"))
+	if rawEffect == "" {
+		http.Error(w, "effect param required", http.StatusBadRequest)
+		return
+	}
+	s, effectType, _, err := devSessionFromRequest(req)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if err := s.switchEffect(effectType); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)

--- a/cmd/ambience/dev_sessions_test.go
+++ b/cmd/ambience/dev_sessions_test.go
@@ -338,3 +338,39 @@ func TestDevSessionRandomizeConfigChangesSnapshotConfig(t *testing.T) {
 		t.Fatal("expected randomized config to differ from previous session config")
 	}
 }
+
+func TestGetOrCreateDevSessionReusesSessionIDAcrossEffects(t *testing.T) {
+	sessionID := "session-1"
+
+	first, err := getOrCreateDevSession("rain", sessionID)
+	if err != nil {
+		t.Fatalf("getOrCreateDevSession rain: %v", err)
+	}
+	second, err := getOrCreateDevSession("dust", sessionID)
+	if err != nil {
+		t.Fatalf("getOrCreateDevSession dust: %v", err)
+	}
+	if first != second {
+		t.Fatal("expected same session instance for identical session id")
+	}
+	if snap := second.snapshot(); snap.Type != "rain" {
+		t.Fatalf("snapshot type = %q, want rain before explicit switch", snap.Type)
+	}
+}
+
+func TestDevSessionSwitchEffectChangesSnapshotType(t *testing.T) {
+	session, err := newDevSession("rain")
+	if err != nil {
+		t.Fatalf("newDevSession: %v", err)
+	}
+	if err := session.switchEffect("dust"); err != nil {
+		t.Fatalf("switchEffect: %v", err)
+	}
+	snap := session.snapshot()
+	if snap.Type != "dust" {
+		t.Fatalf("snapshot type = %q, want dust", snap.Type)
+	}
+	if snap.GridW != gridW || snap.GridH != gridH {
+		t.Fatalf("grid = %dx%d, want %dx%d", snap.GridW, snap.GridH, gridW, gridH)
+	}
+}

--- a/cmd/ambience/effect_switch.go
+++ b/cmd/ambience/effect_switch.go
@@ -1,0 +1,160 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/nelsong6/ambience/rngutil"
+	"github.com/nelsong6/ambience/sim"
+)
+
+const sceneSeedMix int64 = 0x6d0f27bd0b5a3c11
+
+func effectDisplayName(effectType string) string {
+	return strings.ReplaceAll(strings.TrimSpace(effectType), "-", " ")
+}
+
+func effectHash(effectType string) int64 {
+	var hash int64 = 1469598103934665603
+	for _, ch := range strings.TrimSpace(effectType) {
+		hash ^= int64(ch)
+		hash *= 1099511628211
+	}
+	if hash < 0 {
+		hash = -hash
+	}
+	if hash == 0 {
+		hash = 1
+	}
+	return hash
+}
+
+func deriveEffectSeed(base int64, tick int, effectType string) int64 {
+	seed := base ^ (int64(tick+1) * 1103515245) ^ effectHash(effectType)
+	if seed == 0 {
+		seed = effectHash(effectType)
+	}
+	return seed
+}
+
+func randomizedEffectConfig(effectType string, seed int64) (json.RawMessage, error) {
+	schema, ok := schemaForEffect(effectType)
+	if !ok {
+		return nil, fmt.Errorf("unknown effect type %q", effectType)
+	}
+	return randomizedDevConfig(schema, seed)
+}
+
+func buildSharedEffectState(effectType string, seed int64, tick int) (effectRuntime, *rngutil.RNG, Scene, Scene, sim.Config, error) {
+	switch effectType {
+	case "rain":
+		sceneRNG := rngutil.New(seed ^ sceneSeedMix)
+		current := generateScene(sceneRNG, tick)
+		next := generateScene(sceneRNG, 0)
+		cfgData, _ := json.Marshal(current.Config)
+		rt, err := newEffectRuntime(effectType, gridW, gridH, seed, cfgData)
+		if err != nil {
+			return nil, nil, Scene{}, Scene{}, sim.Config{}, err
+		}
+		return rt, sceneRNG, current, next, current.Config, nil
+	default:
+		cfgData, err := randomizedEffectConfig(effectType, seed)
+		if err != nil {
+			return nil, nil, Scene{}, Scene{}, sim.Config{}, err
+		}
+		rt, err := newEffectRuntime(effectType, gridW, gridH, seed, cfgData)
+		if err != nil {
+			return nil, nil, Scene{}, Scene{}, sim.Config{}, err
+		}
+		current := Scene{
+			Name:          effectDisplayName(effectType),
+			DurationTicks: 0,
+			StartedAtTick: tick,
+		}
+		return rt, rngutil.New(seed ^ sceneSeedMix), current, Scene{}, sim.Config{}, nil
+	}
+}
+
+func (a *atmosphere) broadcastSnapshot() {
+	snap := a.snapshot()
+	data, _ := json.Marshal(snap)
+	a.broadcast(Command{
+		Kind: "snapshot",
+		Tick: snap.Tick,
+		Data: data,
+	})
+}
+
+func (a *atmosphere) switchEffect(effectType string) error {
+	effectType = normalizeDevEffect(effectType)
+	oldEffect, _ := a.currentEffectRuntime()
+	tick := oldEffect.CurrentTick()
+
+	a.mu.Lock()
+	baseSeed := a.seed
+	a.mu.Unlock()
+
+	seed := deriveEffectSeed(baseSeed, tick, effectType)
+	rt, sceneRNG, current, next, cfg, err := buildSharedEffectState(effectType, seed, tick)
+	if err != nil {
+		return err
+	}
+
+	a.mu.Lock()
+	a.effect = rt
+	a.effectVersion++
+	a.seed = seed
+	a.sceneRNG = sceneRNG
+	a.cfg = cfg
+	a.current = current
+	a.next = next
+	a.transitionFrom = sim.Config{}
+	a.transitionTo = sim.Config{}
+	a.transitionStart = 0
+	a.transitionDur = 0
+	a.mu.Unlock()
+
+	a.broadcastSnapshot()
+	return nil
+}
+
+func (s *devSession) broadcastSnapshot() {
+	snap := s.snapshot()
+	data, _ := json.Marshal(snap)
+	effect, _ := s.currentEffectRuntime()
+	s.broadcast(Command{
+		Kind: "snapshot",
+		Tick: effect.CurrentTick(),
+		Data: data,
+	})
+}
+
+func (s *devSession) switchEffect(effectType string) error {
+	effectType = normalizeDevEffect(effectType)
+	effect, _ := s.currentEffectRuntime()
+	tick := effect.CurrentTick()
+
+	s.mu.Lock()
+	baseSeed := s.seed
+	s.mu.Unlock()
+
+	seed := deriveEffectSeed(baseSeed, tick, effectType)
+	cfgData, err := randomizedEffectConfig(effectType, seed)
+	if err != nil {
+		return err
+	}
+	rt, err := newEffectRuntime(effectType, gridW, gridH, seed, cfgData)
+	if err != nil {
+		return err
+	}
+
+	s.mu.Lock()
+	s.seed = seed
+	s.effect = rt
+	s.effectVersion++
+	s.mu.Unlock()
+
+	s.broadcastSnapshot()
+	return nil
+}

--- a/cmd/ambience/live_controls.go
+++ b/cmd/ambience/live_controls.go
@@ -49,6 +49,24 @@ func serveSharedConfig(w http.ResponseWriter, req *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
+func serveSharedEffect(w http.ResponseWriter, req *http.Request) {
+	if req.Method != http.MethodPost {
+		http.Error(w, "POST required", http.StatusMethodNotAllowed)
+		return
+	}
+	rawEffect := strings.TrimSpace(req.URL.Query().Get("effect"))
+	if rawEffect == "" {
+		http.Error(w, "effect param required", http.StatusBadRequest)
+		return
+	}
+	effectType := normalizeDevEffect(rawEffect)
+	if err := shared.switchEffect(effectType); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
 func serveSharedTrigger(w http.ResponseWriter, req *http.Request) {
 	if req.Method != http.MethodPost {
 		http.Error(w, "POST required", http.StatusMethodNotAllowed)

--- a/cmd/ambience/main.go
+++ b/cmd/ambience/main.go
@@ -10,12 +10,14 @@
 //	GET  /controls.js           — shared schema-driven control panel helper
 //	GET  /snapshot              — shared atmosphere init payload (JSON)
 //	GET  /events                — shared atmosphere SSE command stream
+//	POST /effect?effect=        — switch the shared atmosphere to another effect
 //	POST /config?effect=&...    — mutate the shared atmosphere config
 //	POST /trigger/:event        — fire a discrete event on the shared atmosphere
 //	GET  /dev                   — dev page with knob controls (defaults to rain)
 //	GET  /dev/<effect>          — effect-specific dev page (e.g. /dev/fireflies)
 //	GET  /dev/snapshot?session=&effect=
 //	GET  /dev/events?session=&effect=
+//	POST /dev/effect?session=&effect=
 //	POST /dev/config?session=&effect=
 //	POST /dev/randomize?session=&effect=
 //	POST /dev/trigger/:session/:event?effect=
@@ -232,6 +234,7 @@ func registerAuthorityRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/events", cors(serveSharedEvents))
 	// Shared live controls stay same-origin only. They intentionally do not
 	// opt into permissive CORS because they mutate the shared atmosphere.
+	mux.HandleFunc("/effect", serveSharedEffect)
 	mux.HandleFunc("/config", serveSharedConfig)
 	mux.HandleFunc("/trigger/", serveSharedTrigger)
 	// Entropy intake — clients POST keystroke-derived bytes here; bytes
@@ -243,6 +246,7 @@ func registerDevRoutes(mux *http.ServeMux) {
 	// Dev atmospheres (per-session)
 	mux.HandleFunc("/dev/snapshot", serveDevSessionSnapshot)
 	mux.HandleFunc("/dev/events", serveDevSessionEvents)
+	mux.HandleFunc("/dev/effect", serveDevSessionEffect)
 	mux.HandleFunc("/dev/config", serveDevSessionConfig)
 	mux.HandleFunc("/dev/randomize", serveDevSessionRandomize)
 	mux.HandleFunc("/dev/trigger/", serveDevSessionTrigger)

--- a/cmd/ambience/persistence.go
+++ b/cmd/ambience/persistence.go
@@ -151,7 +151,7 @@ func restoreSharedAtmosphere(ctx context.Context, store persistenceStore) *atmos
 
 	sceneRNGState := state.SceneRNGState
 	if sceneRNGState == 0 {
-		sceneRNGState = uint64(state.Seed ^ 0x6d0f27bd0b5a3c11)
+		sceneRNGState = uint64(state.Seed ^ sceneSeedMix)
 	}
 
 	rt, err := newEffectRuntime(state.Type, state.Effect.GridW, state.Effect.GridH, state.Seed, state.Effect.Config)
@@ -161,15 +161,16 @@ func restoreSharedAtmosphere(ctx context.Context, store persistenceStore) *atmos
 	}
 
 	a := &atmosphere{
-		effect:     rt,
-		cfg:        state.Config,
-		seed:       state.Seed,
-		sceneRNG:   rngutil.NewFromState(sceneRNGState),
-		commandSeq: state.CommandSeq,
-		current:    state.CurrentScene,
-		next:       state.NextScene,
-		listeners:  make(map[chan Command]struct{}),
-		lastSeen:   time.Now(),
+		effect:        rt,
+		effectVersion: 1,
+		cfg:           state.Config,
+		seed:          state.Seed,
+		sceneRNG:      rngutil.NewFromState(sceneRNGState),
+		commandSeq:    state.CommandSeq,
+		current:       state.CurrentScene,
+		next:          state.NextScene,
+		listeners:     make(map[chan Command]struct{}),
+		lastSeen:      time.Now(),
 	}
 	if err := a.effect.RestorePersisted(state.Effect); err != nil {
 		log.Printf("restore %s state: %v; starting fresh", state.Type, err)

--- a/cmd/ambience/persistence_test.go
+++ b/cmd/ambience/persistence_test.go
@@ -46,11 +46,12 @@ func TestSharedAtmospherePersistenceRoundTrip(t *testing.T) {
 	a := newAtmosphere(sim.Config{})
 	a.broadcast(Command{Kind: "metric", Tick: 1})
 	a.AddEntropy([]byte("hello"))
+	effect, _ := a.currentEffectRuntime()
 	for i := 0; i < 5; i++ {
-		a.effect.Step()
+		effect.Step()
 	}
-	a.rotateScene(a.effect.CurrentTick())
-	a.applyTransition(a.effect.CurrentTick())
+	a.rotateScene(effect.CurrentTick())
+	a.applyTransition(effect.CurrentTick())
 
 	store := &fileStore{path: filepath.Join(t.TempDir(), "state.json")}
 	if err := store.Save(context.Background(), a.persistedState()); err != nil {
@@ -90,5 +91,26 @@ func TestSharedAtmospherePersistenceRoundTrip(t *testing.T) {
 	}
 	if len(gotState.Splashes) != len(wantState.Splashes) {
 		t.Fatalf("splashes = %d, want %d", len(gotState.Splashes), len(wantState.Splashes))
+	}
+}
+
+func TestSharedAtmospherePersistenceRoundTripAfterEffectSwitch(t *testing.T) {
+	a := newAtmosphere(sim.Config{})
+	if err := a.switchEffect("dust"); err != nil {
+		t.Fatalf("switchEffect: %v", err)
+	}
+
+	store := &fileStore{path: filepath.Join(t.TempDir(), "state.json")}
+	if err := store.Save(context.Background(), a.persistedState()); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	restored := restoreSharedAtmosphere(context.Background(), store)
+	got := restored.snapshot()
+	if got.Type != "dust" {
+		t.Fatalf("restored type = %q, want dust", got.Type)
+	}
+	if got.CurrentScene.Name != "dust" {
+		t.Fatalf("restored current scene = %q, want dust", got.CurrentScene.Name)
 	}
 }

--- a/cmd/ambience/proxy.go
+++ b/cmd/ambience/proxy.go
@@ -64,10 +64,12 @@ func registerEdgeRoutes(mux *http.ServeMux, proxy *authorityProxy) {
 	mux.HandleFunc("/snapshot", cors(proxy.serveSnapshot))
 	mux.HandleFunc("/events", cors(proxy.serveEvents))
 	mux.HandleFunc("/entropy", cors(proxy.serveEntropy))
+	mux.HandleFunc("/effect", proxy.serveHTTP)
 	mux.HandleFunc("/config", proxy.serveHTTP)
 	mux.HandleFunc("/trigger/", proxy.serveHTTP)
 	mux.HandleFunc("/dev/snapshot", proxy.serveHTTP)
 	mux.HandleFunc("/dev/events", proxy.serveHTTP)
+	mux.HandleFunc("/dev/effect", proxy.serveHTTP)
 	mux.HandleFunc("/dev/config", proxy.serveHTTP)
 	mux.HandleFunc("/dev/randomize", proxy.serveHTTP)
 	mux.HandleFunc("/dev/trigger/", proxy.serveHTTP)
@@ -442,6 +444,9 @@ func (m *authorityMirror) handleEventPayload(id string, payload []byte) error {
 			return err
 		}
 		m.setSnapshot(snap, cmd.ID)
+		m.mu.Lock()
+		m.broadcastLocked(cmd)
+		m.mu.Unlock()
 		return nil
 	}
 	m.applyCommand(cmd)

--- a/cmd/ambience/proxy_test.go
+++ b/cmd/ambience/proxy_test.go
@@ -68,7 +68,7 @@ func TestEntropyForwarderFlushesPendingPayloads(t *testing.T) {
 	}
 }
 
-func TestAuthorityMirrorSnapshotFramesRefreshCacheWithoutBroadcast(t *testing.T) {
+func TestAuthorityMirrorSnapshotFramesRefreshCacheAndBroadcast(t *testing.T) {
 	m := &authorityMirror{
 		ctx:       context.Background(),
 		client:    &http.Client{},
@@ -103,8 +103,14 @@ func TestAuthorityMirrorSnapshotFramesRefreshCacheWithoutBroadcast(t *testing.T)
 
 	select {
 	case cmd := <-ch:
-		t.Fatalf("unexpected downstream broadcast: %+v", cmd)
+		if cmd.Kind != "snapshot" {
+			t.Fatalf("broadcast kind = %q, want snapshot", cmd.Kind)
+		}
+		if cmd.ID != "42" {
+			t.Fatalf("broadcast id = %q, want 42", cmd.ID)
+		}
 	default:
+		t.Fatal("expected snapshot broadcast to downstream listeners")
 	}
 }
 

--- a/cmd/ambience/web/client.js
+++ b/cmd/ambience/web/client.js
@@ -62,6 +62,7 @@
 	// connection window.
 	let effectType = 'rain';
 	let sim = new AmbienceSim.effects[effectType](GRID_W, GRID_H, {});
+	let transition = AmbienceSim.createTransitionController(sim, { durationMs: 1800 });
 	let ready = false;
 
 	// Patch the subscribe snapshot handler so we can detect effect-type
@@ -82,7 +83,12 @@
 						break;
 					}
 					effectType = newType;
-					sim = new ctor(GRID_W, GRID_H, {});
+					const nextSim = new ctor(GRID_W, GRID_H, {});
+					try { nextSim.restoreSnapshot(data); } catch (err) { console.error('bad snapshot', err); }
+					sim = nextSim;
+					transition.setEffect(nextSim);
+					ready = true;
+					break;
 				}
 				try { sim.restoreSnapshot(data); } catch (err) { console.error('bad snapshot', err); }
 				ready = true;
@@ -101,8 +107,8 @@
 	// in one setInterval — rAF pauses in background tabs and we don't need
 	// 60 Hz for a 10 Hz sim.
 	setInterval(() => {
-		if (ready) sim.step();
-		sim.render(ctx, canvas.width, canvas.height, { transparent: TRANSPARENT });
+		if (ready) transition.step();
+		transition.render(ctx, canvas.width, canvas.height, { transparent: TRANSPARENT });
 	}, 100);
 
 	// ── Entropy ──────────────────────────────────────────────────

--- a/cmd/ambience/web/dev.html
+++ b/cmd/ambience/web/dev.html
@@ -170,6 +170,7 @@
 	let currentSchema = null;
 	let effect = effectFromLocation();
 	let sim = newEffectInstance(effect);
+	let transition = AmbienceSim.createTransitionController(sim, { durationMs: 1800 });
 	let ready = false;
 
 	function effectFromLocation() {
@@ -534,7 +535,7 @@
 	effectSelect.addEventListener('change', () => {
 		const next = effectSelect.value;
 		if (!next || next === effect) return;
-		window.location.assign(effectPath(next));
+		switchEffect(next);
 	});
 	presetSelect.addEventListener('change', () => {
 		if (presetSelect.value === CUSTOM_PRESET) return;
@@ -551,9 +552,9 @@
 	});
 
 	// Local tick + render loops
-	setInterval(() => { if (ready) sim.step(); }, 100);
+	setInterval(() => { if (ready) transition.step(); }, 100);
 	(function draw() {
-		sim.render(ctx, canvas.width, canvas.height);
+		transition.render(ctx, canvas.width, canvas.height);
 		requestAnimationFrame(draw);
 	})();
 
@@ -571,8 +572,12 @@
 					const snapType = (snap && snap.type) || effect;
 					if (snapType !== effect) {
 						effect = snapType;
-						sim = newEffectInstance(effect);
+						const nextSim = newEffectInstance(effect);
+						sim = nextSim;
+						transition.setEffect(nextSim);
 						loadSchema(effect);
+						syncEffectSwitcher();
+						window.history.replaceState(null, '', effectPath(effect));
 					}
 					sim.restoreSnapshot(snap);
 					ready = true;
@@ -599,6 +604,18 @@
 			.then(r => r.json())
 			.then(schema => { renderPanel(schema); updateReadouts(); })
 			.catch(err => console.error('schema', err));
+	}
+
+	async function switchEffect(nextEffect) {
+		try {
+			const resp = await fetch('/dev/effect?session=' + encodeURIComponent(SESSION_ID) +
+				'&effect=' + encodeURIComponent(nextEffect), { method: 'POST' });
+			if (!resp.ok) throw new Error('effect switch failed: ' + resp.status);
+			window.history.replaceState(null, '', effectPath(nextEffect));
+		} catch (err) {
+			console.error('effect switch', err);
+			syncEffectSwitcher();
+		}
 	}
 
 	// Boot: fetch schema, render panel; SSE will deliver the initial snapshot

--- a/cmd/ambience/web/index.html
+++ b/cmd/ambience/web/index.html
@@ -476,8 +476,13 @@
     return new ctor(GRID_W, GRID_H, {});
   }
 
+  function availableEffects() {
+    return Object.keys(AmbienceSim.effects || {}).sort((a, b) => a.localeCompare(b));
+  }
+
   let effectType = 'rain';
   let effect = newEffectInstance(effectType);
+  let transition = AmbienceSim.createTransitionController(effect, { durationMs: 1800 });
   let latestConfig = null;
   let ready = false;
   let schemaLoadToken = 0;
@@ -505,13 +510,14 @@
   const controls = AmbienceControls.create({
     root: el.controlBody,
     effect: effectType,
-    effectOptions: (current) => [current],
+    effectOptions: () => availableEffects(),
     effectSelect: el.effectSelect,
     presetSelect: el.presetSelect,
     toggleAll: el.toggleAll,
     storagePrefix: 'ambience.live.section.',
     locked: true,
-    canSwitchEffect: false,
+    canSwitchEffect: true,
+    onEffectChange: (nextEffect) => switchSharedEffect(nextEffect),
     onConfigChange: () => scheduleSharedConfigPush(),
     onTrigger: (eventName) => triggerSharedEvent(eventName),
   });
@@ -653,13 +659,28 @@
     }
   }
 
+  async function switchSharedEffect(nextEffect) {
+    if (controls.isLocked()) return;
+    try {
+      const resp = await fetch('/effect?effect=' + encodeURIComponent(nextEffect), { method: 'POST' });
+      if (!resp.ok) throw new Error('effect returned ' + resp.status);
+      log('switching to ' + nextEffect, 'scene');
+    } catch (err) {
+      console.error('shared effect switch', err);
+      log('effect switch failed: ' + nextEffect, 'system');
+      controls.setEffect(effectType);
+    }
+  }
+
   function applySnapshot(snap) {
     const nextType = (snap && snap.type) || 'rain';
     const typeChanged = nextType !== effectType;
     if (typeChanged) {
       effectType = nextType;
       controls.setEffect(effectType);
-      effect = newEffectInstance(effectType);
+      const nextEffect = newEffectInstance(effectType);
+      effect = nextEffect;
+      transition.setEffect(nextEffect);
       loadSchema(effectType);
     }
     try {
@@ -740,11 +761,11 @@
   };
 
   setInterval(() => {
-    if (ready) effect.step();
+    if (ready) transition.step();
   }, 100);
 
   (function draw() {
-    effect.render(ctx, canvas.width, canvas.height);
+    transition.render(ctx, canvas.width, canvas.height);
     requestAnimationFrame(draw);
   })();
 

--- a/cmd/ambience/web/sim.js
+++ b/cmd/ambience/web/sim.js
@@ -8831,5 +8831,113 @@
 		],
 	};
 
-	global.AmbienceSim = { Rain, Dust, Fireflies, Waterfall, WheatField, Beach, Campfire, Windmill, Lighthouse, Rowboat, Underwater, Volcano, Train, MysteriousMan, BurningTrees, Sand, WaterPipe, Tetris, Aurora, AutumnLeaves, Snow, Starfield, subscribe, applyDefaults, hslToRGB, effects, presets };
+	class EffectTransitionController {
+		constructor(effect, options) {
+			options = options || {};
+			this.current = effect || null;
+			this.outgoing = null;
+			this.startedAt = 0;
+			this.durationMs = Math.max(100, Math.round(options.durationMs || 1600));
+			this.buffers = [];
+		}
+
+		_now() {
+			return (global.performance && typeof global.performance.now === 'function')
+				? global.performance.now()
+				: Date.now();
+		}
+
+		_progress() {
+			if (!this.outgoing || this.startedAt <= 0) return 1;
+			return clamp01((this._now() - this.startedAt) / this.durationMs);
+		}
+
+		_buffer(index, width, height) {
+			let canvas = this.buffers[index];
+			if (!canvas) {
+				canvas = global.document && typeof global.document.createElement === 'function'
+					? global.document.createElement('canvas')
+					: null;
+				this.buffers[index] = canvas;
+			}
+			if (!canvas) return null;
+			if (canvas.width !== width) canvas.width = width;
+			if (canvas.height !== height) canvas.height = height;
+			return canvas;
+		}
+
+		currentEffect() {
+			return this.current;
+		}
+
+		isTransitioning() {
+			return !!this.outgoing;
+		}
+
+		setEffect(nextEffect) {
+			if (!nextEffect) return;
+			if (!this.current) {
+				this.current = nextEffect;
+				this.outgoing = null;
+				this.startedAt = 0;
+				return;
+			}
+			this.outgoing = this.current;
+			this.current = nextEffect;
+			this.startedAt = this._now();
+		}
+
+		step() {
+			if (this.outgoing) this.outgoing.step();
+			if (this.current) this.current.step();
+			if (this.outgoing && this._progress() >= 1) {
+				this.outgoing = null;
+				this.startedAt = 0;
+			}
+		}
+
+		render(ctx, canvasW, canvasH, opts) {
+			if (!this.current) return;
+			if (!this.outgoing) {
+				this.current.render(ctx, canvasW, canvasH, opts);
+				return;
+			}
+
+			const fromCanvas = this._buffer(0, canvasW, canvasH);
+			const toCanvas = this._buffer(1, canvasW, canvasH);
+			if (!fromCanvas || !toCanvas) {
+				this.current.render(ctx, canvasW, canvasH, opts);
+				return;
+			}
+
+			const fromCtx = fromCanvas.getContext('2d');
+			const toCtx = toCanvas.getContext('2d');
+			fromCtx.clearRect(0, 0, canvasW, canvasH);
+			toCtx.clearRect(0, 0, canvasW, canvasH);
+			this.outgoing.render(fromCtx, canvasW, canvasH, opts);
+			this.current.render(toCtx, canvasW, canvasH, opts);
+
+			const progress = this._progress();
+			ctx.clearRect(0, 0, canvasW, canvasH);
+			ctx.save();
+			ctx.globalAlpha = 1 - progress;
+			ctx.drawImage(fromCanvas, 0, 0);
+			ctx.restore();
+			ctx.save();
+			ctx.globalAlpha = progress;
+			ctx.drawImage(toCanvas, 0, 0);
+			ctx.restore();
+
+			if (progress >= 1) {
+				this.outgoing = null;
+				this.startedAt = 0;
+			}
+		}
+	}
+
+	function createTransitionController(effect, options) {
+		return new EffectTransitionController(effect, options);
+	}
+
+	global.AmbienceSim = { Rain, Dust, Fireflies, Waterfall, WheatField, Beach, Campfire, Windmill, Lighthouse, Rowboat, Underwater, Volcano, Train, MysteriousMan, BurningTrees, Sand, WaterPipe, Tetris, Aurora, AutumnLeaves, Snow, Starfield, subscribe, applyDefaults, hslToRGB, effects, presets, createTransitionController };
 })(window);


### PR DESCRIPTION
## Summary
- add shared `/effect` and per-session `/dev/effect` endpoints that switch runtimes and rebroadcast full mid-stream `snapshot` events over SSE
- add a browser-side transition controller in `sim.js` and wire it into `/`, `/dev`, and `client.js` so effect changes crossfade instead of cutting
- fix the edge authority mirror so mid-stream `snapshot` commands are forwarded to already-connected SSE subscribers
- add coverage for dev-session switching, persistence after effect switches, and mirror snapshot rebroadcast behavior

## Architecture
This stays purely SSE-driven:
- the server never streams pixel frames
- the server only broadcasts semantic state/config/trigger/snapshot commands
- clients swap local sims and blend them locally during the transition

## Validation
- `go test ./...`
- switched the shared effect on `https://ambience.dev.romaine.life/` and verified the connected monitor updated live after `POST /effect`
- switched a dev session on `https://ambience.dev.romaine.life/dev/water-pipe` to `underwater` and confirmed the old and new effects overlapped during the transition
- verified `/snapshot` and `/dev/snapshot` both report the new effect type after switching

Implements #8's cross-effect transition mechanism. Rotation policy remains follow-up work, as noted in the issue.