### PR TITLE
Gate live controls behind auth

### DIFF
--- a/chart/ambience/templates/authority-statefulset.yaml
+++ b/chart/ambience/templates/authority-statefulset.yaml
@@ -44,6 +44,15 @@ spec:
               value: {{ join "," .effects | quote }}
             {{- end }}
             {{- end }}
+            {{- with .Values.authority.controlAuth }}
+            {{- if .existingSecret }}
+            - name: AMBIENCE_CONTROL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .existingSecret | quote }}
+                  key: {{ .passwordKey | quote }}
+            {{- end }}
+            {{- end }}
           ports:
             - containerPort: 8080
               name: http

--- a/chart/ambience/values-prod.yaml
+++ b/chart/ambience/values-prod.yaml
@@ -8,5 +8,10 @@ image:
 edge:
   replicas: 2
 
+authority:
+  controlAuth:
+    existingSecret: ambience-control-auth
+    passwordKey: password
+
 pdb:
   enabled: true

--- a/chart/ambience/values.yaml
+++ b/chart/ambience/values.yaml
@@ -116,6 +116,9 @@ authority:
     enabled: true
     cadence: 10m
     effects: []
+  controlAuth:
+    existingSecret: ""
+    passwordKey: password
   resources:
     requests:
       cpu: 10m

--- a/cmd/ambience/control_auth.go
+++ b/cmd/ambience/control_auth.go
@@ -1,0 +1,153 @@
+package main
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+const controlAuthCookie = "ambience_control"
+
+type controlAuthenticator struct {
+	passwordHash [sha256.Size]byte
+	required     bool
+	mu           sync.Mutex
+	sessions     map[string]time.Time
+}
+
+func newControlAuthenticator(password string) *controlAuthenticator {
+	password = strings.TrimSpace(password)
+	a := &controlAuthenticator{
+		required: password != "",
+		sessions: make(map[string]time.Time),
+	}
+	if a.required {
+		a.passwordHash = sha256.Sum256([]byte(password))
+	}
+	return a
+}
+
+func (a *controlAuthenticator) authenticated(req *http.Request) bool {
+	if a == nil || !a.required {
+		return true
+	}
+	cookie, err := req.Cookie(controlAuthCookie)
+	if err != nil || cookie.Value == "" {
+		return false
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	expires, ok := a.sessions[cookie.Value]
+	if !ok {
+		return false
+	}
+	if time.Now().After(expires) {
+		delete(a.sessions, cookie.Value)
+		return false
+	}
+	return true
+}
+
+func (a *controlAuthenticator) require(w http.ResponseWriter, req *http.Request) bool {
+	if a.authenticated(req) {
+		return true
+	}
+	http.Error(w, "control auth required", http.StatusUnauthorized)
+	return false
+}
+
+func (a *controlAuthenticator) serve(w http.ResponseWriter, req *http.Request) {
+	if a == nil {
+		http.Error(w, "control auth unavailable", http.StatusServiceUnavailable)
+		return
+	}
+	switch req.Method {
+	case http.MethodGet:
+		a.writeStatus(w, req)
+	case http.MethodPost:
+		a.login(w, req)
+	case http.MethodDelete:
+		a.logout(w, req)
+	default:
+		http.Error(w, "GET, POST, or DELETE required", http.StatusMethodNotAllowed)
+	}
+}
+
+func (a *controlAuthenticator) writeStatus(w http.ResponseWriter, req *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]bool{
+		"required":      a.required,
+		"authenticated": a.authenticated(req),
+	})
+}
+
+func (a *controlAuthenticator) login(w http.ResponseWriter, req *http.Request) {
+	if !a.required {
+		a.writeStatus(w, req)
+		return
+	}
+	var body struct {
+		Password string `json:"password"`
+	}
+	if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
+		http.Error(w, "bad auth payload", http.StatusBadRequest)
+		return
+	}
+	got := sha256.Sum256([]byte(body.Password))
+	if subtle.ConstantTimeCompare(got[:], a.passwordHash[:]) != 1 {
+		http.Error(w, "bad password", http.StatusUnauthorized)
+		return
+	}
+	token, err := randomToken()
+	if err != nil {
+		http.Error(w, "auth token unavailable", http.StatusInternalServerError)
+		return
+	}
+	expires := time.Now().Add(24 * time.Hour)
+	a.mu.Lock()
+	a.sessions[token] = expires
+	a.mu.Unlock()
+	http.SetCookie(w, &http.Cookie{
+		Name:     controlAuthCookie,
+		Value:    token,
+		Path:     "/",
+		Expires:  expires,
+		HttpOnly: true,
+		SameSite: http.SameSiteStrictMode,
+		Secure:   req.TLS != nil || req.Header.Get("X-Forwarded-Proto") == "https",
+	})
+	a.writeStatus(w, req)
+}
+
+func (a *controlAuthenticator) logout(w http.ResponseWriter, req *http.Request) {
+	if cookie, err := req.Cookie(controlAuthCookie); err == nil {
+		a.mu.Lock()
+		delete(a.sessions, cookie.Value)
+		a.mu.Unlock()
+	}
+	http.SetCookie(w, &http.Cookie{
+		Name:     controlAuthCookie,
+		Value:    "",
+		Path:     "/",
+		Expires:  time.Unix(0, 0),
+		MaxAge:   -1,
+		HttpOnly: true,
+		SameSite: http.SameSiteStrictMode,
+		Secure:   req.TLS != nil || req.Header.Get("X-Forwarded-Proto") == "https",
+	})
+	a.writeStatus(w, req)
+}
+
+func randomToken() (string, error) {
+	var buf [32]byte
+	if _, err := rand.Read(buf[:]); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(buf[:]), nil
+}

