### PR TITLE
Clarify scene versus effect terminology

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -171,6 +171,19 @@ advance timers and physics locally. Frame-level sync is not guaranteed
 (each client RNG drifts after initial snapshot), but event timing
 (downpour starts/ends, calm windows, scene changes) stays in sync.
 
+## Terminology
+
+- **Effect** = a registry entry / simulation mechanism keyed by snapshot
+  `type` (`rain`, `sand`, `volcano`, ...).
+- **Scene** = the viewer-facing current/next state within that effect,
+  surfaced as `currentScene` / `nextScene`.
+- Rain currently has true within-effect scene generation; simpler
+  effects can still use scene fields as the display surface for
+  "what is showing now?" without a rotating config pipeline.
+
+Short version: effect answers "which mechanism is active?", while scene
+answers "what is that mechanism showing right now?"
+
 ## Scene rotation
 
 Rain runs with generated scenes rather than a single fixed config.

--- a/README.md
+++ b/README.md
@@ -106,6 +106,20 @@ Clients do not roll for discrete events — only the server does. Each
 client's RNG drifts from the server's after the initial snapshot, but
 event timing stays in sync.
 
+## Terminology
+
+- **Effect** means the simulation mechanism selected from the
+  `AmbienceSim.effects` registry and carried on the wire as snapshot
+  `type` (`rain`, `sand`, `volcano`, ...).
+- **Scene** means the viewer-facing "what is showing right now?" state
+  within an effect, carried as `currentScene` / `nextScene`.
+- In Rain today, a scene is a generated config variant with a duration
+  and lookahead. In simpler effects, scene data can just be the display
+  label surface for the active effect.
+
+Short version: effect answers "which sim is running?", while scene
+answers "what version of that sim is on screen right now?"
+
 ## Effects model
 
 Every effect fills a 5-slot template — see

--- a/cmd/ambience/atmosphere.go
+++ b/cmd/ambience/atmosphere.go
@@ -54,10 +54,15 @@ type Command struct {
 // snapshotData is carried in the initial "snapshot" command and in response
 // to GET /snapshot.
 //
-// Type identifies which effect this atmosphere is currently running ("rain"
-// for now; future: "sand", "fire", etc.). Clients look the type up in
+// Type identifies which effect mechanism this atmosphere is currently running
+// ("rain", "sand", "volcano", ...). Clients look the type up in
 // AmbienceSim.effects[type] to pick the renderer constructor — so adding a
 // new effect doesn't require any client-side change.
+//
+// CurrentScene / NextScene are the viewer-facing current/next scene labels
+// within that effect. They are intentionally distinct from Type: Type answers
+// "which effect is active?", while Scene answers "what is that effect showing
+// right now?"
 type snapshotData struct {
 	Type   string          `json:"type"`
 	Tick   int             `json:"tick"`
@@ -66,8 +71,9 @@ type snapshotData struct {
 	Seed   int64           `json:"seed"`
 	GridW  int             `json:"gridW"`
 	GridH  int             `json:"gridH"`
-	// Scene + entropy status — used by the / live monitor. Panels update
-	// via periodic "metric" commands between full snapshot re-requests.
+	// Viewer-facing scene + entropy status — used by the / live monitor.
+	// Panels update via periodic "metric" commands between full snapshot
+	// re-requests.
 	CurrentScene   Scene `json:"currentScene"`
 	NextScene      Scene `json:"nextScene"`
 	EntropyBytes   int64 `json:"entropyBytes"`

--- a/cmd/ambience/scene.go
+++ b/cmd/ambience/scene.go
@@ -1,8 +1,10 @@
-// Scene is a time-bounded Rain configuration. The atmosphere keeps a single-
-// slot lookahead (current + next) and transitions when current's DurationTicks
-// elapses. Each scene is freshly generated from the atmosphere's RNG, so
-// entropy contributed via AddEntropy naturally biases future scene generation —
-// no separate wiring needed.
+// Scene is the viewer-facing "what is showing right now?" metadata carried in
+// shared snapshots and live-monitor updates.
+//
+// For rain, a scene is a generated config variant with a duration and
+// single-slot lookahead (current + next). For other effects, we still reuse
+// Scene as the current/next display surface even when there is no rotating
+// within-effect config pipeline.
 package main
 
 import (
@@ -30,9 +32,10 @@ func (s Scene) Remaining(currentTick int) int {
 	return r
 }
 
-// generateScene produces a Scene using rng. Duration is randomized across
-// 1–4 hours (36k–144k ticks at 10 Hz). The config ranges are kept within
-// sim-safe bounds so any generated scene is guaranteed to look reasonable.
+// generateScene produces a rain-specific Scene using rng. Duration is
+// randomized across 1–4 hours (36k–144k ticks at 10 Hz). The config ranges are
+// kept within sim-safe bounds so any generated scene is guaranteed to look
+// reasonable.
 func generateScene(rng *rngutil.RNG, startedAt int) Scene {
 	hue := rng.Float64() * 360
 	hueSpread := 10 + rng.Float64()*50     // 10–60°

--- a/cmd/ambience/web/index.html
+++ b/cmd/ambience/web/index.html
@@ -406,9 +406,9 @@
     </span>
   </h2>
   <div class="panel-body" id="panelBody">
-    <div class="row"><span class="k">scene</span><span class="v" id="sceneName">-</span></div>
+    <div class="row"><span class="k">current scene</span><span class="v" id="sceneName">-</span></div>
     <div class="row"><span class="k">remaining</span><span class="v" id="sceneRemaining">-</span></div>
-    <div class="row"><span class="k">up next</span><span class="v" id="nextName">-</span></div>
+    <div class="row"><span class="k">next scene</span><span class="v" id="nextName">-</span></div>
     <div class="row"><span class="k">tick</span><span class="v" id="tick">0</span></div>
 
     <div class="section-lite toggle">
@@ -737,7 +737,7 @@
           el.nextName.textContent = scene.nextName || '-';
           sceneDurationTicks = scene.durationTicks || 0;
           sceneStartTick = scene.startedAtTick || 0;
-          log('scene -> ' + scene.name + ' - up next ' + scene.nextName, 'scene');
+          log('scene -> ' + scene.name + ' - next scene ' + scene.nextName, 'scene');
           el.panel.classList.remove('flash');
           void el.panel.offsetWidth;
           el.panel.classList.add('flash');


### PR DESCRIPTION
## Summary
- document the effect vs scene boundary in `README.md` and `AGENTS.md`
- clarify the server comments around `snapshotData` and `Scene` so `type` means effect mechanism while `currentScene` / `nextScene` mean the viewer-facing current and next scene
- update the live monitor copy to say `current scene` and `next scene`

## Validation
- `go test ./...`
- `powershell -ExecutionPolicy Bypass -File scripts/dev-loop.ps1 -Once`
- verified `https://ambience.dev.romaine.life/` reflects the updated live-monitor copy

Refs #17