### PR TITLE
Add buffered ambience client playback

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,19 @@
 # ambience
 
-Shared-world ambient pixel-art effects. A 10 Hz server decides when
-discrete events fire (downpour, calm, gust, splash) and broadcasts those
-as commands via SSE; every consumer (browser canvas, terminal sixel)
-runs its own sim replica and applies the commands in sync. Rain is the
-only effect in the shared live world today; Fireflies, Waterfall, and
-Dust are available in isolated dev sessions.
+Shared-world ambient pixel-art effects. A 10 Hz server decides which
+effect is active, which scene/config is current, and when discrete
+events fire, then broadcasts those commands via SSE; every consumer
+(browser canvas, terminal sixel) runs its own sim replica and applies
+the commands in sync.
+
+The long-term target is clock-like lock-step rendering across consumers:
+if `ambience.romaine.life` is open on one machine and a subscriber such
+as `homepage.romaine.life` is open on another, they should appear to be
+displaying the same shared world at the same moment, modulo ordinary
+network and browser scheduling jitter. The server still avoids streaming
+raw pixels; the engineering challenge is keeping semantic snapshots,
+ticks, RNG state, scene transitions, and client replay tight enough that
+subscribers feel synchronized rather than merely thematically similar.
 
 Canonical live view: <https://ambience.romaine.life>.
 
@@ -96,8 +104,9 @@ scripts/dev-loop.ps1
 ## Atmosphere model
 
 The server does not broadcast pixel frames. Each atmosphere is a
-server-side sim running at 10 Hz whose job is to decide when discrete
-events fire. Clients run their own sims locally and apply five kinds of
+server-side sim running at 10 Hz whose job is to choose the active
+effect, own scene/config transitions, and decide when discrete events
+fire. Clients run their own sims locally and apply five kinds of
 commands:
 
 - **`snapshot`** — state dump on connect. The outer envelope is
@@ -110,9 +119,12 @@ commands:
 - **`scene`** — scene rotation metadata for the live monitor.
 - **`metric`** — entropy and scene-progress heartbeat data.
 
-Clients do not roll for discrete events — only the server does. Each
-client's RNG drifts from the server's after the initial snapshot, but
-event timing stays in sync.
+Clients do not roll for discrete events — only the server does. The goal
+is for clients to treat the authority stream like a clock signal: restore
+from snapshots, advance by authoritative ticks, and converge on the same
+visible phase after reconnects or effect changes. Any client-side RNG
+use should be deterministic from authority-provided state or limited to
+visual details that do not make subscribers visibly diverge.
 
 ## Effects model
 
@@ -125,11 +137,13 @@ Every effect fills a 5-slot template — see
 4. **Event modifiers** — per-event randomization
 5. **End conditions** — natural conclusions (optional)
 
-New effects plug in via the `AmbienceSim.effects` registry in `sim.js`.
-Browser clients look up the constructor by the `type` the server
-broadcasts — so adding Sand / Fire / Tetris is a sim-side change with
-no consumer-side update. The `/dev` page reads the same registry to
-switch effects without page-specific wiring.
+New effects plug in via per-effect files under `cmd/ambience/web/effects/`.
+The server bundles those files into `/sim.js`, and browser clients look
+up the constructor by the `type` the server broadcasts. Consumer pages
+that vendor the scripts, such as `my-homepage`, must refresh the vendored
+bundle whenever the shared sim/client changes so they remain full
+subscribers to every live effect. The `/dev` page reads the same registry
+to switch effects without page-specific wiring.
 
 For backlog candidates not yet promoted to their own implementation
 issue, see [`docs/effect-candidates.md`](docs/effect-candidates.md) —
@@ -156,6 +170,11 @@ clone their exact engine.
 - Prefer stable control seams over effect-specific special cases. New
   effects should plug into the registry, schema, snapshot/restore, and
   trigger paths instead of requiring consumer-specific wiring.
+- Treat cross-consumer synchronization as a product goal, not a best
+  effort side effect. Effect implementations should preserve enough
+  state in snapshots and deterministic replay paths that independent
+  clients can render the same phase of the same scene like synchronized
+  clocks.
 
 ## Entropy
 

--- a/cmd/ambience/web/client.js
+++ b/cmd/ambience/web/client.js
@@ -14,6 +14,7 @@
 //   data-ambience-grid-w="200" / data-ambience-grid-h="100" — sim grid size
 //   data-ambience-transparent="false"  — paint solid bg (default: true)
 //   data-ambience-entropy="off"        — disable keystroke entropy upload
+//   data-ambience-delay-ticks="50"     — render this many 10 Hz ticks behind authority
 //
 // Effect agnostic: the server's snapshot broadcasts the effect type; this
 // file looks it up in AmbienceSim.effects[type]. Adding a new effect means
@@ -42,6 +43,11 @@
 	const GRID_H = parseInt(canvas.dataset.ambienceGridH || '100', 10);
 	const TRANSPARENT = canvas.dataset.ambienceTransparent !== 'false';
 	const ENTROPY_ENABLED = canvas.dataset.ambienceEntropy !== 'off';
+	const TICK_MS = 100;
+	const PLAYBACK_DELAY_TICKS = Math.max(0, parseInt(canvas.dataset.ambienceDelayTicks || '50', 10) || 0);
+	const MAX_CATCHUP_STEPS = 5;
+	const SOFT_CATCHUP_DRIFT = 20;
+	const HARD_CATCHUP_DRIFT = 100;
 
 	const ctx = canvas.getContext('2d');
 
