### PR TITLE
Add MCP-backed PR preview lifecycle

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,4 +2,5 @@
 chart/** text eol=lf
 docs/agentic-issue-flow.md text eol=lf
 k8s/** text eol=lf
+mcp/** text eol=lf
 scripts/agent/** text eol=lf

--- a/.github/codex/prompts/issue-implementation.md
+++ b/.github/codex/prompts/issue-implementation.md
@@ -20,17 +20,23 @@ Environment variables you can rely on:
 - `EPHEMERAL_RELEASE`
 - `ARTIFACT_DIR`
 
-Use these repo-native helpers for runtime validation:
-- `bash scripts/agent/build-image.sh "$IMAGE_TAG"`
-- `bash scripts/agent/deploy-env.sh "$EPHEMERAL_NAMESPACE" "$IMAGE" "$EPHEMERAL_RELEASE"`
-- `bash scripts/agent/capture-screenshot.sh "$EPHEMERAL_NAMESPACE" "/path" "$ARTIFACT_DIR/file.png"`
+Use the `ambience_preview` MCP server for fixed platform operations:
+- `build_preview_image`
+- `deploy_validation_preview`
+- `capture_validation_screenshot`
+
+Those tools encode the exact build, deploy, and screenshot commands for this repo. Prefer them over ad hoc `az`, `helm`, `kubectl`, or Playwright command lines unless the MCP server is unavailable.
+
+Preview lifecycle rules:
+- Your run-scoped validation namespace is scratch space. The workflow tears it down after the run.
+- The long-lived public PR preview is handled by a separate pull-request workflow after the PR opens, and it is cleaned up automatically when the PR closes.
 
 Validation rules:
 - Prefer the narrowest useful test loop, but run the checks needed to justify the change.
 - For browser-facing work, capture at least one screenshot from the route you validated.
 - For non-visual work, still deploy and smoke-test the most relevant route if the issue can be exercised there.
-- Do not tear down the ephemeral namespace; the workflow wrapper handles cleanup.
-- Do not push branches or open the pull request yourself; the workflow wrapper handles git push and PR creation after you finish.
+- Do not tear down the ephemeral namespace; the workflow handles cleanup.
+- Do not push branches or open the pull request yourself; the workflow handles git push and PR creation after you finish.
 
 When you finish, your final response must match the configured JSON schema:
 - `status`: use `ready_for_pr`, `needs_human_input`, or `no_change`

--- a/.github/workflows/codex-issue-agent.yml
+++ b/.github/workflows/codex-issue-agent.yml
@@ -238,6 +238,12 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - name: Set up Python
+        if: steps.issue.outputs.should_run == 'true'
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
       - name: Set up kubectl
         if: steps.issue.outputs.should_run == 'true'
         uses: azure/setup-kubectl@v4
@@ -252,6 +258,38 @@ jobs:
           set -euo pipefail
           npm install --no-save @openai/codex playwright
           npx playwright install --with-deps chromium || npx playwright install chromium
+
+      - name: Install ambience preview MCP package
+        if: steps.issue.outputs.should_run == 'true'
+        run: |
+          set -euo pipefail
+          python -m pip install --upgrade pip
+          python -m pip install ./mcp
+
+      - name: Configure Codex MCP server
+        if: steps.issue.outputs.should_run == 'true'
+        env:
+          WORKSPACE: ${{ github.workspace }}
+        run: |
+          set -euo pipefail
+          mkdir -p "$HOME/.codex"
+          python <<'PY'
+          import os
+          from pathlib import Path
+
+          workspace = os.environ["WORKSPACE"]
+          config = f"""[projects.'{workspace}']
+          trust_level = "trusted"
+
+          [mcp_servers.ambience_preview]
+          command = "python"
+          args = ["-m", "ambience_preview.mcp_server"]
+          cwd = "{workspace}"
+          """
+          config_path = Path.home() / ".codex" / "config.toml"
+          config_path.write_text(config, encoding="utf-8")
+          print(config_path)
+          PY
 
       - name: Azure Login (OIDC)
         if: steps.issue.outputs.should_run == 'true'
@@ -453,7 +491,7 @@ jobs:
           EPHEMERAL_RELEASE: ${{ env.EPHEMERAL_RELEASE }}
         run: |
           set -euo pipefail
-          bash scripts/agent/destroy-env.sh "$EPHEMERAL_NAMESPACE" "$EPHEMERAL_RELEASE"
+          python -m ambience_preview.cli destroy-validation-preview
 
       - name: Comment on failure
         if: failure() && steps.issue.outputs.should_run == 'true'

--- a/.github/workflows/codex-issue-agent.yml
+++ b/.github/workflows/codex-issue-agent.yml
@@ -309,7 +309,6 @@ jobs:
           az aks get-credentials \
             --resource-group "$AZURE_AKS_RESOURCE_GROUP" \
             --name "$AZURE_AKS_CLUSTER_NAME" \
-            --admin \
             --overwrite-existing
 
       - name: Compute run-scoped variables

--- a/.github/workflows/codex-pr-preview.yml
+++ b/.github/workflows/codex-pr-preview.yml
@@ -1,0 +1,256 @@
+name: Codex PR Preview
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - closed
+
+permissions:
+  contents: read
+  pull-requests: write
+  id-token: write
+
+concurrency:
+  group: codex-pr-preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  deploy-preview:
+    name: Build and publish PR preview
+    if: github.event.action != 'closed' && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    env:
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+      PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+      PREVIEW_COMMENT_MARKER: "<!-- ambience-pr-preview -->"
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - name: Validate job configuration
+        env:
+          ARM_CLIENT_ID: ${{ vars.ARM_CLIENT_ID }}
+          ARM_TENANT_ID: ${{ vars.ARM_TENANT_ID }}
+          ARM_SUBSCRIPTION_ID: ${{ vars.ARM_SUBSCRIPTION_ID }}
+          AZURE_AKS_RESOURCE_GROUP: ${{ vars.AZURE_AKS_RESOURCE_GROUP }}
+          AZURE_AKS_CLUSTER_NAME: ${{ vars.AZURE_AKS_CLUSTER_NAME }}
+        run: |
+          set -euo pipefail
+          required_vars=(
+            ARM_CLIENT_ID
+            ARM_TENANT_ID
+            ARM_SUBSCRIPTION_ID
+            AZURE_AKS_RESOURCE_GROUP
+            AZURE_AKS_CLUSTER_NAME
+          )
+          missing=()
+          for name in "${required_vars[@]}"; do
+            if [ -z "${!name:-}" ]; then
+              missing+=("$name")
+            fi
+          done
+          if [ "${#missing[@]}" -ne 0 ]; then
+            echo "Missing required configuration: ${missing[*]}" >&2
+            exit 1
+          fi
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Set up kubectl
+        uses: azure/setup-kubectl@v4
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+
+      - name: Install ambience preview package
+        run: |
+          set -euo pipefail
+          python -m pip install --upgrade pip
+          python -m pip install ./mcp
+
+      - name: Azure Login (OIDC)
+        uses: azure/login@v2
+        with:
+          client-id: ${{ vars.ARM_CLIENT_ID }}
+          tenant-id: ${{ vars.ARM_TENANT_ID }}
+          subscription-id: ${{ vars.ARM_SUBSCRIPTION_ID }}
+
+      - name: Set AKS context
+        env:
+          AZURE_AKS_RESOURCE_GROUP: ${{ vars.AZURE_AKS_RESOURCE_GROUP }}
+          AZURE_AKS_CLUSTER_NAME: ${{ vars.AZURE_AKS_CLUSTER_NAME }}
+        run: |
+          set -euo pipefail
+          az aks get-credentials \
+            --resource-group "$AZURE_AKS_RESOURCE_GROUP" \
+            --name "$AZURE_AKS_CLUSTER_NAME" \
+            --admin \
+            --overwrite-existing
+
+      - name: Build preview image
+        id: image
+        env:
+          PR_NUMBER: ${{ env.PR_NUMBER }}
+          PR_HEAD_SHA: ${{ env.PR_HEAD_SHA }}
+        run: |
+          set -euo pipefail
+          short_sha="${PR_HEAD_SHA:0:7}"
+          image_tag="pr-${PR_NUMBER}-${short_sha}"
+          python -m ambience_preview.cli build-preview-image --image-tag "$image_tag" > preview-image.json
+          image="$(python -c "import json, pathlib; print(json.loads(pathlib.Path('preview-image.json').read_text())['image'])")"
+          echo "image=$image" >> "$GITHUB_OUTPUT"
+          echo "image_tag=$image_tag" >> "$GITHUB_OUTPUT"
+
+      - name: Upsert public preview
+        id: preview
+        env:
+          PR_NUMBER: ${{ env.PR_NUMBER }}
+          IMAGE: ${{ steps.image.outputs.image }}
+        run: |
+          set -euo pipefail
+          python -m ambience_preview.cli upsert-pr-preview --pr-number "$PR_NUMBER" --image "$IMAGE" > preview.json
+          url="$(python -c "import json, pathlib; print(json.loads(pathlib.Path('preview.json').read_text())['url'])")"
+          echo "url=$url" >> "$GITHUB_OUTPUT"
+
+      - name: Wait for preview URL
+        id: wait
+        continue-on-error: true
+        env:
+          PREVIEW_URL: ${{ steps.preview.outputs.url }}
+        run: |
+          set -euo pipefail
+          python -m ambience_preview.cli wait-public-preview --url "$PREVIEW_URL"
+
+      - name: Upsert PR preview comment
+        uses: actions/github-script@v7
+        env:
+          PREVIEW_COMMENT_MARKER: ${{ env.PREVIEW_COMMENT_MARKER }}
+          PREVIEW_URL: ${{ steps.preview.outputs.url }}
+          PREVIEW_IMAGE: ${{ steps.image.outputs.image }}
+          PREVIEW_STATUS: ${{ steps.wait.outcome == 'success' && 'ready' || 'provisioning' }}
+        with:
+          script: |
+            const marker = process.env.PREVIEW_COMMENT_MARKER;
+            const body = [
+              marker,
+              `Preview: ${process.env.PREVIEW_URL}`,
+              `Status: ${process.env.PREVIEW_STATUS}`,
+              `Image: \`${process.env.PREVIEW_IMAGE}\``,
+            ].join("\n");
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              per_page: 100,
+            });
+
+            const existing = comments.find((comment) =>
+              comment.user?.type === "Bot" && typeof comment.body === "string" && comment.body.includes(marker)
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+              return;
+            }
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body,
+            });
+
+  destroy-preview:
+    name: Remove PR preview
+    if: github.event.action == 'closed' && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    env:
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+    steps:
+      - name: Checkout default branch
+        uses: actions/checkout@v5
+
+      - name: Validate job configuration
+        env:
+          ARM_CLIENT_ID: ${{ vars.ARM_CLIENT_ID }}
+          ARM_TENANT_ID: ${{ vars.ARM_TENANT_ID }}
+          ARM_SUBSCRIPTION_ID: ${{ vars.ARM_SUBSCRIPTION_ID }}
+          AZURE_AKS_RESOURCE_GROUP: ${{ vars.AZURE_AKS_RESOURCE_GROUP }}
+          AZURE_AKS_CLUSTER_NAME: ${{ vars.AZURE_AKS_CLUSTER_NAME }}
+        run: |
+          set -euo pipefail
+          required_vars=(
+            ARM_CLIENT_ID
+            ARM_TENANT_ID
+            ARM_SUBSCRIPTION_ID
+            AZURE_AKS_RESOURCE_GROUP
+            AZURE_AKS_CLUSTER_NAME
+          )
+          missing=()
+          for name in "${required_vars[@]}"; do
+            if [ -z "${!name:-}" ]; then
+              missing+=("$name")
+            fi
+          done
+          if [ "${#missing[@]}" -ne 0 ]; then
+            echo "Missing required configuration: ${missing[*]}" >&2
+            exit 1
+          fi
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Set up kubectl
+        uses: azure/setup-kubectl@v4
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+
+      - name: Install ambience preview package
+        run: |
+          set -euo pipefail
+          python -m pip install --upgrade pip
+          python -m pip install ./mcp
+
+      - name: Azure Login (OIDC)
+        uses: azure/login@v2
+        with:
+          client-id: ${{ vars.ARM_CLIENT_ID }}
+          tenant-id: ${{ vars.ARM_TENANT_ID }}
+          subscription-id: ${{ vars.ARM_SUBSCRIPTION_ID }}
+
+      - name: Set AKS context
+        env:
+          AZURE_AKS_RESOURCE_GROUP: ${{ vars.AZURE_AKS_RESOURCE_GROUP }}
+          AZURE_AKS_CLUSTER_NAME: ${{ vars.AZURE_AKS_CLUSTER_NAME }}
+        run: |
+          set -euo pipefail
+          az aks get-credentials \
+            --resource-group "$AZURE_AKS_RESOURCE_GROUP" \
+            --name "$AZURE_AKS_CLUSTER_NAME" \
+            --admin \
+            --overwrite-existing
+
+      - name: Destroy preview
+        env:
+          PR_NUMBER: ${{ env.PR_NUMBER }}
+        run: |
+          set -euo pipefail
+          python -m ambience_preview.cli destroy-pr-preview --pr-number "$PR_NUMBER"

--- a/.github/workflows/codex-pr-preview.yml
+++ b/.github/workflows/codex-pr-preview.yml
@@ -93,7 +93,6 @@ jobs:
           az aks get-credentials \
             --resource-group "$AZURE_AKS_RESOURCE_GROUP" \
             --name "$AZURE_AKS_CLUSTER_NAME" \
-            --admin \
             --overwrite-existing
 
       - name: Build preview image
@@ -245,7 +244,6 @@ jobs:
           az aks get-credentials \
             --resource-group "$AZURE_AKS_RESOURCE_GROUP" \
             --name "$AZURE_AKS_CLUSTER_NAME" \
-            --admin \
             --overwrite-existing
 
       - name: Destroy preview

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@
 node_modules/
 /.github/codex/output/
 /.github/codex/tmp/
+mcp/.venv/
+mcp/**/__pycache__/

