### PR TITLE
Add label-driven Codex issue automation

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+.github/** text eol=lf
+chart/** text eol=lf
+docs/agentic-issue-flow.md text eol=lf
+k8s/** text eol=lf
+scripts/agent/** text eol=lf

--- a/.github/codex/issue-result.schema.json
+++ b/.github/codex/issue-result.schema.json
@@ -1,0 +1,46 @@
+{
+  "type": "object",
+  "properties": {
+    "status": {
+      "type": "string",
+      "enum": ["ready_for_pr", "needs_human_input", "no_change"]
+    },
+    "pr_title": {
+      "type": "string"
+    },
+    "change_summary": {
+      "type": "string"
+    },
+    "testing": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "validation_notes": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "screenshots": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "issue_comment": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "status",
+    "pr_title",
+    "change_summary",
+    "testing",
+    "validation_notes",
+    "screenshots",
+    "issue_comment"
+  ],
+  "additionalProperties": false
+}

--- a/.github/codex/prompts/issue-implementation.md
+++ b/.github/codex/prompts/issue-implementation.md
@@ -1,0 +1,44 @@
+You are running inside the ambience repository as a non-interactive Codex automation job.
+
+The issue context is provided on stdin. Read it first, then read the repo's `AGENTS.md` and any code you need before changing files.
+
+Your goal:
+1. Implement a bounded fix or feature slice for the labeled issue.
+2. Run the relevant repo tests and checks.
+3. Validate the change in an ephemeral Kubernetes environment.
+4. Capture screenshots of the validated result when the change has any user-visible surface.
+5. Stop only when you are satisfied the slice is ready for a pull request, or when you hit a real blocker that needs a human.
+
+Environment variables you can rely on:
+- `ISSUE_NUMBER`
+- `ISSUE_TITLE`
+- `ISSUE_URL`
+- `DEFAULT_BRANCH`
+- `BRANCH_NAME`
+- `IMAGE_TAG`
+- `EPHEMERAL_NAMESPACE`
+- `EPHEMERAL_RELEASE`
+- `ARTIFACT_DIR`
+
+Use these repo-native helpers for runtime validation:
+- `bash scripts/agent/build-image.sh "$IMAGE_TAG"`
+- `bash scripts/agent/deploy-env.sh "$EPHEMERAL_NAMESPACE" "$IMAGE" "$EPHEMERAL_RELEASE"`
+- `bash scripts/agent/capture-screenshot.sh "$EPHEMERAL_NAMESPACE" "/path" "$ARTIFACT_DIR/file.png"`
+
+Validation rules:
+- Prefer the narrowest useful test loop, but run the checks needed to justify the change.
+- For browser-facing work, capture at least one screenshot from the route you validated.
+- For non-visual work, still deploy and smoke-test the most relevant route if the issue can be exercised there.
+- Do not tear down the ephemeral namespace; the workflow wrapper handles cleanup.
+- Do not push branches or open the pull request yourself; the workflow wrapper handles git push and PR creation after you finish.
+
+When you finish, your final response must match the configured JSON schema:
+- `status`: use `ready_for_pr`, `needs_human_input`, or `no_change`
+- `pr_title`: concise pull request title
+- `change_summary`: short high-signal summary of what changed
+- `testing`: flat list of commands or checks you ran
+- `validation_notes`: flat list of notable validation outcomes, caveats, or follow-ups
+- `screenshots`: repo-relative paths to captured screenshots that should be committed with the branch
+- `issue_comment`: short comment body for the originating issue
+
+If the issue is too broad, ambiguous, unsafe, or blocked by missing credentials or infrastructure, do not guess. Explain the blocker with `status: "needs_human_input"`.

--- a/.github/runner/Dockerfile
+++ b/.github/runner/Dockerfile
@@ -1,0 +1,20 @@
+FROM ghcr.io/actions/actions-runner:latest
+
+USER root
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        git \
+        jq \
+        sudo \
+        unzip \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN echo "runner ALL=(ALL) NOPASSWD:ALL" >/etc/sudoers.d/runner \
+    && chmod 0440 /etc/sudoers.d/runner
+
+RUN curl -sL https://aka.ms/InstallAzureCLIDeb | bash
+
+USER runner

--- a/.github/workflows/build-agent-runner-image.yml
+++ b/.github/workflows/build-agent-runner-image.yml
@@ -1,0 +1,53 @@
+name: Build Agent Runner Image
+
+on:
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: "Image tag to publish. Leave blank to use the current short SHA."
+        required: false
+        type: string
+
+permissions:
+  id-token: write
+  contents: read
+
+concurrency:
+  group: build-agent-runner-image
+  cancel-in-progress: false
+
+jobs:
+  build-and-push:
+    name: Build agent runner image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Azure Login (OIDC)
+        uses: azure/login@v2
+        with:
+          client-id: ${{ vars.ARM_CLIENT_ID }}
+          tenant-id: ${{ vars.ARM_TENANT_ID }}
+          subscription-id: ${{ vars.ARM_SUBSCRIPTION_ID }}
+
+      - name: Resolve image tag
+        run: |
+          set -euo pipefail
+          TAG="${{ inputs.image_tag }}"
+          if [ -z "$TAG" ]; then
+            TAG="$(git rev-parse --short=7 HEAD)"
+          fi
+          echo "TAG=$TAG" >> "$GITHUB_ENV"
+          echo "Publishing romainecr.azurecr.io/ambience-agent-runner:${TAG}" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Build and push runner image
+        run: |
+          set -euo pipefail
+          az acr build \
+            --registry romainecr \
+            --image "ambience-agent-runner:${TAG}" \
+            --file .github/runner/Dockerfile \
+            .

--- a/.github/workflows/codex-issue-agent.yml
+++ b/.github/workflows/codex-issue-agent.yml
@@ -1,0 +1,474 @@
+name: Codex Issue Agent
+
+on:
+  issues:
+    types:
+      - labeled
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: "Issue number to process."
+        required: true
+        type: number
+      trigger_label:
+        description: "Trigger label to emulate."
+        required: false
+        default: codex:run
+        type: string
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+  id-token: write
+
+concurrency:
+  group: codex-issue-${{ github.event.issue.number || inputs.issue_number }}
+  cancel-in-progress: false
+
+jobs:
+  codex:
+    name: Implement labeled issue
+    runs-on: ambience-issue-agents
+    env:
+      DEFAULT_TRIGGER_LABELS_JSON: '["codex:run"]'
+      ISSUE_CONTEXT_FILE: .github/codex/output/issue-context.md
+      RESULT_FILE: .github/codex/output/result.json
+      RESULT_SCHEMA_FILE: .github/codex/issue-result.schema.json
+      PR_BODY_FILE: .github/codex/output/pr-body.md
+      FINAL_MESSAGE_FILE: .github/codex/output/final-message.md
+      RUN_LOG_FILE: .github/codex/output/run.jsonl
+      PROGRESS_LOG_FILE: .github/codex/output/progress.log
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Ensure output directories
+        run: |
+          set -euo pipefail
+          mkdir -p .github/codex/output .github/agent-artifacts
+
+      - name: Resolve issue and trigger
+        id: issue
+        uses: actions/github-script@v7
+        env:
+          DEFAULT_TRIGGER_LABELS_JSON: ${{ env.DEFAULT_TRIGGER_LABELS_JSON }}
+          TRIGGER_LABELS_JSON: ${{ vars.CODEX_TRIGGER_LABELS_JSON }}
+          EVENT_TRIGGER_LABEL: ${{ github.event.label.name }}
+          MANUAL_TRIGGER_LABEL: ${{ inputs.trigger_label }}
+          MANUAL_ISSUE_NUMBER: ${{ inputs.issue_number }}
+          ISSUE_CONTEXT_FILE: ${{ env.ISSUE_CONTEXT_FILE }}
+        with:
+          script: |
+            const fs = require("fs");
+            const path = require("path");
+
+            function parseTriggerLabels(rawValue, fallbackValue) {
+              const source = (rawValue || fallbackValue || "").trim();
+              if (!source) {
+                return [];
+              }
+
+              try {
+                const parsed = JSON.parse(source);
+                if (Array.isArray(parsed)) {
+                  return parsed.map((item) => String(item).trim()).filter(Boolean);
+                }
+                if (typeof parsed === "string" && parsed.trim()) {
+                  return [parsed.trim()];
+                }
+              } catch (error) {
+                // Fall through to a forgiving plain-text parse.
+              }
+
+              return source
+                .split(",")
+                .map((item) => item.replace(/^[\s\[\]"']+|[\s\[\]"']+$/g, "").trim())
+                .filter(Boolean);
+            }
+
+            function sanitize(text) {
+              return (text || "")
+                .replace(/<!--[\s\S]*?-->/g, "")
+                .replace(/\r/g, "")
+                .trim();
+            }
+
+            const triggerLabels = parseTriggerLabels(
+              process.env.TRIGGER_LABELS_JSON,
+              process.env.DEFAULT_TRIGGER_LABELS_JSON
+            );
+            const selectedLabel = context.eventName === "workflow_dispatch"
+              ? (process.env.MANUAL_TRIGGER_LABEL || triggerLabels[0] || "")
+              : (process.env.EVENT_TRIGGER_LABEL || "");
+            const shouldRun = context.eventName === "workflow_dispatch" || triggerLabels.includes(selectedLabel);
+
+            core.setOutput("should_run", shouldRun ? "true" : "false");
+            core.setOutput("selected_label", selectedLabel);
+
+            if (!shouldRun) {
+              core.notice(`Ignoring label '${selectedLabel}'.`);
+              return;
+            }
+
+            const issueNumber = context.eventName === "workflow_dispatch"
+              ? Number(process.env.MANUAL_ISSUE_NUMBER)
+              : Number(context.payload.issue.number);
+            const { owner, repo } = context.repo;
+            const issueResp = await github.rest.issues.get({
+              owner,
+              repo,
+              issue_number: issueNumber,
+            });
+            const commentsResp = await github.rest.issues.listComments({
+              owner,
+              repo,
+              issue_number: issueNumber,
+              per_page: 10,
+            });
+
+            const issue = issueResp.data;
+            const comments = commentsResp.data.slice(-5);
+            const labels = (issue.labels || []).map((label) => {
+              if (typeof label === "string") {
+                return label;
+              }
+              return label.name;
+            });
+
+            const lines = [
+              `# Issue #${issue.number}: ${issue.title}`,
+              "",
+              `- URL: ${issue.html_url}`,
+              `- Trigger label: ${selectedLabel}`,
+              `- Labels: ${labels.length ? labels.join(", ") : "(none)"}`,
+              `- Author: ${issue.user?.login || "unknown"}`,
+              "",
+              "## Body",
+              sanitize(issue.body) || "(no body provided)",
+              "",
+              "## Recent Comments",
+            ];
+
+            if (!comments.length) {
+              lines.push("(no comments)");
+            } else {
+              for (const comment of comments) {
+                lines.push(`### ${comment.user?.login || "unknown"}`);
+                lines.push(sanitize(comment.body) || "(empty comment)");
+                lines.push("");
+              }
+            }
+
+            fs.writeFileSync(process.env.ISSUE_CONTEXT_FILE, `${lines.join("\n").trim()}\n`);
+
+            core.setOutput("issue_number", String(issue.number));
+            core.setOutput("issue_title", issue.title);
+            core.setOutput("issue_url", issue.html_url);
+            core.setOutput("default_branch", context.payload.repository?.default_branch || "main");
+            core.setOutput("branch_name", `codex/issue-${issue.number}`);
+            core.setOutput("artifact_dir", `.github/agent-artifacts/issue-${issue.number}`);
+
+      - name: Short-circuit unmatched labels
+        if: steps.issue.outputs.should_run != 'true'
+        run: |
+          echo "No configured trigger label matched; exiting without work."
+
+      - name: Comment on queued issue
+        if: steps.issue.outputs.should_run == 'true' && github.event_name == 'issues'
+        uses: actions/github-script@v7
+        env:
+          ISSUE_NUMBER: ${{ steps.issue.outputs.issue_number }}
+          SELECTED_LABEL: ${{ steps.issue.outputs.selected_label }}
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: Number(process.env.ISSUE_NUMBER),
+              body: [
+                "Queued a Codex automation run for this issue.",
+                "",
+                `Workflow run: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+                `Trigger label: \`${process.env.SELECTED_LABEL}\``,
+              ].join("\n"),
+            });
+
+      - name: Validate job configuration
+        if: steps.issue.outputs.should_run == 'true'
+        env:
+          CODEX_API_KEY: ${{ secrets.CODEX_API_KEY }}
+          ARM_CLIENT_ID: ${{ vars.ARM_CLIENT_ID }}
+          ARM_TENANT_ID: ${{ vars.ARM_TENANT_ID }}
+          ARM_SUBSCRIPTION_ID: ${{ vars.ARM_SUBSCRIPTION_ID }}
+          AZURE_AKS_RESOURCE_GROUP: ${{ vars.AZURE_AKS_RESOURCE_GROUP }}
+          AZURE_AKS_CLUSTER_NAME: ${{ vars.AZURE_AKS_CLUSTER_NAME }}
+        run: |
+          set -euo pipefail
+          required_vars=(
+            CODEX_API_KEY
+            ARM_CLIENT_ID
+            ARM_TENANT_ID
+            ARM_SUBSCRIPTION_ID
+            AZURE_AKS_RESOURCE_GROUP
+            AZURE_AKS_CLUSTER_NAME
+          )
+          missing=()
+          for name in "${required_vars[@]}"; do
+            if [ -z "${!name:-}" ]; then
+              missing+=("$name")
+            fi
+          done
+          if [ "${#missing[@]}" -ne 0 ]; then
+            echo "Missing required configuration: ${missing[*]}" >&2
+            exit 1
+          fi
+
+      - name: Set up Node.js
+        if: steps.issue.outputs.should_run == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Set up Go
+        if: steps.issue.outputs.should_run == 'true'
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Set up kubectl
+        if: steps.issue.outputs.should_run == 'true'
+        uses: azure/setup-kubectl@v4
+
+      - name: Set up Helm
+        if: steps.issue.outputs.should_run == 'true'
+        uses: azure/setup-helm@v4
+
+      - name: Install Codex and Playwright packages
+        if: steps.issue.outputs.should_run == 'true'
+        run: |
+          set -euo pipefail
+          npm install --no-save @openai/codex playwright
+          npx playwright install --with-deps chromium || npx playwright install chromium
+
+      - name: Azure Login (OIDC)
+        if: steps.issue.outputs.should_run == 'true'
+        uses: azure/login@v2
+        with:
+          client-id: ${{ vars.ARM_CLIENT_ID }}
+          tenant-id: ${{ vars.ARM_TENANT_ID }}
+          subscription-id: ${{ vars.ARM_SUBSCRIPTION_ID }}
+
+      - name: Set AKS context
+        if: steps.issue.outputs.should_run == 'true'
+        env:
+          AZURE_AKS_RESOURCE_GROUP: ${{ vars.AZURE_AKS_RESOURCE_GROUP }}
+          AZURE_AKS_CLUSTER_NAME: ${{ vars.AZURE_AKS_CLUSTER_NAME }}
+        run: |
+          set -euo pipefail
+          az aks get-credentials \
+            --resource-group "$AZURE_AKS_RESOURCE_GROUP" \
+            --name "$AZURE_AKS_CLUSTER_NAME" \
+            --admin \
+            --overwrite-existing
+
+      - name: Compute run-scoped variables
+        if: steps.issue.outputs.should_run == 'true'
+        env:
+          ISSUE_NUMBER: ${{ steps.issue.outputs.issue_number }}
+          ARTIFACT_DIR: ${{ steps.issue.outputs.artifact_dir }}
+        run: |
+          set -euo pipefail
+          short_sha="$(git rev-parse --short=7 HEAD)"
+          namespace="ambience-issue-${ISSUE_NUMBER}-${GITHUB_RUN_ID}"
+          release="ambience-agent"
+          image_tag="issue-${ISSUE_NUMBER}-${GITHUB_RUN_ID}-${short_sha}"
+          echo "EPHEMERAL_NAMESPACE=$namespace" >> "$GITHUB_ENV"
+          echo "EPHEMERAL_RELEASE=$release" >> "$GITHUB_ENV"
+          echo "IMAGE_TAG=$image_tag" >> "$GITHUB_ENV"
+          echo "ARTIFACT_DIR=$ARTIFACT_DIR" >> "$GITHUB_ENV"
+          mkdir -p "$ARTIFACT_DIR"
+
+      - name: Run Codex implementation loop
+        if: steps.issue.outputs.should_run == 'true'
+        env:
+          CODEX_API_KEY: ${{ secrets.CODEX_API_KEY }}
+          ISSUE_NUMBER: ${{ steps.issue.outputs.issue_number }}
+          ISSUE_TITLE: ${{ steps.issue.outputs.issue_title }}
+          ISSUE_URL: ${{ steps.issue.outputs.issue_url }}
+          DEFAULT_BRANCH: ${{ steps.issue.outputs.default_branch }}
+          BRANCH_NAME: ${{ steps.issue.outputs.branch_name }}
+          IMAGE_TAG: ${{ env.IMAGE_TAG }}
+          EPHEMERAL_NAMESPACE: ${{ env.EPHEMERAL_NAMESPACE }}
+          EPHEMERAL_RELEASE: ${{ env.EPHEMERAL_RELEASE }}
+          ARTIFACT_DIR: ${{ env.ARTIFACT_DIR }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          prompt="$(cat .github/codex/prompts/issue-implementation.md)"
+          cat "$ISSUE_CONTEXT_FILE" | npx codex exec \
+            --ephemeral \
+            --sandbox danger-full-access \
+            --full-auto \
+            --json \
+            --output-schema "$RESULT_SCHEMA_FILE" \
+            -o "$RESULT_FILE" \
+            "$prompt" \
+            > >(tee "$RUN_LOG_FILE") \
+            2> >(tee "$PROGRESS_LOG_FILE" >&2)
+
+      - name: Detect repo changes
+        if: steps.issue.outputs.should_run == 'true'
+        id: diff
+        run: |
+          set -euo pipefail
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build pull request body
+        if: steps.issue.outputs.should_run == 'true'
+        id: result
+        uses: actions/github-script@v7
+        env:
+          RESULT_FILE: ${{ env.RESULT_FILE }}
+          PR_BODY_FILE: ${{ env.PR_BODY_FILE }}
+          BRANCH_NAME: ${{ steps.issue.outputs.branch_name }}
+          HAS_CHANGES: ${{ steps.diff.outputs.has_changes }}
+          ISSUE_NUMBER: ${{ steps.issue.outputs.issue_number }}
+        with:
+          script: |
+            const fs = require("fs");
+            const path = require("path");
+
+            const result = JSON.parse(fs.readFileSync(process.env.RESULT_FILE, "utf8"));
+            const screenshots = Array.isArray(result.screenshots) ? result.screenshots : [];
+            const screenshotLines = screenshots.length
+              ? screenshots.map((relativePath) => {
+                  const label = path.basename(relativePath);
+                  const url = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/blob/${process.env.BRANCH_NAME}/${relativePath}?raw=1`;
+                  return `![${label}](${url})`;
+                })
+              : ["No screenshots were captured."];
+
+            const toBullets = (items) => {
+              if (!items || !items.length) {
+                return "- none";
+              }
+              return items.map((item) => `- ${item}`).join("\n");
+            };
+
+            const body = [
+              `Closes #${process.env.ISSUE_NUMBER}.`,
+              "",
+              "## Summary",
+              result.change_summary || "No summary provided.",
+              "",
+              "## Validation",
+              toBullets(result.validation_notes),
+              "",
+              "## Checks",
+              toBullets(result.testing),
+              "",
+              "## Screenshots",
+              screenshotLines.join("\n"),
+            ].join("\n");
+
+            fs.writeFileSync(process.env.PR_BODY_FILE, `${body.trim()}\n`);
+
+            const shouldCreatePr = result.status === "ready_for_pr" && process.env.HAS_CHANGES === "true";
+            core.setOutput("status", result.status);
+            core.setOutput("pr_title", result.pr_title || `Codex: address issue #${process.env.ISSUE_NUMBER}`);
+            core.setOutput("issue_comment", result.issue_comment || "");
+            core.setOutput("should_create_pr", shouldCreatePr ? "true" : "false");
+
+      - name: Create pull request
+        if: steps.issue.outputs.should_run == 'true' && steps.result.outputs.should_create_pr == 'true'
+        id: cpr
+        uses: peter-evans/create-pull-request@v8
+        with:
+          token: ${{ secrets.CODEX_GH_TOKEN != '' && secrets.CODEX_GH_TOKEN || github.token }}
+          branch: ${{ steps.issue.outputs.branch_name }}
+          base: ${{ steps.issue.outputs.default_branch }}
+          commit-message: "Codex: address issue #${{ steps.issue.outputs.issue_number }}"
+          title: ${{ steps.result.outputs.pr_title }}
+          body-path: ${{ env.PR_BODY_FILE }}
+          add-paths: |
+            .
+          draft: false
+
+      - name: Comment with pull request
+        if: steps.issue.outputs.should_run == 'true' && steps.cpr.outputs.pull-request-url != ''
+        uses: actions/github-script@v7
+        env:
+          ISSUE_NUMBER: ${{ steps.issue.outputs.issue_number }}
+          PR_URL: ${{ steps.cpr.outputs.pull-request-url }}
+          ISSUE_COMMENT: ${{ steps.result.outputs.issue_comment }}
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: Number(process.env.ISSUE_NUMBER),
+              body: [
+                `Opened PR: ${process.env.PR_URL}`,
+                "",
+                process.env.ISSUE_COMMENT.trim(),
+              ].join("\n"),
+            });
+
+      - name: Comment when no pull request was created
+        if: steps.issue.outputs.should_run == 'true' && steps.cpr.outputs.pull-request-url == '' && steps.result.outputs.status != 'ready_for_pr'
+        uses: actions/github-script@v7
+        env:
+          ISSUE_NUMBER: ${{ steps.issue.outputs.issue_number }}
+          ISSUE_COMMENT: ${{ steps.result.outputs.issue_comment }}
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: Number(process.env.ISSUE_NUMBER),
+              body: process.env.ISSUE_COMMENT || "Codex completed without opening a pull request.",
+            });
+
+      - name: Upload Codex artifacts
+        if: always() && steps.issue.outputs.should_run == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: codex-issue-${{ steps.issue.outputs.issue_number }}-artifacts
+          path: |
+            .github/codex/output
+            .github/agent-artifacts/issue-${{ steps.issue.outputs.issue_number }}
+          if-no-files-found: warn
+
+      - name: Tear down ephemeral environment
+        if: always() && steps.issue.outputs.should_run == 'true'
+        env:
+          EPHEMERAL_NAMESPACE: ${{ env.EPHEMERAL_NAMESPACE }}
+          EPHEMERAL_RELEASE: ${{ env.EPHEMERAL_RELEASE }}
+        run: |
+          set -euo pipefail
+          bash scripts/agent/destroy-env.sh "$EPHEMERAL_NAMESPACE" "$EPHEMERAL_RELEASE"
+
+      - name: Comment on failure
+        if: failure() && steps.issue.outputs.should_run == 'true'
+        uses: actions/github-script@v7
+        env:
+          ISSUE_NUMBER: ${{ steps.issue.outputs.issue_number }}
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: Number(process.env.ISSUE_NUMBER),
+              body: [
+                "Codex automation failed before it could finish.",
+                "",
+                `Workflow run: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+              ].join("\n"),
+            });

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@
 *.prof
 .env
 /.claude/settings.local.json
+node_modules/
+/.github/codex/output/
+/.github/codex/tmp/

--- a/chart/ambience/templates/xlistenerset.yaml
+++ b/chart/ambience/templates/xlistenerset.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.gateway.listenerSetEnabled }}
 apiVersion: gateway.networking.x-k8s.io/v1alpha1
 kind: XListenerSet
 metadata:
@@ -22,3 +23,4 @@ spec:
           - group: ""
             kind: Secret
             name: {{ .Values.domain.tlsSecretName }}
+{{- end }}

--- a/chart/ambience/values.yaml
+++ b/chart/ambience/values.yaml
@@ -15,6 +15,7 @@ gateway:
     kind: Gateway
     name: main
     namespace: envoy-gateway-system
+  listenerSetEnabled: true
   listenerSetName: ambience
   listenerName: https
 

--- a/docs/agentic-issue-flow.md
+++ b/docs/agentic-issue-flow.md
@@ -1,0 +1,132 @@
+# Agentic Issue Flow
+
+This repo now has a first-pass GitHub-to-Codex-to-k8s issue flow aimed at bounded backlog slices.
+
+## What it does
+
+1. A GitHub issue gets a trigger label.
+2. GitHub Actions becomes the queue manager.
+3. The job runs on an ARC-backed self-hosted runner scale set capped at five runners.
+4. Codex implements the issue in the checked-out repo, runs tests, deploys an ephemeral ambience environment in Kubernetes, validates the change, captures screenshots, and hands a structured result back to the workflow.
+5. The workflow wrapper opens a pull request with the screenshots and posts the result back to the issue.
+6. The namespace is deleted at the end of the run.
+
+Because each job owns one runner and one namespace, a `maxRunners: 5` scale set also caps us at five concurrent ephemeral environments.
+
+## Files added for this flow
+
+- `.github/workflows/codex-issue-agent.yml`
+- `.github/workflows/build-agent-runner-image.yml`
+- `.github/codex/prompts/issue-implementation.md`
+- `.github/codex/issue-result.schema.json`
+- `.github/runner/Dockerfile`
+- `scripts/agent/*.sh`
+- `scripts/agent/capture-screenshot.mjs`
+- `k8s/arc/values-issue-agents.yaml`
+
+## Trigger label
+
+Default trigger label:
+
+- `codex:run`
+
+Optional repo variable:
+
+- `CODEX_TRIGGER_LABELS_JSON`
+
+Example:
+
+```json
+["codex:run", "codex:retry"]
+```
+
+If the variable is unset, the workflow falls back to `["codex:run"]`. The workflow also tolerates a simpler non-JSON value such as `codex:run` if you set it through the GitHub CLI and the shell mangles the quoting.
+
+## Required GitHub secrets and variables
+
+Secrets:
+
+- `CODEX_API_KEY`: OpenAI API key used by `codex exec`
+- `CODEX_GH_TOKEN`: optional PAT or GitHub App token used when opening PRs; if omitted the workflow falls back to `GITHUB_TOKEN`
+
+Variables:
+
+- `ARM_CLIENT_ID`
+- `ARM_TENANT_ID`
+- `ARM_SUBSCRIPTION_ID`
+- `AZURE_AKS_RESOURCE_GROUP`
+- `AZURE_AKS_CLUSTER_NAME`
+
+## Runner image
+
+The ARC runners for this workflow should use the Dockerfile at `.github/runner/Dockerfile`.
+
+Build and push it with the manual workflow:
+
+- `Build Agent Runner Image`
+
+That image intentionally stays small. The job still installs `@openai/codex` and `playwright` at runtime, but the image provides:
+
+- Azure CLI
+- `sudo` so `playwright install --with-deps chromium` can succeed on Linux runners
+- the standard GitHub runner base
+
+## ARC scale set
+
+Use `k8s/arc/values-issue-agents.yaml` with the official `gha-runner-scale-set` chart.
+
+Recommended install shape:
+
+1. Put ARC controller pods in a controller namespace such as `arc-system`.
+2. Put the runner scale set in a different namespace such as `arc-runners`.
+3. Use a GitHub App secret named `arc-github-app` in that runner namespace.
+4. Keep `minRunners: 0` and `maxRunners: 5` for the initial rollout.
+
+Example install:
+
+```bash
+helm upgrade --install ambience-issue-agents \
+  --namespace arc-runners \
+  --create-namespace \
+  -f k8s/arc/values-issue-agents.yaml \
+  oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set
+```
+
+This setup targets the runner scale set by name (`ambience-issue-agents`) instead of extra ARC labels. That keeps it compatible with the controller/chart version currently running in the cluster.
+
+## Ephemeral environment behavior
+
+Each run uses:
+
+- a unique namespace: `ambience-issue-<issue>-<run-id>`
+- a fixed Helm release name inside that namespace
+- a unique image tag built from the current branch contents
+
+The deploy helper disables public gateway resources by default and keeps the validation environment internal-only. The workflow validates through `kubectl port-forward`, which avoids burning public DNS names for short-lived runs.
+
+## Security notes
+
+This workflow intentionally gives Codex broad access inside an isolated automation runner:
+
+- `codex exec --sandbox danger-full-access`
+- Azure login
+- Kubernetes namespace create/delete
+- image builds
+
+Treat that runner pool as privileged automation infrastructure. GitHub's ARC guidance explicitly recommends isolating these workloads because GitHub Actions jobs execute arbitrary code.
+
+Strongly recommended:
+
+- dedicate a node pool or cluster to ARC runners
+- keep runner pods in a different namespace from the ARC controller
+- scope the GitHub App and Azure identity as tightly as practical
+- keep production workloads and secrets out of the runner namespace
+
+## Expected operator loop
+
+1. Label a bounded issue with `codex:run`.
+2. Wait for the ARC runner to scale up and pick up the job.
+3. Review the PR that the workflow opens.
+4. Re-label or manually dispatch if you want another pass.
+
+If the run is blocked, the workflow comments back on the issue instead of guessing.

--- a/k8s/arc/values-issue-agents.yaml
+++ b/k8s/arc/values-issue-agents.yaml
@@ -1,0 +1,22 @@
+githubConfigUrl: "https://github.com/nelsong6/ambience"
+githubConfigSecret: arc-github-app
+
+maxRunners: 5
+minRunners: 0
+
+runnerScaleSetName: "ambience-issue-agents"
+
+template:
+  spec:
+    containers:
+      - name: runner
+        image: romainecr.azurecr.io/ambience-agent-runner:issue-agents-20260423221714
+        command:
+          - /home/runner/run.sh
+        resources:
+          requests:
+            cpu: "1000m"
+            memory: "2Gi"
+          limits:
+            cpu: "4000m"
+            memory: "8Gi"

--- a/scripts/agent/build-image.sh
+++ b/scripts/agent/build-image.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+registry_name="${REGISTRY_NAME:-romainecr}"
+image_repository="${IMAGE_REPOSITORY:-ambience}"
+registry_server="${REGISTRY_SERVER:-${registry_name}.azurecr.io}"
+tag="${1:-}"
+
+if [[ -z "$tag" ]]; then
+  short_sha="$(git -C "$repo_root" rev-parse --short=7 HEAD)"
+  stamp="$(date -u +%Y%m%d%H%M%S)"
+  tag="agent-${short_sha}-${stamp}"
+fi
+
+image="${registry_server}/${image_repository}:${tag}"
+
+az acr build \
+  --registry "$registry_name" \
+  --image "${image_repository}:${tag}" \
+  "$repo_root"
+
+verified_tag="$(az acr repository show-tags \
+  --name "$registry_name" \
+  --repository "$image_repository" \
+  --query "[?@=='${tag}'] | [0]" \
+  --output tsv || true)"
+
+if [[ "$verified_tag" != "$tag" ]]; then
+  echo "Image tag '${tag}' was not found in ${registry_server}/${image_repository} after build." >&2
+  exit 1
+fi
+
+printf 'TAG=%s\n' "$tag"
+printf 'IMAGE=%s\n' "$image"
+printf 'REGISTRY_SERVER=%s\n' "$registry_server"

--- a/scripts/agent/capture-screenshot.mjs
+++ b/scripts/agent/capture-screenshot.mjs
@@ -1,0 +1,47 @@
+import path from "node:path";
+import { chromium } from "playwright";
+
+function readArg(flag, fallback = "") {
+  const index = process.argv.indexOf(flag);
+  if (index === -1 || index === process.argv.length - 1) {
+    return fallback;
+  }
+  return process.argv[index + 1];
+}
+
+function hasFlag(flag) {
+  return process.argv.includes(flag);
+}
+
+const url = readArg("--url");
+const output = readArg("--output");
+const waitMs = Number(readArg("--wait-ms", "5000"));
+const width = Number(readArg("--width", "1600"));
+const height = Number(readArg("--height", "900"));
+const fullPage = hasFlag("--full-page");
+
+if (!url) {
+  throw new Error("--url is required");
+}
+
+if (!output) {
+  throw new Error("--output is required");
+}
+
+const browser = await chromium.launch({ headless: true });
+
+try {
+  const context = await browser.newContext({
+    viewport: { width, height },
+  });
+  const page = await context.newPage();
+  await page.goto(url, { waitUntil: "domcontentloaded" });
+  await page.waitForTimeout(waitMs);
+  await page.screenshot({
+    path: path.resolve(output),
+    fullPage,
+  });
+  await context.close();
+} finally {
+  await browser.close();
+}

--- a/scripts/agent/capture-screenshot.sh
+++ b/scripts/agent/capture-screenshot.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ $# -lt 3 ]]; then
+  echo "usage: $0 <namespace> <page-path> <output-path>" >&2
+  exit 1
+fi
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+namespace="$1"
+page_path="$2"
+output_path="$3"
+service_name="${SERVICE_NAME:-ambience}"
+local_port="${LOCAL_PORT:-18080}"
+wait_ms="${WAIT_MS:-5000}"
+health_path="${HEALTH_PATH:-/healthz}"
+
+mkdir -p "$(dirname "$output_path")"
+
+cleanup() {
+  if [[ -n "${port_forward_pid:-}" ]]; then
+    kill "$port_forward_pid" >/dev/null 2>&1 || true
+    wait "$port_forward_pid" >/dev/null 2>&1 || true
+  fi
+}
+
+trap cleanup EXIT
+
+kubectl port-forward -n "$namespace" "service/${service_name}" "${local_port}:80" >/tmp/ambience-port-forward.log 2>&1 &
+port_forward_pid="$!"
+
+for _ in $(seq 1 30); do
+  if curl -fsS "http://127.0.0.1:${local_port}${health_path}" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 2
+done
+
+if ! curl -fsS "http://127.0.0.1:${local_port}${health_path}" >/dev/null 2>&1; then
+  echo "Timed out waiting for port-forward to become ready." >&2
+  exit 1
+fi
+
+node "${repo_root}/scripts/agent/capture-screenshot.mjs" \
+  --url "http://127.0.0.1:${local_port}${page_path}" \
+  --output "$output_path" \
+  --wait-ms "$wait_ms" \
+  --full-page

--- a/scripts/agent/deploy-env.sh
+++ b/scripts/agent/deploy-env.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ $# -lt 2 ]]; then
+  echo "usage: $0 <namespace> <image> [release]" >&2
+  exit 1
+fi
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+chart_path="${CHART_PATH:-${repo_root}/chart/ambience}"
+namespace="$1"
+image="$2"
+release="${3:-ambience-agent}"
+timeout="${HELM_TIMEOUT:-10m}"
+rollout_timeout="${ROLLOUT_TIMEOUT:-180s}"
+image_repository="${image%:*}"
+image_tag="${image##*:}"
+service_name="${SERVICE_NAME:-ambience}"
+service_url="http://${service_name}.${namespace}.svc.cluster.local"
+
+helm upgrade --install "$release" "$chart_path" \
+  --namespace "$namespace" \
+  --create-namespace \
+  --wait \
+  --timeout "$timeout" \
+  --set "image.repository=${image_repository}" \
+  --set "image.tag=${image_tag}" \
+  --set "image.pullPolicy=Always" \
+  --set "edge.replicas=1" \
+  --set "authority.replicas=1" \
+  --set "authority.storage.size=256Mi" \
+  --set "pdb.enabled=false" \
+  --set "edge.shutdownDrain=1s" \
+  --set "edge.terminationGracePeriodSeconds=3" \
+  --set "authority.terminationGracePeriodSeconds=5" \
+  --set "route.enabled=false" \
+  --set "certificate.enabled=false" \
+  --set "gateway.listenerSetEnabled=false"
+
+kubectl rollout status deployment/ambience-edge -n "$namespace" --timeout="$rollout_timeout"
+kubectl rollout status statefulset/ambience-authority -n "$namespace" --timeout="$rollout_timeout"
+
+printf 'NAMESPACE=%s\n' "$namespace"
+printf 'RELEASE=%s\n' "$release"
+printf 'SERVICE_URL=%s\n' "$service_url"

--- a/scripts/agent/destroy-env.sh
+++ b/scripts/agent/destroy-env.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+  echo "usage: $0 <namespace> [release]" >&2
+  exit 1
+fi
+
+namespace="$1"
+release="${2:-ambience-agent}"
+
+helm uninstall "$release" --namespace "$namespace" >/dev/null 2>&1 || true
+kubectl delete namespace "$namespace" --ignore-not-found=true --wait=false >/dev/null 2>&1 || true


### PR DESCRIPTION
## Summary
- add a label-driven Codex issue workflow that runs on an ARC scale set and opens PRs with screenshots
- add the runner image build workflow, prompt/schema files, and ephemeral environment helper scripts
- let the Helm chart disable public gateway listener resources for internal ephemeral test environments
- enforce LF line endings for the agent automation files that execute on Linux runners

## Validation
- go test ./...
- git diff --check
- bash -n scripts/agent/build-image.sh
- bash -n scripts/agent/deploy-env.sh
- bash -n scripts/agent/destroy-env.sh
- bash -n scripts/agent/capture-screenshot.sh
- node --check scripts/agent/capture-screenshot.mjs
