### PR TITLE
Harden ARC issue runners against disk pressure

### DIFF
--- a/.github/runner/Dockerfile
+++ b/.github/runner/Dockerfile
@@ -2,19 +2,36 @@ FROM ghcr.io/actions/actions-runner:latest
 
 USER root
 
+ENV DEBIAN_FRONTEND=noninteractive \
+    PLAYWRIGHT_BROWSERS_PATH=/ms-playwright \
+    PLAYWRIGHT_PACKAGE_PATH=/opt/ambience-agent/node_modules/playwright/index.mjs
+
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         ca-certificates \
         curl \
         git \
+        gnupg \
         jq \
         sudo \
         unzip \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends nodejs \
     && rm -rf /var/lib/apt/lists/*
 
 RUN echo "runner ALL=(ALL) NOPASSWD:ALL" >/etc/sudoers.d/runner \
     && chmod 0440 /etc/sudoers.d/runner
 
 RUN curl -sL https://aka.ms/InstallAzureCLIDeb | bash
+
+RUN npm install -g @openai/codex \
+    && mkdir -p /opt/ambience-agent \
+    && npm install --prefix /opt/ambience-agent playwright \
+    && npx --prefix /opt/ambience-agent playwright install --with-deps chromium \
+    && npm cache clean --force \
+    && rm -rf /root/.npm /opt/ambience-agent/.cache
 
 USER runner

--- a/.github/workflows/codex-issue-agent.yml
+++ b/.github/workflows/codex-issue-agent.yml
@@ -39,6 +39,8 @@ jobs:
       FINAL_MESSAGE_FILE: .github/codex/output/final-message.md
       RUN_LOG_FILE: .github/codex/output/run.jsonl
       PROGRESS_LOG_FILE: .github/codex/output/progress.log
+      PLAYWRIGHT_BROWSERS_PATH: /ms-playwright
+      PLAYWRIGHT_PACKAGE_PATH: /opt/ambience-agent/node_modules/playwright/index.mjs
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -226,12 +228,6 @@ jobs:
             exit 1
           fi
 
-      - name: Set up Node.js
-        if: steps.issue.outputs.should_run == 'true'
-        uses: actions/setup-node@v4
-        with:
-          node-version: "22"
-
       - name: Set up Go
         if: steps.issue.outputs.should_run == 'true'
         uses: actions/setup-go@v5
@@ -251,13 +247,6 @@ jobs:
       - name: Set up Helm
         if: steps.issue.outputs.should_run == 'true'
         uses: azure/setup-helm@v4
-
-      - name: Install Codex and Playwright packages
-        if: steps.issue.outputs.should_run == 'true'
-        run: |
-          set -euo pipefail
-          npm install --no-save @openai/codex playwright
-          npx playwright install --with-deps chromium || npx playwright install chromium
 
       - name: Install ambience preview MCP package
         if: steps.issue.outputs.should_run == 'true'
@@ -345,7 +334,7 @@ jobs:
         run: |
           set -euo pipefail
           prompt="$(cat .github/codex/prompts/issue-implementation.md)"
-          cat "$ISSUE_CONTEXT_FILE" | npx codex exec \
+          cat "$ISSUE_CONTEXT_FILE" | codex exec \
             --ephemeral \
             --sandbox danger-full-access \
             --full-auto \

--- a/.github/workflows/codex-issue-agent.yml
+++ b/.github/workflows/codex-issue-agent.yml
@@ -473,7 +473,7 @@ jobs:
           if-no-files-found: warn
 
       - name: Tear down ephemeral environment
-        if: always() && steps.issue.outputs.should_run == 'true'
+        if: always() && steps.issue.outputs.should_run == 'true' && env.EPHEMERAL_NAMESPACE != ''
         env:
           EPHEMERAL_NAMESPACE: ${{ env.EPHEMERAL_NAMESPACE }}
           EPHEMERAL_RELEASE: ${{ env.EPHEMERAL_RELEASE }}

--- a/docs/agentic-issue-flow.md
+++ b/docs/agentic-issue-flow.md
@@ -68,11 +68,15 @@ Build and push it with the manual workflow:
 
 - `Build Agent Runner Image`
 
-That image intentionally stays small. The job still installs `@openai/codex` and `playwright` at runtime, but the image provides:
+That image now preinstalls the heavy runtime tooling so issue jobs do less work on every ephemeral runner start. It provides:
 
 - Azure CLI
-- `sudo` so `playwright install --with-deps chromium` can succeed on Linux runners
+- Node.js 22
+- `@openai/codex`
+- Playwright plus Chromium
 - the standard GitHub runner base
+
+The runner scale-set values now also declare `ephemeral-storage` requests and limits so runner pods are less likely to be evicted under disk pressure.
 
 ## ARC scale set
 

--- a/k8s/arc/values-issue-agents.yaml
+++ b/k8s/arc/values-issue-agents.yaml
@@ -10,13 +10,15 @@ template:
   spec:
     containers:
       - name: runner
-        image: romainecr.azurecr.io/ambience-agent-runner:issue-agents-20260423221714
+        image: romainecr.azurecr.io/ambience-agent-runner:issue-agents-20260424001818
         command:
           - /home/runner/run.sh
         resources:
           requests:
             cpu: "1000m"
             memory: "2Gi"
+            ephemeral-storage: "4Gi"
           limits:
             cpu: "4000m"
             memory: "8Gi"
+            ephemeral-storage: "8Gi"

--- a/scripts/agent/capture-screenshot.mjs
+++ b/scripts/agent/capture-screenshot.mjs
@@ -1,5 +1,11 @@
 import path from "node:path";
-import { chromium } from "playwright";
+import { pathToFileURL } from "node:url";
+
+const playwrightModule =
+  process.env.PLAYWRIGHT_PACKAGE_PATH
+    ? pathToFileURL(process.env.PLAYWRIGHT_PACKAGE_PATH).href
+    : "playwright";
+const { chromium } = await import(playwrightModule);
 
 function readArg(flag, fallback = "") {
   const index = process.argv.indexOf(flag);


### PR DESCRIPTION
## Summary
- preinstall Codex, Playwright, and Chromium in the ARC runner image and use the baked-in tooling from the issue workflow
- add explicit ephemeral-storage requests and limits for issue runner pods
- point the screenshot helper at the image-baked Playwright package path and guard cleanup when setup fails before a namespace exists

## Validation
- go run github.com/rhysd/actionlint/cmd/actionlint@latest -ignore '.*ambience-issue-agents.*'
- node --check scripts/agent/capture-screenshot.mjs
- dynamic import smoke test for the Playwright package path override
- az acr build for romainecr.azurecr.io/ambience-agent-runner:issue-agents-20260424001818
- live ARC scale-set rollout in arc-runners-ambience-issue-agents
- manual issue workflow dispatch from this branch advanced past the prior runner disconnect and reached Azure OIDC auth, which is expected to fail on a branch-only workflow_dispatch subject
