### PR TITLE
Add authority clock telemetry for clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,10 @@ commands:
 - **`trigger`** — a discrete event fired; clients apply its effects.
 - **`scene`** — scene rotation metadata for the live monitor.
 - **`metric`** — entropy and scene-progress heartbeat data.
+- **`clock`** — sparse authority tick samples. Clients use these like a
+  clock signal and render behind the authority by a small delay buffer, so
+  independent consumers can seek the same playback tick without streaming
+  dense per-frame state.
 
 Clients do not roll for discrete events — only the server does. The goal
 is for clients to treat the authority stream like a clock signal: restore
@@ -125,6 +129,12 @@ from snapshots, advance by authoritative ticks, and converge on the same
 visible phase after reconnects or effect changes. Any client-side RNG
 use should be deterministic from authority-provided state or limited to
 visual details that do not make subscribers visibly diverge.
+
+The browser client exposes `window.AmbienceClient.getDebugState()` when it
+is running. That returns the estimated authority tick, delayed playback
+tick, local sim tick, drift, queue depth, and active effect type; use it to
+compare `ambience.romaine.life` with subscribers such as
+`homepage.romaine.life` without adding transport volume.
 
 ## Effects model
 

--- a/cmd/ambience/atmosphere.go
+++ b/cmd/ambience/atmosphere.go
@@ -33,6 +33,7 @@ const (
 	maxTransitionTicks       = 600 // 60 s at 10 Hz
 	transitionBroadcastEvery = 10  // every 1 s during drift
 	metricBroadcastEvery     = 50  // every 5 s as a low-rate heartbeat
+	clockBroadcastEvery      = 10  // every 1 s; sparse authority-clock samples
 )
 
 // Command is a single message sent from server to clients.
