### PR TITLE
Make initial ambience fade reliable

### DIFF
--- a/cmd/ambience/web/client.js
+++ b/cmd/ambience/web/client.js
@@ -146,12 +146,23 @@
 	function revealInitialScene() {
 		if (initialFadeStarted) return;
 		initialFadeStarted = true;
-		if (INITIAL_FADE_MS <= 0) return;
-		const opacityTransition = `opacity ${INITIAL_FADE_MS}ms ease`;
-		canvas.style.transition = canvas.style.transition
-			? `${canvas.style.transition}, ${opacityTransition}`
-			: opacityTransition;
-		requestAnimationFrame(() => { canvas.style.opacity = '1'; });
+		if (INITIAL_FADE_MS <= 0) {
+			canvas.style.opacity = '1';
+			return;
+		}
+		if (canvas.animate) {
+			const fade = canvas.animate(
+				[{ opacity: 0 }, { opacity: 1 }],
+				{ duration: INITIAL_FADE_MS, easing: 'ease', fill: 'both' },
+			);
+			fade.finished
+				.then(() => { canvas.style.opacity = '1'; })
+				.catch(() => { canvas.style.opacity = '1'; });
+			return;
+		}
+		canvas.style.transition = `opacity ${INITIAL_FADE_MS}ms ease`;
+		canvas.offsetWidth;
+		canvas.style.opacity = '1';
 	}
 
 	function getSimTick(s) {


### PR DESCRIPTION
## Summary
- use Web Animations API for the initial canvas fade after the first real authority render
- keep a forced-layout CSS transition fallback for browsers without `animate()`
- avoid depending on startup CSS transition timing, which could make the scene appear all at once

## Verification
- `node --check cmd/ambience/web/client.js`
- `node scripts/test-client-clock.mjs`
- `git diff --check`