--- a/docs/agentic-issue-flow.md
+++ b/docs/agentic-issue-flow.md
@@ -7,19 +7,22 @@ This repo now has a first-pass GitHub-to-Codex-to-k8s issue flow aimed at bounde
 1. A GitHub issue gets a trigger label.
 2. GitHub Actions becomes the queue manager.
 3. The job runs on an ARC-backed self-hosted runner scale set capped at five runners.
-4. Codex implements the issue in the checked-out repo, runs tests, deploys an ephemeral ambience environment in Kubernetes, validates the change, captures screenshots, and hands a structured result back to the workflow.
-5. The workflow wrapper opens a pull request with the screenshots and posts the result back to the issue.
-6. The namespace is deleted at the end of the run.
+4. Codex implements the issue in the checked-out repo, runs tests, uses the repo-local `ambience_preview` MCP server for the exact build/deploy/screenshot commands, and hands a structured result back to the workflow.
+5. The workflow opens a pull request with the screenshots and posts the result back to the issue.
+6. A separate pull-request workflow builds and publishes a long-lived preview at `pr-<number>.ambience.dev.romaine.life`.
+7. The scratch validation namespace is deleted at the end of the issue run, while the PR preview stays up until the PR closes.
 
 Because each job owns one runner and one namespace, a `maxRunners: 5` scale set also caps us at five concurrent ephemeral environments.
 
 ## Files added for this flow
 
 - `.github/workflows/codex-issue-agent.yml`
