### PR TITLE
Quote numeric ambience image tag

### DIFF
--- a/chart/ambience/values-prod.yaml
+++ b/chart/ambience/values-prod.yaml
@@ -3,7 +3,7 @@ domain:
   tlsSecretName: ambience-tls
 
 image:
-  tag: 4372696
+  tag: "4372696"
 
 edge:
   replicas: 2


### PR DESCRIPTION
## Summary
- quote the production image tag so Helm treats numeric-looking SHAs as strings
- unblocks the `4372696` rollout, which rendered as `%!s(float64=...)` when parsed as YAML number

## Testing
- observed invalid deployed image: `romainecr.azurecr.io/ambience:%!s(float64=4.372696e+06)`
- local diff only changes `chart/ambience/values-prod.yaml`