@@ -43,6 +44,7 @@ const (
 //	"trigger"   an event fired (downpour/calm/gust/splash)
 //	"scene"     scene rotated; carries new name + duration + next-up name
 //	"metric"    periodic status beat (entropy bytes, scene remaining)
+//	"clock"     sparse authority-clock sample for delayed client playback
 type Command struct {
 	ID    string          `json:"-"`
 	Kind  string          `json:"kind"`
@@ -73,6 +75,12 @@ type snapshotData struct {
 	NextScene      Scene `json:"nextScene"`
 	EntropyBytes   int64 `json:"entropyBytes"`
 	SceneRemaining int   `json:"sceneRemaining"`
+}
+
+type clockData struct {
+	Tick                int `json:"tick"`
+	TickRateMs          int `json:"tickRateMs"`
+	SuggestedDelayTicks int `json:"suggestedDelayTicks"`
 }
 
 type atmosphere struct {
@@ -158,8 +166,8 @@ func newAtmosphereWithEffectAndSeed(effectType string, seed int64) *atmosphere {
 //     next → current, generate new next, start a fresh transition
 //  4. drain sim log → broadcast trigger commands for fired events
 //
-// No periodic metric broadcast — that's event-driven now, fired from
-// AddEntropy and rotateScene.
+// The run loop also emits low-rate clock and metric heartbeats so browsers
+// can maintain delayed playback without a dense stream of pixel frames.
 func (a *atmosphere) run(ctx context.Context) {
 	t := time.NewTicker(tickRate)
 	defer t.Stop()
@@ -184,6 +192,9 @@ func (a *atmosphere) run(ctx context.Context) {
 			// supersedes the regenerated rain scene anyway.
 			if a.maybeRotateEffect(cur) {
 				cur = a.effect.CurrentTick()
+			}
+			if cur%clockBroadcastEvery == 0 {
+				a.broadcastClock(cur)
 			}
 			if cur%metricBroadcastEvery == 0 {
 				a.broadcastMetric(cur)
@@ -375,6 +386,15 @@ func (a *atmosphere) rotateToEffect(cur int, effectType string) bool {
 	a.broadcastMetric(0)
 	log.Printf("rotation: shared effect %s -> %s (tick %d)", previousType, effectType, cur)
 	return true
+}
+
+func (a *atmosphere) broadcastClock(tick int) {
+	data, _ := json.Marshal(clockData{
+		Tick:                tick,
+		TickRateMs:          int(tickRate / time.Millisecond),
+		SuggestedDelayTicks: 50,
+	})
+	a.broadcast(Command{Kind: "clock", Tick: tick, Data: data})
 }
 
 // broadcastMetric pushes the current entropy total + scene progress. Called

--- a/cmd/ambience/web/client.js
+++ b/cmd/ambience/web/client.js
@@ -23,6 +23,66 @@
 (function () {
 	'use strict';
 
+	function createPlaybackClock(opts) {
+		opts = opts || {};
+		const now = opts.now || (() => performance.now());
+		const tickMs = Math.max(1, opts.tickMs || 100);
+		const delayTicks = Math.max(0, opts.delayTicks || 0);
+		const softCatchupDrift = Math.max(1, opts.softCatchupDrift || 20);
+		const hardCatchupDrift = Math.max(softCatchupDrift, opts.hardCatchupDrift || 100);
+		const maxCatchupSteps = Math.max(1, opts.maxCatchupSteps || 5);
+		let authoritySampleTick = 0;
+		let authoritySampleAt = now();
+		let haveAuthoritySample = false;
+
+		function noteAuthorityTick(tick, sampleAt) {
+			if (!Number.isFinite(tick)) return;
+			authoritySampleTick = tick;
+			authoritySampleAt = Number.isFinite(sampleAt) ? sampleAt : now();
+			haveAuthoritySample = true;
+		}
+
+		function estimatedAuthorityTick(fallbackTick) {
+			if (!haveAuthoritySample) return Number.isFinite(fallbackTick) ? fallbackTick : 0;
+			const elapsedTicks = Math.floor((now() - authoritySampleAt) / tickMs);
+			return authoritySampleTick + Math.max(0, elapsedTicks);
+		}
+
+		function targetPlaybackTick(fallbackTick) {
+			return Math.max(0, estimatedAuthorityTick(fallbackTick) - delayTicks);
+		}
+
+		function stepsFor(currentTick) {
+			const current = Number.isFinite(currentTick) ? currentTick : 0;
+			const target = targetPlaybackTick(current);
+			const drift = target - current;
+			if (drift <= 0) return 0;
+			if (drift > hardCatchupDrift) return maxCatchupSteps;
+			if (drift > softCatchupDrift) return Math.min(maxCatchupSteps, 2);
+			return 1;
+		}
+
+		function debugState(currentTick, queuedCommands) {
+			const current = Number.isFinite(currentTick) ? currentTick : 0;
+			const authorityTick = estimatedAuthorityTick(current);
+			const playbackTick = targetPlaybackTick(current);
+			return {
+				authorityTick,
+				playbackTick,
+				simTick: current,
+				driftTicks: playbackTick - current,
+				delayTicks,
+				tickMs,
+				queuedCommands: queuedCommands || 0,
+				haveAuthoritySample,
+			};
+		}
+
+		return { noteAuthorityTick, estimatedAuthorityTick, targetPlaybackTick, stepsFor, debugState };
+	}
+
+	window.AmbienceClientClock = window.AmbienceClientClock || { createPlaybackClock };
+
 	const canvas = document.querySelector('canvas[data-ambience]');
 	if (!canvas) {
 		console.warn('ambience-client: no <canvas data-ambience> found');
@@ -69,27 +129,14 @@
 	let effectType = 'rain';
 	let sim = new AmbienceSim.effects[effectType](GRID_W, GRID_H, {});
 	let ready = false;
-	let authoritySampleTick = 0;
-	let authoritySampleAt = performance.now();
-	let haveAuthoritySample = false;
 	const pendingCommands = [];
-
-	function noteAuthorityTick(tick) {
-		if (!Number.isFinite(tick)) return;
-		authoritySampleTick = tick;
-		authoritySampleAt = performance.now();
-		haveAuthoritySample = true;
-	}
-
-	function estimatedAuthorityTick() {
-		if (!haveAuthoritySample) return getSimTick(sim);
-		const elapsedTicks = Math.floor((performance.now() - authoritySampleAt) / TICK_MS);
-		return authoritySampleTick + Math.max(0, elapsedTicks);
-	}
-
-	function targetPlaybackTick() {
-		return Math.max(0, estimatedAuthorityTick() - PLAYBACK_DELAY_TICKS);
-	}
+	const clock = createPlaybackClock({
+		tickMs: TICK_MS,
+		delayTicks: PLAYBACK_DELAY_TICKS,
+		softCatchupDrift: SOFT_CATCHUP_DRIFT,
+		hardCatchupDrift: HARD_CATCHUP_DRIFT,
+		maxCatchupSteps: MAX_CATCHUP_STEPS,
+	});
 
 	function getSimTick(s) {
 		if (!s) return 0;
@@ -99,17 +146,10 @@
 
 	function stepTowardAuthorityClock() {
 		const current = getSimTick(sim);
-		const target = targetPlaybackTick();
-		const drift = target - current;
-		if (drift <= 0) {
+		const steps = clock.stepsFor(current);
+		if (steps <= 0) {
 			applyDueCommands(current);
 			return;
-		}
-		let steps = 1;
-		if (drift > HARD_CATCHUP_DRIFT) {
-			steps = MAX_CATCHUP_STEPS;
-		} else if (drift > SOFT_CATCHUP_DRIFT) {
-			steps = Math.min(MAX_CATCHUP_STEPS, 2);
 		}
 		for (let i = 0; i < steps; i++) {
 			applyDueCommands(getSimTick(sim) + 1);
@@ -176,7 +216,7 @@
 	es.addEventListener('message', (e) => {
 		let cmd;
 		try { cmd = JSON.parse(e.data); } catch (_) { return; }
-		noteAuthorityTick(cmd.tick);
+		clock.noteAuthorityTick(cmd.tick);
 		const data = typeof cmd.data === 'string' ? JSON.parse(cmd.data) : cmd.data;
 		switch (cmd.kind) {
 			case 'snapshot':
@@ -188,6 +228,7 @@
 				break;
 			case 'metric':
 			case 'scene':
+			case 'clock':
 				break;
 			case 'config':
 			case 'trigger':
@@ -195,6 +236,10 @@
 				break;
 		}
 	});
+
+	window.AmbienceClient = {
+		getDebugState: () => Object.assign({ effectType, ready }, clock.debugState(getSimTick(sim), pendingCommands.length)),
+	};
 
 	// Combined 10 Hz tick (matches server atmosphere rate). Step + render
 	// in one setInterval — rAF pauses in background tabs and we don't need

--- a/scripts/test-client-clock.mjs
+++ b/scripts/test-client-clock.mjs
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import vm from 'node:vm';
+
+const repoRoot = path.resolve(import.meta.dirname, '..');
+const clientPath = path.join(repoRoot, 'cmd', 'ambience', 'web', 'client.js');
+let now = 0;
+const context = {
+	console: {
+		warn() {},
+		error: console.error,
+	},
+	document: {
+		querySelector() {
+			return null;
+		},
+	},
+	performance: {
+		now() {
+			return now;
+		},
+	},
+	window: {},
+};
+context.window.window = context.window;
+
+vm.createContext(context);
+vm.runInContext(fs.readFileSync(clientPath, 'utf8'), context, { filename: clientPath });
+
+const createPlaybackClock = context.window.AmbienceClientClock?.createPlaybackClock;
+assert.equal(typeof createPlaybackClock, 'function');
+
+function makeClock() {
+	now = 0;
+	return createPlaybackClock({
+		tickMs: 100,
+		delayTicks: 50,
+		softCatchupDrift: 20,
+		hardCatchupDrift: 100,
+		maxCatchupSteps: 5,
+		now: () => now,
+	});
+}
+
+{
+	const clock = makeClock();
+	assert.equal(clock.estimatedAuthorityTick(12), 12);
+	assert.equal(clock.targetPlaybackTick(12), 0);
+	assert.equal(clock.stepsFor(12), 0);
+
+	clock.noteAuthorityTick(100);
+	assert.equal(clock.estimatedAuthorityTick(0), 100);
+	assert.equal(clock.targetPlaybackTick(0), 50);
+
+	now = 1000;
+	assert.equal(clock.estimatedAuthorityTick(0), 110);
+	assert.equal(clock.targetPlaybackTick(0), 60);
+	assert.equal(clock.stepsFor(60), 0);
+}
+
+{
+	const clock = makeClock();
+	clock.noteAuthorityTick(55);
+	assert.equal(clock.stepsFor(4), 1);
+}
+
+{
+	const clock = makeClock();
+	clock.noteAuthorityTick(80);
+	assert.equal(clock.stepsFor(5), 2);
+}
+
+{
+	const clock = makeClock();
+	clock.noteAuthorityTick(200);
+	assert.equal(clock.stepsFor(40), 5);
+}
+
+{
+	const clock = makeClock();
+	clock.noteAuthorityTick(100);
+	const state = JSON.parse(JSON.stringify(clock.debugState(45, 3)));
+	assert.deepEqual(state, {
+		authorityTick: 100,
+		playbackTick: 50,
+		simTick: 45,
+		driftTicks: 5,
+		delayTicks: 50,
+		tickMs: 100,
+		queuedCommands: 3,
+		haveAuthoritySample: true,
+	});
+}
+
+console.log('client playback clock ok');


### PR DESCRIPTION
## Summary
- broadcast sparse `clock` commands from the authority once per second
- extract the browser playback clock into a testable helper and expose debug state
- document the low-volume clock-sync contract for subscribers

## Verification
- `node scripts/test-client-clock.mjs`
- `node --check cmd/ambience/web/client.js`
- `node --check cmd/ambience/web/sim.js`
- bundled effect registry VM load check verified 22 effects including `windmill`
- `git diff --check`

`go test ./...` could not run in this pod because `go` is not installed.