+- `.github/workflows/codex-pr-preview.yml`
 - `.github/workflows/build-agent-runner-image.yml`
 - `.github/codex/prompts/issue-implementation.md`
 - `.github/codex/issue-result.schema.json`
 - `.github/runner/Dockerfile`
+- `mcp/`
 - `scripts/agent/*.sh`
 - `scripts/agent/capture-screenshot.mjs`
 - `k8s/arc/values-issue-agents.yaml`
@@ -94,7 +97,19 @@ helm upgrade --install ambience-issue-agents \
 
 This setup targets the runner scale set by name (`ambience-issue-agents`) instead of extra ARC labels. That keeps it compatible with the controller/chart version currently running in the cluster.
 
-## Ephemeral environment behavior
+## Agent MCP server
+
+The issue automation now installs a small repo-local Python MCP server from `mcp/` before it launches `codex exec`.
+
+That server gives Codex exact, typed tools for the fixed preview operations:
+
+- `build_preview_image`
+- `deploy_validation_preview`
+- `capture_validation_screenshot`
+
+The point is to move the exact build/deploy/screenshot command lines behind a stable tool surface instead of making the model reconstruct them from prompt text on every run.
+
+## Ephemeral validation behavior
 
 Each run uses:
 
@@ -102,7 +117,20 @@ Each run uses:
 - a fixed Helm release name inside that namespace
 - a unique image tag built from the current branch contents
 
