### PR TITLE
Support OPENAI_API_KEY in Codex issue workflow

### DIFF
--- a/.github/workflows/codex-issue-agent.yml
+++ b/.github/workflows/codex-issue-agent.yml
@@ -201,7 +201,7 @@ jobs:
       - name: Validate job configuration
         if: steps.issue.outputs.should_run == 'true'
         env:
-          CODEX_API_KEY: ${{ secrets.CODEX_API_KEY }}
+          CODEX_API_KEY: ${{ secrets.OPENAI_API_KEY != '' && secrets.OPENAI_API_KEY || secrets.CODEX_API_KEY }}
           ARM_CLIENT_ID: ${{ vars.ARM_CLIENT_ID }}
           ARM_TENANT_ID: ${{ vars.ARM_TENANT_ID }}
           ARM_SUBSCRIPTION_ID: ${{ vars.ARM_SUBSCRIPTION_ID }}
@@ -320,7 +320,7 @@ jobs:
       - name: Run Codex implementation loop
         if: steps.issue.outputs.should_run == 'true'
         env:
-          CODEX_API_KEY: ${{ secrets.CODEX_API_KEY }}
+          CODEX_API_KEY: ${{ secrets.OPENAI_API_KEY != '' && secrets.OPENAI_API_KEY || secrets.CODEX_API_KEY }}
           ISSUE_NUMBER: ${{ steps.issue.outputs.issue_number }}
           ISSUE_TITLE: ${{ steps.issue.outputs.issue_title }}
           ISSUE_URL: ${{ steps.issue.outputs.issue_url }}

--- a/docs/agentic-issue-flow.md
+++ b/docs/agentic-issue-flow.md
@@ -49,7 +49,7 @@ If the variable is unset, the workflow falls back to `["codex:run"]`. The workfl
 
 Secrets:
 
-- `CODEX_API_KEY`: OpenAI API key used by `codex exec`
+- `OPENAI_API_KEY` or `CODEX_API_KEY`: OpenAI API key used by `codex exec`
 - `CODEX_GH_TOKEN`: optional PAT or GitHub App token used when opening PRs; if omitted the workflow falls back to `GITHUB_TOKEN`
 
 Variables:


### PR DESCRIPTION
## Summary
- let the issue automation read OPENAI_API_KEY before falling back to CODEX_API_KEY
- keep the existing CODEX_API_KEY path working
- update the ops doc to reflect both supported secret names

## Validation
- go run github.com/rhysd/actionlint/cmd/actionlint@latest -ignore '.*ambience-issue-agents.*'