@@ -63,16 +69,75 @@
 	let effectType = 'rain';
 	let sim = new AmbienceSim.effects[effectType](GRID_W, GRID_H, {});
 	let ready = false;
+	let authoritySampleTick = 0;
+	let authoritySampleAt = performance.now();
+	let haveAuthoritySample = false;
+	const pendingCommands = [];
 
-	// Patch the subscribe snapshot handler so we can detect effect-type
-	// changes (for when more effects ship). The shared subscribe() swaps
-	// config on the existing sim; a type switch crossfades the outgoing
-	// effect into the incoming one via AmbienceSim.EffectTransition.
-	const es = new EventSource(SERVER.replace(/\/+$/, '') + '/events');
-	es.addEventListener('message', (e) => {
-		let cmd;
-		try { cmd = JSON.parse(e.data); } catch (_) { return; }
-		const data = typeof cmd.data === 'string' ? JSON.parse(cmd.data) : cmd.data;
+	function noteAuthorityTick(tick) {
+		if (!Number.isFinite(tick)) return;
+		authoritySampleTick = tick;
+		authoritySampleAt = performance.now();
+		haveAuthoritySample = true;
+	}
+
+	function estimatedAuthorityTick() {
+		if (!haveAuthoritySample) return getSimTick(sim);
+		const elapsedTicks = Math.floor((performance.now() - authoritySampleAt) / TICK_MS);
+		return authoritySampleTick + Math.max(0, elapsedTicks);
+	}
+
+	function targetPlaybackTick() {
+		return Math.max(0, estimatedAuthorityTick() - PLAYBACK_DELAY_TICKS);
+	}
+
+	function getSimTick(s) {
+		if (!s) return 0;
+		if (s.isTransition && s.incoming) return getSimTick(s.incoming);
+		return Number.isFinite(s.tick) ? s.tick : 0;
+	}
+
+	function stepTowardAuthorityClock() {
+		const current = getSimTick(sim);
+		const target = targetPlaybackTick();
+		const drift = target - current;
+		if (drift <= 0) {
+			applyDueCommands(current);
+			return;
+		}
+		let steps = 1;
+		if (drift > HARD_CATCHUP_DRIFT) {
+			steps = MAX_CATCHUP_STEPS;
+		} else if (drift > SOFT_CATCHUP_DRIFT) {
+			steps = Math.min(MAX_CATCHUP_STEPS, 2);
+		}
+		for (let i = 0; i < steps; i++) {
+			applyDueCommands(getSimTick(sim) + 1);
+			sim.step();
+		}
+		applyDueCommands(getSimTick(sim));
+	}
+
+	function queueCommand(cmd, data) {
+		pendingCommands.push({ cmd, data });
+		pendingCommands.sort((a, b) => {
+			const at = Number.isFinite(a.cmd.tick) ? a.cmd.tick : 0;
+			const bt = Number.isFinite(b.cmd.tick) ? b.cmd.tick : 0;
+			return at - bt;
+		});
+	}
+
+	function applyDueCommands(playbackTick) {
+		while (pendingCommands.length > 0) {
+			const item = pendingCommands[0];
+			const tick = Number.isFinite(item.cmd.tick) ? item.cmd.tick : playbackTick;
+			if (tick > playbackTick) return;
+			pendingCommands.shift();
+			applyCommandNow(item.cmd, item.data);
+		}
+	}
+
+	function applyCommandNow(cmd, data) {
 		switch (cmd.kind) {
 			case 'snapshot': {
 				const newType = (data && data.type) || 'rain';
@@ -101,13 +166,41 @@
 				if (sim.triggerEvent) sim.triggerEvent(cmd.event);
 				break;
 		}
+	}
+
+	// Patch the subscribe snapshot handler so we can detect effect-type
+	// changes (for when more effects ship). The shared subscribe() swaps
+	// config on the existing sim; a type switch crossfades the outgoing
+	// effect into the incoming one via AmbienceSim.EffectTransition.
+	const es = new EventSource(SERVER.replace(/\/+$/, '') + '/events');
+	es.addEventListener('message', (e) => {
+		let cmd;
+		try { cmd = JSON.parse(e.data); } catch (_) { return; }
+		noteAuthorityTick(cmd.tick);
+		const data = typeof cmd.data === 'string' ? JSON.parse(cmd.data) : cmd.data;
+		switch (cmd.kind) {
+			case 'snapshot':
+				if (!ready) {
+					applyCommandNow(cmd, data);
+				} else {
+					queueCommand(cmd, data);
+				}
+				break;
+			case 'metric':
+			case 'scene':
+				break;
+			case 'config':
+			case 'trigger':
+				queueCommand(cmd, data);
+				break;
+		}
 	});
 
 	// Combined 10 Hz tick (matches server atmosphere rate). Step + render
 	// in one setInterval — rAF pauses in background tabs and we don't need
 	// 60 Hz for a 10 Hz sim.
 	setInterval(() => {
-		if (ready) sim.step();
+		if (ready) stepTowardAuthorityClock();
 		// Unwrap a finished crossfade so we drop the outgoing sim and stop
 		// paying its render cost.
 		if (sim.isTransition && sim.done()) sim = sim.incoming;


### PR DESCRIPTION
## Summary
- make the browser client seek a delayed authority playback tick instead of free-running immediately
- queue snapshot/config/trigger commands by authority tick before applying them
- document the cross-consumer lock-step goal and sparse timeline constraints

## Checks
- `node --check cmd/ambience/web/client.js`
- `node --check cmd/ambience/web/sim.js`
- bundled effect registry load check: 22 effects including `windmill`
- `git diff --check`

Go tests were not run locally because `go` is not installed in this pod.