### PR TITLE
Remove GitHub secrets from issue agent flow

### DIFF
--- a/.github/workflows/codex-issue-agent.yml
+++ b/.github/workflows/codex-issue-agent.yml
@@ -292,7 +292,6 @@ jobs:
         if: steps.issue.outputs.should_run == 'true'
         env:
           KEY_VAULT_NAME: ${{ vars.KEY_VAULT_NAME }}
-          FALLBACK_CODEX_API_KEY: ${{ secrets.OPENAI_API_KEY != '' && secrets.OPENAI_API_KEY || secrets.CODEX_API_KEY }}
         shell: bash
         run: |
           set -euo pipefail
@@ -303,10 +302,7 @@ jobs:
               -o tsv \
               2>/dev/null || true)"
           if [ -z "$codex_api_key" ]; then
-            codex_api_key="${FALLBACK_CODEX_API_KEY:-}"
-          fi
-          if [ -z "$codex_api_key" ]; then
-            echo "Unable to load a Codex API key from GitHub Actions secrets or Azure Key Vault secret 'openai-api-key'." >&2
+            echo "Unable to load a Codex API key from Azure Key Vault secret 'openai-api-key'." >&2
             exit 1
           fi
           echo "::add-mask::$codex_api_key"
@@ -344,7 +340,6 @@ jobs:
       - name: Run Codex implementation loop
         if: steps.issue.outputs.should_run == 'true'
         env:
-          CODEX_API_KEY: ${{ secrets.OPENAI_API_KEY != '' && secrets.OPENAI_API_KEY || secrets.CODEX_API_KEY }}
           ISSUE_NUMBER: ${{ steps.issue.outputs.issue_number }}
           ISSUE_TITLE: ${{ steps.issue.outputs.issue_title }}
           ISSUE_URL: ${{ steps.issue.outputs.issue_url }}
@@ -441,7 +436,7 @@ jobs:
         id: cpr
         uses: peter-evans/create-pull-request@v8
         with:
-          token: ${{ secrets.CODEX_GH_TOKEN != '' && secrets.CODEX_GH_TOKEN || github.token }}
+          token: ${{ github.token }}
           branch: ${{ steps.issue.outputs.branch_name }}
           base: ${{ steps.issue.outputs.default_branch }}
           commit-message: "Codex: address issue #${{ steps.issue.outputs.issue_number }}"

--- a/docs/agentic-issue-flow.md
+++ b/docs/agentic-issue-flow.md
@@ -47,11 +47,6 @@ If the variable is unset, the workflow falls back to `["codex:run"]`. The workfl
 
 ## Required GitHub secrets and variables
 
-Secrets:
-
-- `OPENAI_API_KEY` or `CODEX_API_KEY`: optional fallback OpenAI API key used by `codex exec`
-- `CODEX_GH_TOKEN`: optional PAT or GitHub App token used when opening PRs; if omitted the workflow falls back to `GITHUB_TOKEN`
-
 Variables:
 
 - `ARM_CLIENT_ID`
@@ -61,7 +56,7 @@ Variables:
 - `AZURE_AKS_CLUSTER_NAME`
 - `KEY_VAULT_NAME`
 
-The workflow loads the API key from Azure Key Vault secret `openai-api-key` after OIDC login. If that lookup fails or you need an override, it falls back to the GitHub Actions secrets `OPENAI_API_KEY` and then `CODEX_API_KEY`.
+The workflow loads the API key only from Azure Key Vault secret `openai-api-key` after OIDC login, and it uses the built-in `GITHUB_TOKEN` for pull request operations.
 
 ## Runner image
 


### PR DESCRIPTION
## Summary
- remove GitHub Actions secret usage from the issue agent workflow
- load the Codex API key only from Azure Key Vault secret openai-api-key
- rely on the built-in GITHUB_TOKEN for PR creation

## Validation
- go run github.com/rhysd/actionlint/cmd/actionlint@latest -ignore '.*ambience-issue-agents.*'