-The deploy helper disables public gateway resources by default and keeps the validation environment internal-only. The workflow validates through `kubectl port-forward`, which avoids burning public DNS names for short-lived runs.
+The validation deploy stays internal-only. Codex validates through the MCP server, which deploys the chart without public gateway resources and captures screenshots through a temporary `kubectl port-forward`.
+
+## PR preview behavior
+
+When the issue workflow opens a pull request, `Codex PR Preview` takes over the long-lived review environment:
+
+- build an image for the PR head SHA
+- deploy it to `ambience-pr-<number>`
+- expose `https://pr-<number>.ambience.dev.romaine.life`
+- let external-dns publish the record from the `HTTPRoute`
+- update the preview on `pull_request.synchronize`
+- delete the namespace on `pull_request.closed`
+
+Preview cleanup is intentionally non-agentic and deterministic.
 
 ## Security notes
 
@@ -126,7 +154,8 @@ Strongly recommended:
 
 1. Label a bounded issue with `codex:run`.
 2. Wait for the ARC runner to scale up and pick up the job.
-3. Review the PR that the workflow opens.
-4. Re-label or manually dispatch if you want another pass.
+3. Review the PR that the workflow opens and use the PR preview URL that the preview workflow comments back.
+4. Close the PR when you are done; the preview namespace will be removed automatically.
+5. Re-label or manually dispatch if you want another pass.
 
 If the run is blocked, the workflow comments back on the issue instead of guessing.

--- a/mcp/ambience_preview/__init__.py
+++ b/mcp/ambience_preview/__init__.py
@@ -1,0 +1,1 @@
+"""Exact preview operations for ambience automation."""

