### PR TITLE
Fix control auth login response

### DIFF
--- a/cmd/ambience/control_auth.go
+++ b/cmd/ambience/control_auth.go
@@ -122,7 +122,11 @@ func (a *controlAuthenticator) login(w http.ResponseWriter, req *http.Request) {
 		SameSite: http.SameSiteStrictMode,
 		Secure:   req.TLS != nil || req.Header.Get("X-Forwarded-Proto") == "https",
 	})
-	a.writeStatus(w, req)
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]bool{
+		"required":      true,
+		"authenticated": true,
+	})
 }
 
 func (a *controlAuthenticator) logout(w http.ResponseWriter, req *http.Request) {


### PR DESCRIPTION
## Summary
- return `authenticated: true` immediately after a successful live-control login, matching the Set-Cookie response

## Testing
- `awk '/<script>/{flag=1; next} /<\/script>/{flag=0} flag {print}' cmd/ambience/web/index.html > /tmp/ambience-index-inline.js && node --check /tmp/ambience-index-inline.js`
- `node --check cmd/ambience/web/client.js`
- live verification before this patch confirmed the cookie worked on the next GET but the login response body was stale