--- a/cmd/ambience/live_controls.go
+++ b/cmd/ambience/live_controls.go
@@ -32,6 +32,9 @@ func serveSharedConfig(w http.ResponseWriter, req *http.Request) {
 		http.Error(w, "POST required", http.StatusMethodNotAllowed)
 		return
 	}
+	if !controlAuth.require(w, req) {
+		return
+	}
 	_, schema, err := sharedEffectSchema(req)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
@@ -52,6 +55,9 @@ func serveSharedConfig(w http.ResponseWriter, req *http.Request) {
 func serveSharedTrigger(w http.ResponseWriter, req *http.Request) {
 	if req.Method != http.MethodPost {
 		http.Error(w, "POST required", http.StatusMethodNotAllowed)
+		return
+	}
+	if !controlAuth.require(w, req) {
 		return
 	}
 	event := strings.Trim(strings.TrimPrefix(req.URL.Path, "/trigger/"), "/")

--- a/cmd/ambience/main.go
+++ b/cmd/ambience/main.go
@@ -11,6 +11,8 @@
 //	GET  /controls.js           — shared schema-driven control panel helper
 //	GET  /snapshot              — shared atmosphere init payload (JSON)
 //	GET  /events                — shared atmosphere SSE command stream
+//	GET  /control-auth          — live-control auth status
+//	POST /control-auth          — live-control password login
 //	POST /config?effect=&...    — mutate the shared atmosphere config
 //	POST /trigger/:event        — fire a discrete event on the shared atmosphere
 //	GET  /dev                   — dev page with knob controls (defaults to rain)
@@ -61,11 +63,12 @@ const (
 )
 
 type appConfig struct {
-	role           appRole
-	addr           string
-	authorityURL   string
-	shutdownDrain  time.Duration
-	webOverrideDir string
+	role            appRole
+	addr            string
+	authorityURL    string
+	controlPassword string
+	shutdownDrain   time.Duration
+	webOverrideDir  string
 }
 
 type lifecycleState struct {
@@ -78,6 +81,7 @@ type effectLookup func(effect string) (bool, error)
 var webFS embed.FS
 
 var shared *atmosphere
+var controlAuth *controlAuthenticator
 
 func main() {
 	cfg, err := loadAppConfigFromEnv()
@@ -92,6 +96,7 @@ func main() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	lifecycle := &lifecycleState{}
+	controlAuth = newControlAuthenticator(cfg.controlPassword)
 
 	mux := http.NewServeMux()
 	baseReady := func() bool { return true }
@@ -180,6 +185,7 @@ func loadAppConfigFromEnv() (appConfig, error) {
 	if cfg.role == roleEdge && cfg.authorityURL == "" {
 		return appConfig{}, fmt.Errorf("AMBIENCE_AUTHORITY_URL is required when AMBIENCE_ROLE=%q", roleEdge)
 	}
+	cfg.controlPassword = os.Getenv("AMBIENCE_CONTROL_PASSWORD")
 	if rawDrain := strings.TrimSpace(os.Getenv("AMBIENCE_SHUTDOWN_DRAIN")); rawDrain != "" {
 		d, err := time.ParseDuration(rawDrain)
 		if err != nil {
@@ -252,6 +258,7 @@ func registerAuthorityRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/events", cors(serveSharedEvents))
 	// Shared live controls stay same-origin only. They intentionally do not
 	// opt into permissive CORS because they mutate the shared atmosphere.
+	mux.HandleFunc("/control-auth", controlAuth.serve)
 	mux.HandleFunc("/config", serveSharedConfig)
 	mux.HandleFunc("/trigger/", serveSharedTrigger)
 	// Entropy intake — clients POST keystroke-derived bytes here; bytes

--- a/cmd/ambience/proxy.go
+++ b/cmd/ambience/proxy.go
@@ -70,6 +70,7 @@ func registerEdgeRoutes(mux *http.ServeMux, proxy *authorityProxy) {
 	mux.HandleFunc("/snapshot", cors(proxy.serveSnapshot))
 	mux.HandleFunc("/events", cors(proxy.serveEvents))
 	mux.HandleFunc("/entropy", cors(proxy.serveEntropy))
+	mux.HandleFunc("/control-auth", proxy.serveHTTP)
 	mux.HandleFunc("/config", proxy.serveHTTP)
 	mux.HandleFunc("/trigger/", proxy.serveHTTP)
 	mux.HandleFunc("/dev/snapshot", proxy.serveHTTP)

--- a/cmd/ambience/web/index.html
+++ b/cmd/ambience/web/index.html
@@ -78,6 +78,10 @@
     background: #1a1a1a;
     border-color: #555;
   }
+  a.iconbtn {
+    color: #e0e0e0;
+    text-decoration: none;
+  }
   .row {
     display: flex;
     justify-content: space-between;
@@ -190,6 +194,10 @@
     background: #33210c;
     border-color: #a56d20;
     color: #ffdca7;
+  }
+  .lock-button:disabled {
+    cursor: default;
+    opacity: 0.55;
   }
   .hint {
     margin-top: 6px;
@@ -367,15 +375,6 @@
     color: #f7b86c;
   }
   #devlink {
-    margin-top: 8px;
-    font-size: 10px;
-    text-align: right;
-  }
-  #devlink a {
-    color: #666;
-    text-decoration: none;
-  }
-  #devlink a:hover {
     color: #9cf;
   }
   .flash {
@@ -401,6 +400,7 @@
   <h2>
     <span>ambience live broadcast</span>
     <span class="btnbar">
+      <a class="iconbtn" id="devlink" href="/dev" title="open dev controls">dev -&gt;</a>
       <button class="iconbtn" id="toggleAll" title="collapse or expand all control sections">[]</button>
       <button class="iconbtn" id="togglePanel" title="collapse or expand panel (h)">-</button>
     </span>
@@ -446,7 +446,6 @@
       <div id="events"></div>
     </div>
 
-    <div id="devlink"><a href="/dev">/dev -&gt;</a></div>
   </div>
 </div>
 
@@ -485,6 +484,8 @@
   let initialFadeStarted = false;
   let schemaLoadToken = 0;
   let initialFadeCover = null;
+  let controlAuthenticated = false;
+  let controlAuthRequired = true;
 
   const el = {
     panel: document.getElementById('panel'),
@@ -521,17 +522,70 @@
   });
 
   function setControlsLocked(locked) {
-    controls.setLocked(locked);
-    el.lockButton.textContent = locked ? 'unlock' : 'lock';
-    el.lockButton.classList.toggle('unlocked', !locked);
-    el.lockState.textContent = locked ? 'view only' : 'live mutations armed';
-    el.lockState.classList.toggle('locked', locked);
-    el.lockState.classList.toggle('unlocked', !locked);
-    el.lockHelp.textContent = locked
-      ? 'Controls mirror the shared atmosphere, but slider moves and fire buttons stay inert until you unlock them.'
-      : 'Slider moves, presets, and fire buttons now hit the shared atmosphere immediately. This is the deliberate havoc switch.';
+    const nextLocked = locked || !controlAuthenticated;
+    controls.setLocked(nextLocked);
+    el.lockButton.disabled = false;
+    el.lockButton.classList.toggle('unlocked', !nextLocked && controlAuthenticated);
+    el.lockState.classList.toggle('locked', nextLocked);
+    el.lockState.classList.toggle('unlocked', !nextLocked && controlAuthenticated);
+    if (!controlAuthenticated) {
+      el.lockButton.textContent = controlAuthRequired ? 'sign in' : 'unlock';
+      el.lockState.textContent = controlAuthRequired ? 'read only' : 'view only';
+      el.lockHelp.textContent = controlAuthRequired
+        ? 'Controls mirror the shared atmosphere. Sign in to unlock live mutations.'
+        : 'Controls mirror the shared atmosphere, but slider moves and fire buttons stay inert until you unlock them.';
+      return;
+    }
+    el.lockButton.textContent = nextLocked ? 'unlock' : 'lock';
+    el.lockState.textContent = nextLocked ? 'view only' : 'live mutations armed';
+    el.lockHelp.textContent = nextLocked
+      ? 'Controls mirror the shared atmosphere. You are signed in; unlock to mutate the live scene.'
+      : 'Slider moves, presets, and fire buttons now hit the shared atmosphere immediately.';
   }
   setControlsLocked(true);
+
+  async function refreshControlAuth() {
+    try {
+      const resp = await fetch('/control-auth', { credentials: 'same-origin' });
+      if (!resp.ok) throw new Error('auth status returned ' + resp.status);
+      const status = await resp.json();
+      controlAuthRequired = !!status.required;
+      controlAuthenticated = !controlAuthRequired || !!status.authenticated;
+    } catch (err) {
+      console.error('control auth', err);
+      controlAuthRequired = true;
+      controlAuthenticated = false;
+    }
+    setControlsLocked(controls.isLocked());
+  }
+
+  async function signInControls() {
+    const password = window.prompt('live control password');
+    if (!password) return;
+    el.lockButton.disabled = true;
+    let signedIn = false;
+    try {
+      const resp = await fetch('/control-auth', {
+        method: 'POST',
+        credentials: 'same-origin',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ password }),
+      });
+      if (!resp.ok) throw new Error('auth returned ' + resp.status);
+      const status = await resp.json();
+      controlAuthRequired = !!status.required;
+      controlAuthenticated = !controlAuthRequired || !!status.authenticated;
+      signedIn = controlAuthenticated;
+      log('live controls signed in', 'system');
+    } catch (err) {
+      console.error('control auth', err);
+      controlAuthenticated = false;
+      log('live control sign-in failed', 'system');
+    } finally {
+      el.lockButton.disabled = false;
+      setControlsLocked(!signedIn);
+    }
+  }
 
   function makeInitialFadeCover() {
     const cover = document.createElement('div');
@@ -577,8 +631,13 @@
   }
 
   el.lockButton.addEventListener('click', () => {
+    if (!controlAuthenticated) {
+      signInControls();
+      return;
+    }
     setControlsLocked(!controls.isLocked());
   });
+  refreshControlAuth();
 
   function setPanelCollapsed(on) {
     el.panel.classList.toggle('collapsed', on);
@@ -673,7 +732,11 @@
   async function pushSharedConfig() {
     if (controls.isLocked() || !controls.getSchema() || !effectType) return;
     try {
-      const resp = await fetch('/config?' + currentSharedQuery(), { method: 'POST' });
+      const resp = await fetch('/config?' + currentSharedQuery(), { method: 'POST', credentials: 'same-origin' });
+      if (resp.status === 401) {
+        controlAuthenticated = false;
+        setControlsLocked(true);
+      }
       if (!resp.ok) throw new Error('config returned ' + resp.status);
     } catch (err) {
       console.error('shared config push', err);
@@ -693,7 +756,12 @@
     try {
       const resp = await fetch('/trigger/' + encodeURIComponent(eventName) + '?effect=' + encodeURIComponent(effectType), {
         method: 'POST',
+        credentials: 'same-origin',
       });
+      if (resp.status === 401) {
+        controlAuthenticated = false;
+        setControlsLocked(true);
+      }
       if (!resp.ok) throw new Error('trigger returned ' + resp.status);
     } catch (err) {
       console.error('shared trigger', err);


### PR DESCRIPTION
## Summary
- add same-origin password/session auth for live shared controls
- reject unauthenticated `/config` and `/trigger` mutations server-side
- keep the live panel read-only for unauthenticated users while still showing current values
- move the `/dev` control link into the panel header for quicker access
- wire prod to read `AMBIENCE_CONTROL_PASSWORD` from the `ambience-control-auth` Secret

## Testing
- `awk '/<script>/{flag=1; next} /<\/script>/{flag=0} flag {print}' cmd/ambience/web/index.html > /tmp/ambience-index-inline.js && node --check /tmp/ambience-index-inline.js`
- `node --check cmd/ambience/web/client.js`
- `node --check cmd/ambience/web/sim.js`
- `node --check cmd/ambience/web/controls.js`
- `go test ./cmd/ambience ./sim` not run: `go` is not installed in this pod
- created prod Secret `ambience/ambience-control-auth` before rollout