### PR TITLE
Load Codex API key from Azure Key Vault

### DIFF
--- a/.github/workflows/codex-issue-agent.yml
+++ b/.github/workflows/codex-issue-agent.yml
@@ -201,21 +201,21 @@ jobs:
       - name: Validate job configuration
         if: steps.issue.outputs.should_run == 'true'
         env:
-          CODEX_API_KEY: ${{ secrets.OPENAI_API_KEY != '' && secrets.OPENAI_API_KEY || secrets.CODEX_API_KEY }}
           ARM_CLIENT_ID: ${{ vars.ARM_CLIENT_ID }}
           ARM_TENANT_ID: ${{ vars.ARM_TENANT_ID }}
           ARM_SUBSCRIPTION_ID: ${{ vars.ARM_SUBSCRIPTION_ID }}
           AZURE_AKS_RESOURCE_GROUP: ${{ vars.AZURE_AKS_RESOURCE_GROUP }}
           AZURE_AKS_CLUSTER_NAME: ${{ vars.AZURE_AKS_CLUSTER_NAME }}
+          KEY_VAULT_NAME: ${{ vars.KEY_VAULT_NAME }}
         run: |
           set -euo pipefail
           required_vars=(
-            CODEX_API_KEY
             ARM_CLIENT_ID
             ARM_TENANT_ID
             ARM_SUBSCRIPTION_ID
             AZURE_AKS_RESOURCE_GROUP
             AZURE_AKS_CLUSTER_NAME
+            KEY_VAULT_NAME
           )
           missing=()
           for name in "${required_vars[@]}"; do
@@ -287,6 +287,30 @@ jobs:
           client-id: ${{ vars.ARM_CLIENT_ID }}
           tenant-id: ${{ vars.ARM_TENANT_ID }}
           subscription-id: ${{ vars.ARM_SUBSCRIPTION_ID }}
+
+      - name: Load Codex API key
+        if: steps.issue.outputs.should_run == 'true'
+        env:
+          KEY_VAULT_NAME: ${{ vars.KEY_VAULT_NAME }}
+          FALLBACK_CODEX_API_KEY: ${{ secrets.OPENAI_API_KEY != '' && secrets.OPENAI_API_KEY || secrets.CODEX_API_KEY }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          codex_api_key="$(az keyvault secret show \
+              --vault-name "$KEY_VAULT_NAME" \
+              --name openai-api-key \
+              --query value \
+              -o tsv \
+              2>/dev/null || true)"
+          if [ -z "$codex_api_key" ]; then
+            codex_api_key="${FALLBACK_CODEX_API_KEY:-}"
+          fi
+          if [ -z "$codex_api_key" ]; then
+            echo "Unable to load a Codex API key from GitHub Actions secrets or Azure Key Vault secret 'openai-api-key'." >&2
+            exit 1
+          fi
+          echo "::add-mask::$codex_api_key"
+          printf 'CODEX_API_KEY=%s\n' "$codex_api_key" >> "$GITHUB_ENV"
 
       - name: Set AKS context
         if: steps.issue.outputs.should_run == 'true'

--- a/docs/agentic-issue-flow.md
+++ b/docs/agentic-issue-flow.md
@@ -49,7 +49,7 @@ If the variable is unset, the workflow falls back to `["codex:run"]`. The workfl
 
 Secrets:
 
-- `OPENAI_API_KEY` or `CODEX_API_KEY`: OpenAI API key used by `codex exec`
+- `OPENAI_API_KEY` or `CODEX_API_KEY`: optional fallback OpenAI API key used by `codex exec`
 - `CODEX_GH_TOKEN`: optional PAT or GitHub App token used when opening PRs; if omitted the workflow falls back to `GITHUB_TOKEN`
 
 Variables:
@@ -59,6 +59,9 @@ Variables:
 - `ARM_SUBSCRIPTION_ID`
 - `AZURE_AKS_RESOURCE_GROUP`
 - `AZURE_AKS_CLUSTER_NAME`
+- `KEY_VAULT_NAME`
+
+The workflow loads the API key from Azure Key Vault secret `openai-api-key` after OIDC login. If that lookup fails or you need an override, it falls back to the GitHub Actions secrets `OPENAI_API_KEY` and then `CODEX_API_KEY`.
 
 ## Runner image
 


### PR DESCRIPTION
## Summary
- load the Codex API key from Azure Key Vault secret openai-api-key after OIDC login
- keep OPENAI_API_KEY and CODEX_API_KEY as fallback GitHub Actions secrets
- document KEY_VAULT_NAME and the new source order

## Validation
- go run github.com/rhysd/actionlint/cmd/actionlint@latest -ignore '.*ambience-issue-agents.*'