--- a/mcp/ambience_preview/cli.py
+++ b/mcp/ambience_preview/cli.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+
+from . import ops
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Exact ambience preview operations")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    build = subparsers.add_parser("build-preview-image")
+    build.add_argument("--image-tag", required=True)
+
+    deploy_validation = subparsers.add_parser("deploy-validation-preview")
+    deploy_validation.add_argument("--image", required=True)
+    deploy_validation.add_argument("--namespace", default="")
+    deploy_validation.add_argument("--release", default="")
+
+    screenshot = subparsers.add_parser("capture-validation-screenshot")
+    screenshot.add_argument("--page-path", required=True)
+    screenshot.add_argument("--output-path", required=True)
+    screenshot.add_argument("--namespace", default="")
+    screenshot.add_argument("--wait-ms", type=int, default=5000)
+
+    upsert_pr = subparsers.add_parser("upsert-pr-preview")
+    upsert_pr.add_argument("--pr-number", type=int, required=True)
+    upsert_pr.add_argument("--image", required=True)
+
+    wait_pr = subparsers.add_parser("wait-public-preview")
+    wait_pr.add_argument("--url", required=True)
+    wait_pr.add_argument("--timeout-seconds", type=int, default=900)
+
+    destroy_validation = subparsers.add_parser("destroy-validation-preview")
+    destroy_validation.add_argument("--namespace", default="")
+    destroy_validation.add_argument("--release", default="")
+
+    destroy_pr = subparsers.add_parser("destroy-pr-preview")
+    destroy_pr.add_argument("--pr-number", type=int, required=True)
+
+    return parser
+
+
+def dump(result: dict) -> None:
+    json.dump(result, sys.stdout, indent=2)
+    sys.stdout.write("\n")
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+    try:
+        if args.command == "build-preview-image":
+            dump(ops.build_preview_image(image_tag=args.image_tag))
+        elif args.command == "deploy-validation-preview":
+            namespace = args.namespace or str(get_required_env("EPHEMERAL_NAMESPACE"))
+            release = args.release or get_optional_env("EPHEMERAL_RELEASE", ops.DEFAULT_RELEASE_NAME)
+            dump(ops.deploy_preview(namespace=namespace, image=args.image, release=release))
+        elif args.command == "capture-validation-screenshot":
+            namespace = args.namespace or str(get_required_env("EPHEMERAL_NAMESPACE"))
+            dump(
+                ops.capture_validation_screenshot(
+                    namespace=namespace,
+                    page_path=args.page_path,
+                    output_path=args.output_path,
+                    wait_ms=args.wait_ms,
+                )
+            )
+        elif args.command == "upsert-pr-preview":
+            dump(ops.upsert_pr_preview(pr_number=args.pr_number, image=args.image))
+        elif args.command == "wait-public-preview":
+            dump(ops.wait_public_preview(url=args.url, timeout_seconds=args.timeout_seconds))
+        elif args.command == "destroy-validation-preview":
+            namespace = args.namespace or str(get_required_env("EPHEMERAL_NAMESPACE"))
+            release = args.release or get_optional_env("EPHEMERAL_RELEASE", ops.DEFAULT_RELEASE_NAME)
+            dump(ops.destroy_preview(namespace=namespace, release=release))
+        elif args.command == "destroy-pr-preview":
+            dump(ops.destroy_pr_preview(pr_number=args.pr_number))
+        else:
+            parser.error(f"unknown command: {args.command}")
+    except Exception as error:
+        print(
+            json.dumps(
+                {
+                    "success": False,
+                    "error": f"{type(error).__name__}: {error}",
+                    "command": args.command,
+                },
+                indent=2,
+            ),
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+def get_required_env(name: str) -> str:
+    value = get_optional_env(name, "")
+    if not value:
+        raise ValueError(f"{name} is required when the CLI flag is omitted")
+    return value
+
+
+def get_optional_env(name: str, default: str) -> str:
+    return str(os.environ.get(name, default))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/mcp/ambience_preview/mcp_server.py
+++ b/mcp/ambience_preview/mcp_server.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import json
+import os
+
+import mcp.types as types
+from mcp.server import Server
+from mcp.server.stdio import stdio_server
+
+from . import ops
+
+
+server = Server("ambience-preview")
+
+
+@server.list_tools()
+async def list_tools() -> list[types.Tool]:
+    return [
+        types.Tool(
+            name="build_preview_image",
+            description="Build and push the exact ambience application image for the current workspace into ACR.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "image_tag": {
+                        "type": "string",
+                        "description": "Optional image tag. Defaults to the IMAGE_TAG environment variable.",
+                    }
+                },
+            },
+        ),
+        types.Tool(
+            name="deploy_validation_preview",
+            description="Deploy the current image into the scratch validation namespace for this issue run.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "image": {
+                        "type": "string",
+                        "description": "Full container image reference returned from build_preview_image.",
+                    },
+                    "namespace": {
+                        "type": "string",
+                        "description": "Optional namespace override. Defaults to EPHEMERAL_NAMESPACE.",
+                    },
+                    "release": {
+                        "type": "string",
+                        "description": "Optional Helm release override. Defaults to EPHEMERAL_RELEASE.",
+                    },
+                },
+                "required": ["image"],
+            },
+        ),
+        types.Tool(
+            name="capture_validation_screenshot",
+            description="Capture a screenshot from the scratch validation preview by port-forwarding the service and using Playwright.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "page_path": {
+                        "type": "string",
+                        "description": "Route to capture, for example '/' or '/dev/waterfall'.",
+                    },
+                    "output_path": {
+                        "type": "string",
+                        "description": "Repo-relative path for the PNG output.",
+                    },
+                    "namespace": {
+                        "type": "string",
+                        "description": "Optional namespace override. Defaults to EPHEMERAL_NAMESPACE.",
+                    },
+                    "wait_ms": {
+                        "type": "integer",
+                        "description": "Additional browser settle time before the screenshot.",
+                        "default": 5000,
+                    },
+                },
+                "required": ["page_path", "output_path"],
+            },
+        ),
+    ]
+
+
+@server.call_tool()
+async def call_tool(name: str, arguments: dict) -> types.CallToolResult:
+    try:
+        result = handle_tool(name, arguments or {})
+        return types.CallToolResult(
+            content=[types.TextContent(type="text", text=json.dumps(result, indent=2))],
+            structuredContent=result,
+            isError=False,
+        )
+    except Exception as error:
+        payload = {
+            "success": False,
+            "tool": name,
+            "error": f"{type(error).__name__}: {error}",
+        }
+        return types.CallToolResult(
+            content=[types.TextContent(type="text", text=json.dumps(payload, indent=2))],
+            structuredContent=payload,
+            isError=True,
+        )
+
+
+def handle_tool(name: str, arguments: dict) -> dict:
+    if name == "build_preview_image":
+        image_tag = arguments.get("image_tag") or os.environ.get("IMAGE_TAG", "")
+        if not image_tag:
+            raise ValueError("image_tag is required when IMAGE_TAG is not set")
+        return ops.build_preview_image(image_tag=image_tag)
+
+    if name == "deploy_validation_preview":
+        namespace = arguments.get("namespace") or os.environ.get("EPHEMERAL_NAMESPACE", "")
+        release = arguments.get("release") or os.environ.get("EPHEMERAL_RELEASE", ops.DEFAULT_RELEASE_NAME)
+        if not namespace:
+            raise ValueError("namespace is required when EPHEMERAL_NAMESPACE is not set")
+        return ops.deploy_preview(namespace=namespace, image=arguments["image"], release=release)
+
+    if name == "capture_validation_screenshot":
+        namespace = arguments.get("namespace") or os.environ.get("EPHEMERAL_NAMESPACE", "")
+        if not namespace:
+            raise ValueError("namespace is required when EPHEMERAL_NAMESPACE is not set")
+        return ops.capture_validation_screenshot(
+            namespace=namespace,
+            page_path=arguments["page_path"],
+            output_path=arguments["output_path"],
+            wait_ms=int(arguments.get("wait_ms", 5000)),
+        )
+
+    raise ValueError(f"Unknown tool: {name}")
+
+
+async def main() -> None:
+    async with stdio_server() as streams:
+        await server.run(
+            streams[0],
+            streams[1],
+            server.create_initialization_options(),
+        )
+
+
+if __name__ == "__main__":
+    import asyncio
+
+    asyncio.run(main())

--- a/mcp/ambience_preview/ops.py
+++ b/mcp/ambience_preview/ops.py
@@ -1,0 +1,345 @@
+from __future__ import annotations
+
+import os
+import ssl
+import subprocess
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+
+DEFAULT_REGISTRY_NAME = "romainecr"
+DEFAULT_IMAGE_REPOSITORY = "ambience"
+DEFAULT_RELEASE_NAME = "ambience-agent"
+DEFAULT_PR_RELEASE_NAME = "ambience-pr"
+DEFAULT_SERVICE_NAME = "ambience"
+DEFAULT_HOST_SUFFIX = "ambience.dev.romaine.life"
+
+
+class CommandError(RuntimeError):
+    """Raised when an underlying command fails."""
+
+
+def repo_root() -> Path:
+    candidate = os.environ.get("AMBIENCE_REPO_ROOT")
+    if candidate:
+        return Path(candidate).resolve()
+    return Path.cwd().resolve()
+
+
+def chart_path() -> Path:
+    return repo_root() / "chart" / "ambience"
+
+
+def resolve_output_path(output_path: str) -> Path:
+    path = Path(output_path)
+    if path.is_absolute():
+        return path
+    return repo_root() / path
+
+
+def repo_relative_path(path: Path) -> str:
+    try:
+        return path.resolve().relative_to(repo_root()).as_posix()
+    except ValueError:
+        return str(path.resolve())
+
+
+def run_command(command: list[str], *, cwd: Path | None = None) -> str:
+    result = subprocess.run(
+        command,
+        cwd=str(cwd or repo_root()),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise CommandError(
+            "\n".join(
+                [
+                    f"Command failed: {' '.join(command)}",
+                    f"exit_code={result.returncode}",
+                    result.stdout.strip(),
+                    result.stderr.strip(),
+                ]
+            ).strip()
+        )
+    return result.stdout.strip()
+
+
+def image_parts(image: str) -> tuple[str, str]:
+    repository, tag = image.rsplit(":", 1)
+    return repository, tag
+
+
+def preview_namespace(pr_number: int) -> str:
+    return f"ambience-pr-{pr_number}"
+
+
+def preview_tls_secret(pr_number: int) -> str:
+    return f"ambience-pr-{pr_number}-tls"
+
+
+def preview_host(pr_number: int, host_suffix: str = DEFAULT_HOST_SUFFIX) -> str:
+    return f"pr-{pr_number}.{host_suffix}"
+
+
+def preview_url(pr_number: int, host_suffix: str = DEFAULT_HOST_SUFFIX) -> str:
+    return f"https://{preview_host(pr_number, host_suffix)}"
+
+
+def build_preview_image(
+    *,
+    image_tag: str,
+    registry_name: str = DEFAULT_REGISTRY_NAME,
+    image_repository: str = DEFAULT_IMAGE_REPOSITORY,
+) -> dict:
+    registry_server = os.environ.get("REGISTRY_SERVER", f"{registry_name}.azurecr.io")
+    image = f"{registry_server}/{image_repository}:{image_tag}"
+
+    run_command(
+        [
+            "az",
+            "acr",
+            "build",
+            "--registry",
+            registry_name,
+            "--image",
+            f"{image_repository}:{image_tag}",
+            str(repo_root()),
+        ]
+    )
+
+    verified_tag = run_command(
+        [
+            "az",
+            "acr",
+            "repository",
+            "show-tags",
+            "--name",
+            registry_name,
+            "--repository",
+            image_repository,
+            "--query",
+            f"[?@=='{image_tag}'] | [0]",
+            "--output",
+            "tsv",
+        ]
+    )
+
+    if verified_tag != image_tag:
+        raise CommandError(f"Image tag '{image_tag}' was not found in {registry_server}/{image_repository}.")
+
+    return {
+        "image": image,
+        "image_tag": image_tag,
+        "image_repository": image_repository,
+        "registry_name": registry_name,
+        "registry_server": registry_server,
+    }
+
+
+def deploy_preview(
+    *,
+    namespace: str,
+    image: str,
+    release: str = DEFAULT_RELEASE_NAME,
+    public_host: str | None = None,
+    tls_secret_name: str | None = None,
+    timeout: str = "10m",
+    rollout_timeout: str = "180s",
+) -> dict:
+    image_repository, image_tag = image_parts(image)
+    command = [
+        "helm",
+        "upgrade",
+        "--install",
+        release,
+        str(chart_path()),
+        "--namespace",
+        namespace,
+        "--create-namespace",
+        "--wait",
+        "--timeout",
+        timeout,
+    ]
+
+    string_values = {
+        "image.repository": image_repository,
+        "image.tag": image_tag,
+        "image.pullPolicy": "Always",
+        "authority.storage.size": "256Mi",
+        "edge.shutdownDrain": "1s",
+        "edge.terminationGracePeriodSeconds": "3",
+        "authority.terminationGracePeriodSeconds": "5",
+    }
+    bool_values = {
+        "edge.replicas": True,
+        "authority.replicas": True,
+        "pdb.enabled": False,
+    }
+
+    if public_host:
+        string_values["domain.host"] = public_host
+        string_values["domain.tlsSecretName"] = tls_secret_name or f"{namespace}-tls"
+        bool_values["route.enabled"] = True
+        bool_values["certificate.enabled"] = True
+        bool_values["gateway.listenerSetEnabled"] = True
+    else:
+        bool_values["route.enabled"] = False
+        bool_values["certificate.enabled"] = False
+        bool_values["gateway.listenerSetEnabled"] = False
+
+    for key, value in string_values.items():
+        command.extend(["--set-string", f"{key}={value}"])
+    for key, value in bool_values.items():
+        if key.endswith(".replicas"):
+            command.extend(["--set", f"{key}={1 if value else 0}"])
+            continue
+        command.extend(["--set", f"{key}={'true' if value else 'false'}"])
+
+    run_command(command)
+    run_command(["kubectl", "rollout", "status", f"deployment/{DEFAULT_SERVICE_NAME}-edge", "-n", namespace, f"--timeout={rollout_timeout}"])
+    run_command(["kubectl", "rollout", "status", f"statefulset/{DEFAULT_SERVICE_NAME}-authority", "-n", namespace, f"--timeout={rollout_timeout}"])
+
+    result = {
+        "namespace": namespace,
+        "release": release,
+        "image": image,
+    }
+    if public_host:
+        result["url"] = f"https://{public_host}"
+    else:
+        result["service_url"] = f"http://{DEFAULT_SERVICE_NAME}.{namespace}.svc.cluster.local"
+    return result
+
+
+def wait_http_ready(
+    *,
+    url: str,
+    timeout_seconds: int = 900,
+    interval_seconds: int = 5,
+) -> dict:
+    deadline = time.time() + timeout_seconds
+    last_error = ""
+    while time.time() < deadline:
+        try:
+            request = urllib.request.Request(url, method="GET")
+            with urllib.request.urlopen(request, timeout=10, context=ssl.create_default_context()) as response:
+                status = response.getcode()
+                if 200 <= status < 400:
+                    return {"ready": True, "status": status, "url": url}
+                last_error = f"unexpected status {status}"
+        except urllib.error.URLError as error:
+            last_error = str(error)
+        time.sleep(interval_seconds)
+
+    raise CommandError(f"Timed out waiting for {url}: {last_error}")
+
+
+def wait_public_preview(*, url: str, health_path: str = "/healthz", timeout_seconds: int = 900) -> dict:
+    health_url = urllib.parse.urljoin(url.rstrip("/") + "/", health_path.lstrip("/"))
+    return wait_http_ready(url=health_url, timeout_seconds=timeout_seconds)
+
+
+def capture_validation_screenshot(
+    *,
+    namespace: str,
+    page_path: str,
+    output_path: str,
+    wait_ms: int = 5000,
+    service_name: str = DEFAULT_SERVICE_NAME,
+    local_port: int = 18080,
+    health_path: str = "/healthz",
+) -> dict:
+    final_output_path = resolve_output_path(output_path)
+    final_output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    log_path = final_output_path.parent / "kubectl-port-forward.log"
+    with log_path.open("w", encoding="utf-8") as log_file:
+        process = subprocess.Popen(
+            [
+                "kubectl",
+                "port-forward",
+                "-n",
+                namespace,
+                f"service/{service_name}",
+                f"{local_port}:80",
+            ],
+            cwd=str(repo_root()),
+            stdout=log_file,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+        try:
+            wait_http_ready(url=f"http://127.0.0.1:{local_port}{health_path}", timeout_seconds=60, interval_seconds=2)
+            page_url = urllib.parse.urljoin(f"http://127.0.0.1:{local_port}/", page_path.lstrip("/"))
+            run_command(
+                [
+                    "node",
+                    str(repo_root() / "scripts" / "agent" / "capture-screenshot.mjs"),
+                    "--url",
+                    page_url,
+                    "--output",
+                    str(final_output_path),
+                    "--wait-ms",
+                    str(wait_ms),
+                    "--full-page",
+                ]
+            )
+        finally:
+            process.terminate()
+            try:
+                process.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                process.wait(timeout=10)
+
+    return {
+        "namespace": namespace,
+        "page_url": page_url,
+        "output_path": repo_relative_path(final_output_path),
+        "port_forward_log": repo_relative_path(log_path),
+    }
+
+
+def upsert_pr_preview(
+    *,
+    pr_number: int,
+    image: str,
+    release: str = DEFAULT_PR_RELEASE_NAME,
+    host_suffix: str = DEFAULT_HOST_SUFFIX,
+) -> dict:
+    host = preview_host(pr_number, host_suffix)
+    return deploy_preview(
+        namespace=preview_namespace(pr_number),
+        image=image,
+        release=release,
+        public_host=host,
+        tls_secret_name=preview_tls_secret(pr_number),
+        rollout_timeout="300s",
+    )
+
+
+def destroy_preview(*, namespace: str, release: str) -> dict:
+    subprocess.run(
+        ["helm", "uninstall", release, "--namespace", namespace],
+        cwd=str(repo_root()),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    subprocess.run(
+        ["kubectl", "delete", "namespace", namespace, "--ignore-not-found=true", "--wait=false"],
+        cwd=str(repo_root()),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return {"namespace": namespace, "release": release, "destroyed": True}
+
+
+def destroy_pr_preview(*, pr_number: int, release: str = DEFAULT_PR_RELEASE_NAME) -> dict:
+    return destroy_preview(namespace=preview_namespace(pr_number), release=release)

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,0 +1,18 @@
+[project]
+name = "ambience-preview"
+version = "0.1.0"
+description = "MCP server and CLI for exact ambience preview operations"
+requires-python = ">=3.11"
+dependencies = [
+    "mcp[cli]>=1.0.0",
+]
+
+[project.scripts]
+ambience-preview = "ambience_preview.cli:main"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["ambience_preview"]

--- a/mcp/run.py
+++ b/mcp/run.py
@@ -1,0 +1,7 @@
+import asyncio
+
+from ambience_preview.mcp_server import main
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- add a repo-local ambience_preview MCP package so issue runs can build, deploy, and screenshot previews through typed tools
- wire the issue workflow to install and register that MCP server before launching Codex, and clean up scratch validation previews through the same package
- add a pull_request workflow that builds and publishes long-lived PR previews at pr-<number>.ambience.dev.romaine.life and removes them deterministically on PR close

## Testing
- go test ./...
- node --check scripts/agent/capture-screenshot.mjs
- python -m py_compile mcp/run.py mcp/ambience_preview/ops.py mcp/ambience_preview/cli.py mcp/ambience_preview/mcp_server.py
- go run github.com/rhysd/actionlint/cmd/actionlint@latest -ignore '.*ambience-issue-agents.*'
- helm template pr-preview chart/ambience --set image.tag=test --set domain.host=pr-123.ambience.dev.romaine.life --set domain.tlsSecretName=ambience-pr-123-tls --set route.enabled=true --set certificate.enabled=true --set gateway.listenerSetEnabled=true
