### PR TITLE
Add native Glimmung runner for Ambience

### DIFF
--- a/.github/runner/Dockerfile
+++ b/.github/runner/Dockerfile
@@ -3,6 +3,7 @@ FROM ghcr.io/actions/actions-runner:latest
 USER root
 
 ENV DEBIAN_FRONTEND=noninteractive \
+    PIP_BREAK_SYSTEM_PACKAGES=1 \
     PLAYWRIGHT_BROWSERS_PATH=/ms-playwright \
     PLAYWRIGHT_PACKAGE_PATH=/opt/ambience-agent/node_modules/playwright/index.mjs
 
@@ -13,6 +14,9 @@ RUN apt-get update \
         git \
         gnupg \
         jq \
+        python3 \
+        python3-pip \
+        python3-venv \
         sudo \
         unzip \
     && rm -rf /var/lib/apt/lists/*
@@ -27,11 +31,21 @@ RUN echo "runner ALL=(ALL) NOPASSWD:ALL" >/etc/sudoers.d/runner \
 
 RUN curl -sL https://aka.ms/InstallAzureCLIDeb | bash
 
+RUN KUBECTL_VERSION="$(curl -fsSL https://dl.k8s.io/release/stable.txt)" \
+    && curl -fsSLo /usr/local/bin/kubectl "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" \
+    && chmod +x /usr/local/bin/kubectl
+
+RUN curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+
 RUN npm install -g @openai/codex \
     && mkdir -p /opt/ambience-agent \
     && npm install --prefix /opt/ambience-agent playwright \
     && npx --prefix /opt/ambience-agent playwright install --with-deps chromium \
+    && chmod -R a+rX /ms-playwright /opt/ambience-agent \
     && npm cache clean --force \
     && rm -rf /root/.npm /opt/ambience-agent/.cache
+
+COPY scripts/glimmung-native /opt/ambience-native/scripts
+RUN chmod +x /opt/ambience-native/scripts/*.sh
 
 USER runner

--- a/.github/workflows/build-native-runner-image.yml
+++ b/.github/workflows/build-native-runner-image.yml
@@ -1,0 +1,79 @@
+name: Build Native Glimmung Runner Image
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/runner/Dockerfile"
+      - ".github/workflows/build-native-runner-image.yml"
+      - "mcp/**"
+      - "scripts/glimmung-native/**"
+  workflow_dispatch:
+    inputs:
+      git_ref:
+        description: "Git ref or commit SHA to build. Leave blank to build the dispatch revision."
+        required: false
+        type: string
+
+permissions:
+  id-token: write
+  contents: read
+
+concurrency:
+  group: build-native-glimmung-runner-image
+  cancel-in-progress: false
+
+jobs:
+  build-and-push:
+    name: Build native runner image and push to ACR
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Resolve requested ref
+        env:
+          INPUT_REF: ${{ inputs.git_ref }}
+        run: |
+          set -euo pipefail
+          git fetch --force --tags origin '+refs/heads/*:refs/remotes/origin/*'
+
+          target_ref="${INPUT_REF:-$GITHUB_SHA}"
+          if full_sha="$(git rev-parse --verify "${target_ref}^{commit}" 2>/dev/null)"; then
+            :
+          elif git show-ref --verify --quiet "refs/remotes/origin/${target_ref}"; then
+            full_sha="$(git rev-parse "refs/remotes/origin/${target_ref}^{commit}")"
+          elif git show-ref --verify --quiet "refs/tags/${target_ref}"; then
+            full_sha="$(git rev-parse "refs/tags/${target_ref}^{commit}")"
+          else
+            echo "::error::Unable to resolve git_ref '${target_ref}' to a commit."
+            exit 1
+          fi
+
+          git checkout --detach "$full_sha"
+          echo "resolved ${target_ref} -> ${full_sha}"
+
+      - name: Azure Login (OIDC)
+        uses: azure/login@v3
+        with:
+          client-id: ${{ vars.ARM_CLIENT_ID }}
+          tenant-id: ${{ vars.ARM_TENANT_ID }}
+          subscription-id: ${{ vars.ARM_SUBSCRIPTION_ID }}
+
+      - name: ACR login
+        run: az acr login --name romainecr
+
+      - name: Resolve image tag
+        run: |
+          tag="native-$(git rev-parse --short=7 HEAD)"
+          echo "TAG=${tag}" >> "$GITHUB_ENV"
+          echo "Built ref $(git rev-parse HEAD) as romainecr.azurecr.io/ambience-agent-runner:${tag}" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Build and push image
+        run: |
+          image="romainecr.azurecr.io/ambience-agent-runner:${TAG}"
+          docker build -f .github/runner/Dockerfile -t "$image" .
+          docker push "$image"

--- a/docs/agentic-issue-flow.md
+++ b/docs/agentic-issue-flow.md
@@ -1,163 +1,77 @@
 # Agentic Issue Flow
 
-This repo now has a first-pass GitHub-to-Codex-to-k8s issue flow aimed at bounded backlog slices.
+Ambience issue automation is moving off GitHub Actions as the runner source.
+Glimmung is the queue, run graph, callback, retry, and report owner.
+Ambience owns the app-specific work that happens inside native Kubernetes
+jobs.
 
-## What it does
+GitHub Actions can still exist for repository CI and image builds. It is not
+the source of issue-run execution for the native Ambience flow.
 
-1. A GitHub issue gets a trigger label.
-2. GitHub Actions becomes the queue manager.
-3. The job runs on an ARC-backed self-hosted runner scale set capped at five runners.
-4. Codex implements the issue in the checked-out repo, runs tests, uses the repo-local `ambience_preview` MCP server for the exact build/deploy/screenshot commands, and hands a structured result back to the workflow.
-5. The workflow opens a pull request with the screenshots and posts the result back to the issue.
-6. A separate pull-request workflow builds and publishes a long-lived preview at `pr-<number>.ambience.dev.romaine.life`.
-7. The scratch validation namespace is deleted at the end of the issue run, while the PR preview stays up until the PR closes.
+## Native Flow
 
-Because each job owns one runner and one namespace, a `maxRunners: 5` scale set also caps us at five concurrent ephemeral environments.
+1. A Glimmung issue for the `ambience` project is dispatched to the registered
+   `agent-run` workflow.
+2. Glimmung creates a Run, acquires native runner capacity, creates the
+   per-attempt callback token, and launches a Kubernetes Job in
+   `glimmung-runs`.
+3. The `env-prep` native phase runs
+   `scripts/glimmung-native/env-prep.sh`.
+4. `env-prep` clones this repo, builds and verifies an Ambience validation
+   image, deploys a public validation environment, checks it, and emits
+   `validation_url`, `namespace`, `image_tag`, and `claude_namespace`.
+5. Glimmung substitutes those phase outputs into `agent-execute`.
+6. The `agent-execute` native phase runs
+   `scripts/glimmung-native/agent-execute.sh`.
+7. `agent-execute` clones this repo, prepares the Claude agent Job in the
+   validation namespace, collects logs/evidence, rebuilds the validation
+   environment from the pushed agent branch, captures screenshots, posts a
+   typed verification result, and lets Glimmung drive retry/report decisions.
 
-## Files added for this flow
+## Ownership
 
-- `.github/workflows/codex-issue-agent.yml`
-- `.github/workflows/codex-pr-preview.yml`
-- `.github/workflows/build-agent-runner-image.yml`
-- `.github/codex/prompts/issue-implementation.md`
-- `.github/codex/issue-result.schema.json`
-- `.github/runner/Dockerfile`
-- `mcp/`
-- `scripts/agent/*.sh`
-- `scripts/agent/capture-screenshot.mjs`
-- `k8s/arc/values-issue-agents.yaml`
+- Glimmung owns clone-token minting, run/session authentication, native
+  callback endpoints, graph state, log archival, retry decisions, and report
+  creation.
+- Ambience owns image build, Helm deploy, validation checks, agent prompt/job
+  creation, screenshot selection, and verification semantics.
+- Steps are observational boundaries emitted by Ambience scripts. Glimmung
+  records them but does not orchestrate inside a step.
 
-## Trigger label
+## Workflow Registration
 
-Default trigger label:
-
-- `codex:run`
-
-Optional repo variable:
-
-- `CODEX_TRIGGER_LABELS_JSON`
-
-Example:
-
-```json
-["codex:run", "codex:retry"]
-```
-
-If the variable is unset, the workflow falls back to `["codex:run"]`. The workflow also tolerates a simpler non-JSON value such as `codex:run` if you set it through the GitHub CLI and the shell mangles the quoting.
-
-## Required GitHub secrets and variables
-
-Variables:
-
-- `ARM_CLIENT_ID`
-- `ARM_TENANT_ID`
-- `ARM_SUBSCRIPTION_ID`
-- `AZURE_AKS_RESOURCE_GROUP`
-- `AZURE_AKS_CLUSTER_NAME`
-- `KEY_VAULT_NAME`
-
-The workflow loads the API key only from Azure Key Vault secret `openai-api-key` after OIDC login, and it uses the built-in `GITHUB_TOKEN` for pull request operations.
-
-## Runner image
-
-The ARC runners for this workflow should use the Dockerfile at `.github/runner/Dockerfile`.
-
-Build and push it with the manual workflow:
-
-- `Build Agent Runner Image`
-
-That image now preinstalls the heavy runtime tooling so issue jobs do less work on every ephemeral runner start. It provides:
-
-- Azure CLI
-- Node.js 22
-- `@openai/codex`
-- Playwright plus Chromium
-- the standard GitHub runner base
-
-The runner scale-set values now also declare `ephemeral-storage` requests and limits so runner pods are less likely to be evicted under disk pressure.
-
-## ARC scale set
-
-Use `k8s/arc/values-issue-agents.yaml` with the official `gha-runner-scale-set` chart.
-
-Recommended install shape:
-
-1. Put ARC controller pods in a controller namespace such as `arc-system`.
-2. Put the runner scale set in a different namespace such as `arc-runners`.
-3. Use a GitHub App secret named `arc-github-app` in that runner namespace.
-4. Keep `minRunners: 0` and `maxRunners: 5` for the initial rollout.
-
-Example install:
+After a native runner image is built, register Ambience with:
 
 ```bash
-helm upgrade --install ambience-issue-agents \
-  --namespace arc-runners \
-  --create-namespace \
-  -f k8s/arc/values-issue-agents.yaml \
-  oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set
+AMBIENCE_NATIVE_RUNNER_IMAGE=romainecr.azurecr.io/ambience-agent-runner:native-<sha> \
+  scripts/glimmung-native/register-workflow.sh
 ```
 
-This setup targets the runner scale set by name (`ambience-issue-agents`) instead of extra ARC labels. That keeps it compatible with the controller/chart version currently running in the cluster.
+The registration currently creates two native phases:
 
-## Agent MCP server
+- `env-prep`
+- `agent-execute`
 
-The issue automation now installs a small repo-local Python MCP server from `mcp/` before it launches `codex exec`.
+The terminal review surface is the Glimmung Report primitive. The current
+Glimmung registration schema still exposes that knob as `pr.enabled` until the
+remaining Report API rename lands.
 
-That server gives Codex exact, typed tools for the fixed preview operations:
+## Runner Image
 
-- `build_preview_image`
-- `deploy_validation_preview`
-- `capture_validation_screenshot`
+The native runner image is built from `.github/runner/Dockerfile` by
+`.github/workflows/build-native-runner-image.yml` and pushed to:
 
-The point is to move the exact build/deploy/screenshot command lines behind a stable tool surface instead of making the model reconstruct them from prompt text on every run.
+```text
+romainecr.azurecr.io/ambience-agent-runner:native-<sha>
+```
 
-## Ephemeral validation behavior
+That image includes Azure CLI, `kubectl`, Helm, Python, Node, Playwright,
+Codex, and the native Ambience scripts under `/opt/ambience-native/scripts`.
 
-Each run uses:
+## Retry And Resume
 
-- a unique namespace: `ambience-issue-<issue>-<run-id>`
-- a fixed Helm release name inside that namespace
-- a unique image tag built from the current branch contents
-
-The validation deploy stays internal-only. Codex validates through the MCP server, which deploys the chart without public gateway resources and captures screenshots through a temporary `kubectl port-forward`.
-
-## PR preview behavior
-
-When the issue workflow opens a pull request, `Codex PR Preview` takes over the long-lived review environment:
-
-- build an image for the PR head SHA
-- deploy it to `ambience-pr-<number>`
-- expose `https://pr-<number>.ambience.dev.romaine.life`
-- let external-dns publish the record from the `HTTPRoute`
-- update the preview on `pull_request.synchronize`
-- delete the namespace on `pull_request.closed`
-
-Preview cleanup is intentionally non-agentic and deterministic.
-
-## Security notes
-
-This workflow intentionally gives Codex broad access inside an isolated automation runner:
-
-- `codex exec --sandbox danger-full-access`
-- Azure login
-- Kubernetes namespace create/delete
-- image builds
-
-Treat that runner pool as privileged automation infrastructure. GitHub's ARC guidance explicitly recommends isolating these workloads because GitHub Actions jobs execute arbitrary code.
-
-Strongly recommended:
-
-- dedicate a node pool or cluster to ARC runners
-- keep runner pods in a different namespace from the ARC controller
-- scope the GitHub App and Azure identity as tightly as practical
-- keep production workloads and secrets out of the runner namespace
-
-## Expected operator loop
-
-1. Label a bounded issue with `codex:run`.
-2. Wait for the ARC runner to scale up and pick up the job.
-3. Review the PR that the workflow opens and use the PR preview URL that the preview workflow comments back.
-4. Close the PR when you are done; the preview namespace will be removed automatically.
-5. Re-label or manually dispatch if you want another pass.
-
-If the run is blocked, the workflow comments back on the issue instead of guessing.
+`agent-execute` is a verification phase with a recycle policy on
+`verify_fail` and `verify_malformed`. The app-owned step boundaries are the
+resume surface for future MCP/API dispatches; a caller that wants to resume
+from a particular point should pass `GLIMMUNG_RESUME_FROM_STEP=<step-slug>`
+when creating the next native attempt.

--- a/mcp/ambience_preview/cli.py
+++ b/mcp/ambience_preview/cli.py
@@ -65,6 +65,8 @@ def build_parser() -> argparse.ArgumentParser:
     apply_agent.add_argument("--issue-number", required=True)
     apply_agent.add_argument("--issue-title", required=True)
     apply_agent.add_argument("--issue-url", required=True)
+    apply_agent.add_argument("--issue-reference", default=None)
+    apply_agent.add_argument("--github-issue-number", default=None)
     apply_agent.add_argument("--validation-url", required=True)
     apply_agent.add_argument("--branch-name", required=True)
     apply_agent.add_argument("--proxy-ip", required=True)
@@ -143,6 +145,8 @@ def main() -> int:
                     issue_number=args.issue_number,
                     issue_title=args.issue_title,
                     issue_url=args.issue_url,
+                    issue_reference=args.issue_reference,
+                    github_issue_number=args.github_issue_number,
                     validation_url=args.validation_url,
                     branch_name=args.branch_name,
                     proxy_ip=args.proxy_ip,

--- a/mcp/ambience_preview/ops.py
+++ b/mcp/ambience_preview/ops.py
@@ -487,12 +487,21 @@ EOF
 git config --global user.name "ambience-agent[bot]"
 git config --global user.email "ambience-agent@romaine.life"
 
-git clone "https://x-access-token:${GH_TOKEN}@github.com/${REPO_SLUG}.git" /workspace/repo
+git -c "http.extraHeader=Authorization: Bearer ${GH_TOKEN}" \
+  clone "https://github.com/${REPO_SLUG}.git" /workspace/repo
 cd /workspace/repo
 git checkout -B "${BRANCH_NAME}"
 
+if [ -n "${GITHUB_ISSUE_NUMBER:-}" ]; then
+  issue_heading="# Issue #${GITHUB_ISSUE_NUMBER}: ${ISSUE_TITLE}"
+  close_line="Closes #${GITHUB_ISSUE_NUMBER}"
+else
+  issue_heading="# Glimmung issue ${ISSUE_REFERENCE}: ${ISSUE_TITLE}"
+  close_line="Glimmung-Issue: ${ISSUE_REFERENCE}"
+fi
+
 cat > /tmp/issue-context.md <<EOF
-# Issue #${ISSUE_NUMBER}: ${ISSUE_TITLE}
+${issue_heading}
 URL: ${ISSUE_URL}
 Validation env: ${VALIDATION_URL}
 EOF
@@ -524,11 +533,11 @@ if git diff --cached --quiet; then
   echo "agent produced no changes; failing job so the workflow doesn't open an empty PR" >&2
   exit 1
 fi
-git commit -m "agent: address issue #${ISSUE_NUMBER}
+git commit -m "agent: address ${ISSUE_REFERENCE}
 
 ${ISSUE_TITLE}
 
-Closes #${ISSUE_NUMBER}"
+${close_line}"
 
 # Sync onto current main before pushing. The agent ran for several minutes;
 # main may have moved (e.g. someone merged a workflow tweak). Pushing a
@@ -537,10 +546,10 @@ Closes #${ISSUE_NUMBER}"
 # commit didn't touch those files. Rebase replays the agent's single
 # commit on top of current main; if there's a real conflict we fail loudly
 # rather than ship a stale-base branch.
-git fetch origin main
+git -c "http.extraHeader=Authorization: Bearer ${GH_TOKEN}" fetch origin main
 git rebase origin/main
 
-git push origin "HEAD:${BRANCH_NAME}"
+git -c "http.extraHeader=Authorization: Bearer ${GH_TOKEN}" push origin "HEAD:${BRANCH_NAME}"
 
 # Stream the evidence dir as a base64-encoded tarball to stdout between
 # clear markers the workflow extracts via sed. We can't kubectl cp from
@@ -595,6 +604,8 @@ def _agent_job_spec(
     issue_number: str,
     issue_title: str,
     issue_url: str,
+    issue_reference: str | None,
+    github_issue_number: str | None,
     validation_url: str,
     branch_name: str,
     proxy_ip: str,
@@ -603,6 +614,9 @@ def _agent_job_spec(
 ) -> dict:
     """Build the Job spec as a Python dict. No templating; values land directly
     in their typed positions."""
+    issue_ref = issue_reference or (f"#{issue_number}" if issue_number else "glimmung-run")
+    gh_issue_number = issue_number if github_issue_number is None else github_issue_number
+
     return {
         "apiVersion": "batch/v1",
         "kind": "Job",
@@ -665,6 +679,8 @@ def _agent_job_spec(
                                 {"name": "NODE_EXTRA_CA_CERTS", "value": "/etc/claude-ca/ca.crt"},
                                 {"name": "HOME", "value": "/workspace"},
                                 {"name": "ISSUE_NUMBER", "value": str(issue_number)},
+                                {"name": "ISSUE_REFERENCE", "value": issue_ref},
+                                {"name": "GITHUB_ISSUE_NUMBER", "value": gh_issue_number or ""},
                                 {"name": "ISSUE_TITLE", "value": issue_title},
                                 {"name": "ISSUE_URL", "value": issue_url},
                                 {"name": "VALIDATION_URL", "value": validation_url},
@@ -706,6 +722,8 @@ def apply_agent_job(
     proxy_ip: str,
     agent_container_tag: str,
     repo_slug: str = "nelsong6/ambience",
+    issue_reference: str | None = None,
+    github_issue_number: str | None = None,
 ) -> dict:
     """Render the agent Job spec and `kubectl apply -f -` it."""
     import json as _json
@@ -715,6 +733,8 @@ def apply_agent_job(
         issue_number=issue_number,
         issue_title=issue_title,
         issue_url=issue_url,
+        issue_reference=issue_reference,
+        github_issue_number=github_issue_number,
         validation_url=validation_url,
         branch_name=branch_name,
         proxy_ip=proxy_ip,

--- a/scripts/glimmung-native/agent-execute.sh
+++ b/scripts/glimmung-native/agent-execute.sh
@@ -1,0 +1,383 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib.sh
+source "${SCRIPT_DIR}/lib.sh"
+
+native_init
+native_require_env \
+  GLIMMUNG_RUN_ID \
+  GLIMMUNG_INPUT_VALIDATION_URL \
+  GLIMMUNG_INPUT_NAMESPACE \
+  GLIMMUNG_INPUT_IMAGE_TAG
+
+REPO_SLUG="${AMBIENCE_REPO_SLUG:-nelsong6/ambience}"
+REPO_DIR="${AMBIENCE_REPO_DIR:-/workspace/ambience}"
+AGENT_CONTAINER_TAG="${AGENT_CONTAINER_TAG:-latest}"
+CLAUDE_NAMESPACE="${GLIMMUNG_INPUT_CLAUDE_NAMESPACE:-tank-operator}"
+
+VALIDATION_URL="${GLIMMUNG_INPUT_VALIDATION_URL}"
+NAMESPACE="${GLIMMUNG_INPUT_NAMESPACE}"
+IMAGE_TAG="${GLIMMUNG_INPUT_IMAGE_TAG}"
+BRANCH_NAME="glimmung/${GLIMMUNG_RUN_ID}"
+JOB_NAME="agent-${IMAGE_TAG}"
+
+ISSUE_TITLE="${GLIMMUNG_ISSUE_TITLE:-Glimmung issue ${GLIMMUNG_ISSUE_ID:-${GLIMMUNG_RUN_ID}}}"
+GITHUB_ISSUE_NUMBER="${GLIMMUNG_ISSUE_NUMBER:-}"
+if [ -n "$GITHUB_ISSUE_NUMBER" ] && [ -n "${GLIMMUNG_ISSUE_REPO:-}" ]; then
+  ISSUE_REFERENCE="#${GITHUB_ISSUE_NUMBER}"
+  ISSUE_URL="https://github.com/${GLIMMUNG_ISSUE_REPO}/issues/${GITHUB_ISSUE_NUMBER}"
+else
+  ISSUE_REFERENCE="${GLIMMUNG_ISSUE_ID:-${GLIMMUNG_RUN_ID}}"
+  ISSUE_URL="${GLIMMUNG_BASE_URL:-https://glimmung.romaine.life}/issues/${ISSUE_REFERENCE}"
+fi
+
+AGENT_EXIT_CODE=0
+VERIFICATION_JSON="/tmp/verification.json"
+VERIFICATION_REASONS="/tmp/verification-reasons.txt"
+EVIDENCE_REFS="/tmp/evidence-refs.txt"
+SCREENSHOTS_MD="/tmp/screenshots.md"
+: >"$VERIFICATION_REASONS"
+: >"$EVIDENCE_REFS"
+: >"$SCREENSHOTS_MD"
+
+clone_repo() {
+  native_clone_repo "$REPO_SLUG" "$REPO_DIR" main "$BRANCH_NAME"
+}
+
+install_preview_package() {
+  python3 -m pip install --user --upgrade pip
+  python3 -m pip install --user "${REPO_DIR}/mcp"
+}
+
+copy_claude_ca() {
+  kubectl -n "$CLAUDE_NAMESPACE" get configmap claude-oauth-ca -o json \
+    | NAMESPACE="$NAMESPACE" jq '
+        del(
+          .metadata.uid,
+          .metadata.resourceVersion,
+          .metadata.generation,
+          .metadata.creationTimestamp,
+          .metadata.managedFields
+        )
+        | .metadata.namespace = env.NAMESPACE
+      ' \
+    | kubectl apply -f -
+}
+
+write_agent_prompt() {
+  local dest="/tmp/agent-prompt.md"
+  : >"$dest"
+  cat "${REPO_DIR}/.github/agent/prompt.md" >>"$dest"
+  {
+    echo ""
+    echo "---"
+    echo ""
+    if [ -n "$GITHUB_ISSUE_NUMBER" ]; then
+      echo "# Issue #${GITHUB_ISSUE_NUMBER}: ${ISSUE_TITLE}"
+    else
+      echo "# Glimmung issue ${ISSUE_REFERENCE}: ${ISSUE_TITLE}"
+    fi
+    echo "URL: ${ISSUE_URL}"
+    echo "Validation env: ${VALIDATION_URL}"
+    echo "Glimmung run: ${GLIMMUNG_RUN_ID}"
+  } >>"$dest"
+  echo "agent prompt size: $(wc -l <"$dest") lines, $(wc -c <"$dest") bytes"
+}
+
+prepare_agent_context() {
+  local token
+  native_azure_login
+  install_preview_package
+  copy_claude_ca
+
+  PROXY_IP="$(kubectl -n "$CLAUDE_NAMESPACE" get svc claude-api-proxy -o jsonpath='{.spec.clusterIP}')"
+  if [ -z "$PROXY_IP" ]; then
+    echo "claude-api-proxy Service not found in ${CLAUDE_NAMESPACE}" >&2
+    return 1
+  fi
+  export PROXY_IP
+
+  write_agent_prompt
+  token="$(native_github_token)"
+  kubectl -n "$NAMESPACE" create configmap agent-config \
+    --from-file=prompt.md=/tmp/agent-prompt.md \
+    --dry-run=client -o yaml | kubectl apply -f -
+  kubectl -n "$NAMESPACE" create secret generic agent-github-token \
+    --from-literal=token="$token" \
+    --dry-run=client -o yaml | kubectl apply -f -
+}
+
+run_agent() {
+  (
+    cd "$REPO_DIR"
+    args=(
+      --namespace "$NAMESPACE"
+      --job-name "$JOB_NAME"
+      --issue-number "${GITHUB_ISSUE_NUMBER:-${ISSUE_REFERENCE}}"
+      --issue-title "$ISSUE_TITLE"
+      --issue-url "$ISSUE_URL"
+      --issue-reference "$ISSUE_REFERENCE"
+      --github-issue-number "$GITHUB_ISSUE_NUMBER"
+      --validation-url "$VALIDATION_URL"
+      --branch-name "$BRANCH_NAME"
+      --proxy-ip "$PROXY_IP"
+      --agent-container-tag "$AGENT_CONTAINER_TAG"
+      --repo-slug "$REPO_SLUG"
+    )
+    python3 -m ambience_preview.cli apply-agent-job "${args[@]}"
+    python3 -m ambience_preview.cli wait-agent-job \
+      --namespace "$NAMESPACE" \
+      --job-name "$JOB_NAME" \
+      --timeout-seconds "${AGENT_JOB_TIMEOUT_SECONDS:-1800}"
+  )
+}
+
+collect_evidence() {
+  mkdir -p /tmp/evidence/screenshots
+  local pod=""
+  pod="$(kubectl -n "$NAMESPACE" get pods -l "job-name=${JOB_NAME}" -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)"
+  if [ -z "$pod" ]; then
+    echo "no pod found for job ${JOB_NAME}; skipping event capture"
+    : >/tmp/agent-pod.log
+    : >/tmp/agent-events.jsonl
+    return 0
+  fi
+
+  kubectl -n "$NAMESPACE" logs "$pod" >/tmp/agent-pod.log || true
+  grep -E '^\{' /tmp/agent-pod.log >/tmp/agent-events.jsonl || true
+  echo "captured $(wc -l </tmp/agent-events.jsonl) event lines from ${pod}"
+
+  if grep -q '===EVIDENCE-TAR-START===' /tmp/agent-pod.log; then
+    if ! sed -n '/===EVIDENCE-TAR-START===/,/===EVIDENCE-TAR-END===/{//!p;}' \
+        /tmp/agent-pod.log \
+        | base64 -d 2>/tmp/extract.err \
+        | tar -xzf - -C /tmp/evidence 2>>/tmp/extract.err; then
+      echo "evidence tarball extraction failed; continuing without in-pod evidence" >&2
+      cat /tmp/extract.err >&2 || true
+      rm -rf /tmp/evidence
+      mkdir -p /tmp/evidence/screenshots
+    fi
+  else
+    echo "no evidence tar markers found in agent pod log"
+  fi
+}
+
+add_reason() {
+  printf '%s\n' "$1" >>"$VERIFICATION_REASONS"
+}
+
+verification_cost() {
+  if [ -s /tmp/agent-events.jsonl ]; then
+    jq -r 'select(.type=="result") | .total_cost_usd // 0' /tmp/agent-events.jsonl \
+      | awk '{s+=$1} END {if (NR>0) printf "%.4f", s; else printf "0"}'
+  else
+    printf '0'
+  fi
+}
+
+write_verification() {
+  local status="$1"
+  local cost
+  cost="$(verification_cost)"
+  find /tmp/evidence/screenshots -maxdepth 1 -type f -name '*.png' \
+    -printf 'screenshots/%f\n' 2>/dev/null | sort >"$EVIDENCE_REFS" || true
+  jq -n \
+    --arg status "$status" \
+    --argjson reasons "$(jq -Rs 'split("\n")[:-1]' "$VERIFICATION_REASONS")" \
+    --argjson evidence_refs "$(jq -Rs 'split("\n")[:-1]' "$EVIDENCE_REFS")" \
+    --argjson cost_usd "${cost:-0}" \
+    --arg run_id "$GLIMMUNG_RUN_ID" \
+    --arg branch "$BRANCH_NAME" \
+    --arg validation_url "$VALIDATION_URL" \
+    '{
+      schema_version: 1,
+      status: $status,
+      reasons: $reasons,
+      evidence_refs: $evidence_refs,
+      cost_usd: $cost_usd,
+      prompt_version: "ambience-native-v1",
+      metadata: {
+        run_id: $run_id,
+        branch: $branch,
+        validation_url: $validation_url
+      }
+    }' >"$VERIFICATION_JSON"
+  cat "$VERIFICATION_JSON"
+}
+
+fetch_agent_branch() {
+  local token
+  token="$(native_github_token)"
+  git -C "$REPO_DIR" \
+    -c "http.extraHeader=Authorization: Bearer ${token}" \
+    fetch origin "refs/heads/${BRANCH_NAME}:refs/remotes/origin/${BRANCH_NAME}"
+  git -C "$REPO_DIR" checkout -B "$BRANCH_NAME" "origin/${BRANCH_NAME}"
+}
+
+rebuild_validation_env() {
+  local rebuild_tag="${IMAGE_TAG}-r2"
+  (
+    cd "$REPO_DIR"
+    python3 -m ambience_preview.cli rebuild-validation-image \
+      --namespace "$NAMESPACE" \
+      --branch "$BRANCH_NAME" \
+      --image-tag "$rebuild_tag" \
+      --repo-slug "$REPO_SLUG"
+    python3 -m ambience_preview.cli wait-public-preview --url "$VALIDATION_URL"
+  )
+}
+
+capture_screenshots() {
+  if [ ! -f "${REPO_DIR}/screenshot-pages.json" ]; then
+    echo "no screenshot-pages.json; skipping screenshot pass"
+    return 0
+  fi
+  (
+    cd "$REPO_DIR"
+    mkdir -p /tmp/evidence/screenshots
+    if [ -d /opt/ambience-agent/node_modules/playwright ]; then
+      mkdir -p node_modules
+      ln -sfn /opt/ambience-agent/node_modules/playwright node_modules/playwright
+    else
+      npm init -y >/dev/null
+      npm install --no-save --silent playwright@1
+      npx --yes playwright install chromium
+    fi
+    BASE_URL="$VALIDATION_URL" \
+      PAGES_JSON=screenshot-pages.json \
+      OUT_DIR=/tmp/evidence/screenshots \
+      GLIMMUNG_RUN_ID="$GLIMMUNG_RUN_ID" \
+      node scripts/screenshot-pages.mjs
+  )
+}
+
+upload_screenshots() {
+  local storage_account="${AGENT_SCREENSHOT_STORAGE_ACCOUNT:-infraagentscreens}"
+  local container="${AGENT_SCREENSHOT_CONTAINER:-ambience}"
+  local container_url="${AGENT_SCREENSHOT_CONTAINER_URL:-https://infraagentscreens.blob.core.windows.net/ambience}"
+  local max_screenshots="${MAX_SCREENSHOTS:-20}"
+  local prefix safe_ref staging total taken upload_ok
+
+  if ! compgen -G "/tmp/evidence/screenshots/*.png" >/dev/null; then
+    return 0
+  fi
+
+  safe_ref="$(printf '%s' "$ISSUE_REFERENCE" | tr -c 'A-Za-z0-9._-' '-')"
+  prefix="issue-${safe_ref}/${GLIMMUNG_RUN_ID}"
+  staging="$(mktemp -d)"
+  total=0
+  taken=0
+  while IFS= read -r file; do
+    total=$((total + 1))
+    if [ "$taken" -lt "$max_screenshots" ]; then
+      cp "$file" "$staging/"
+      taken=$((taken + 1))
+    fi
+  done < <(find /tmp/evidence/screenshots -maxdepth 1 -type f -name '*.png' | sort)
+
+  upload_ok=true
+  if ! az storage blob upload-batch \
+      --account-name "$storage_account" \
+      --destination "$container" \
+      --destination-path "$prefix" \
+      --source "$staging" \
+      --auth-mode login \
+      --overwrite true; then
+    upload_ok=false
+    echo "screenshot upload failed; report body will point at native logs"
+  fi
+
+  {
+    echo "## Screenshots"
+    echo ""
+    if [ "$upload_ok" = "false" ]; then
+      echo "_Screenshot upload failed; see the Glimmung native run logs._"
+      echo ""
+    else
+      if [ "$total" -gt "$taken" ]; then
+        echo "_Showing first ${taken} of ${total} screenshots._"
+        echo ""
+      fi
+      for file in "$staging"/*.png; do
+        [ -e "$file" ] || continue
+        base="$(basename "$file")"
+        echo "### ${base%.png}"
+        echo ""
+        echo "![${base%.png}](${container_url}/${prefix}/${base})"
+        echo ""
+      done
+    fi
+  } >"$SCREENSHOTS_MD"
+  rm -rf "$staging"
+}
+
+verify_result() {
+  if [ "$AGENT_EXIT_CODE" -ne 0 ]; then
+    add_reason "agent job exited with ${AGENT_EXIT_CODE}; see native step logs"
+    if [ -s /tmp/agent-pod.log ]; then
+      grep -E "::error::|Job failed|FATAL|panic:|agent produced no changes" /tmp/agent-pod.log \
+        | head -5 >>"$VERIFICATION_REASONS" || true
+    fi
+    write_verification "fail"
+    return 0
+  fi
+
+  if ! fetch_agent_branch; then
+    add_reason "agent completed but branch ${BRANCH_NAME} was not found"
+    write_verification "fail"
+    return 0
+  fi
+
+  if ! rebuild_validation_env; then
+    add_reason "rebuilt validation environment failed to deploy"
+    write_verification "fail"
+    return 0
+  fi
+
+  if ! capture_screenshots; then
+    add_reason "screenshot capture failed against ${VALIDATION_URL}"
+    write_verification "fail"
+    return 0
+  fi
+
+  upload_screenshots || true
+  write_verification "pass"
+}
+
+push_branch() {
+  local token
+  token="$(native_github_token)"
+  if git -c "http.extraHeader=Authorization: Bearer ${token}" \
+      ls-remote --exit-code "https://github.com/${REPO_SLUG}.git" "refs/heads/${BRANCH_NAME}" >/dev/null; then
+    kubectl label namespace "$NAMESPACE" "ambience.io/branch=${BRANCH_NAME//\//-}" --overwrite || true
+    echo "branch ${BRANCH_NAME} is present"
+    return 0
+  fi
+  if jq -e '.status == "pass"' "$VERIFICATION_JSON" >/dev/null 2>&1; then
+    echo "verification passed but branch ${BRANCH_NAME} is missing" >&2
+    return 1
+  fi
+  echo "branch ${BRANCH_NAME} is absent after failed verification"
+}
+
+emit_agent_outputs() {
+  if [ ! -s "$VERIFICATION_JSON" ]; then
+    add_reason "verification result was not produced"
+    write_verification "error"
+  fi
+  cat "$VERIFICATION_JSON"
+}
+
+native_step "clone-repo" clone_repo
+native_step "prepare-agent-context" prepare_agent_context
+native_step_allow_failure "run-agent" run_agent || AGENT_EXIT_CODE=$?
+native_step "collect-evidence" collect_evidence
+native_step "verify-result" verify_result
+native_step "push-branch" push_branch
+native_step "emit-agent-outputs" emit_agent_outputs
+native_assert_resume_satisfied
+
+native_completed "null" "$(cat "$VERIFICATION_JSON")" "$(cat "$SCREENSHOTS_MD")"

--- a/scripts/glimmung-native/env-prep.sh
+++ b/scripts/glimmung-native/env-prep.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib.sh
+source "${SCRIPT_DIR}/lib.sh"
+
+native_init
+native_require_env GLIMMUNG_VALIDATION_NAMESPACE GLIMMUNG_RUN_ID
+
+REPO_SLUG="${AMBIENCE_REPO_SLUG:-nelsong6/ambience}"
+REPO_DIR="${AMBIENCE_REPO_DIR:-/workspace/ambience}"
+RELEASE_NAME="${AMBIENCE_VALIDATION_RELEASE:-ambience-agent}"
+CLAUDE_NAMESPACE="${CLAUDE_NAMESPACE:-tank-operator}"
+
+NAMESPACE="${GLIMMUNG_VALIDATION_NAMESPACE}"
+VALIDATION_HOST="${NAMESPACE}.ambience.dev.romaine.life"
+VALIDATION_URL="https://${VALIDATION_HOST}"
+IMAGE_TAG="${NAMESPACE}"
+IMAGE_JSON="/tmp/ambience-preview-image.json"
+IMAGE_FILE="/tmp/ambience-preview-image.txt"
+
+clone_repo() {
+  native_clone_repo "$REPO_SLUG" "$REPO_DIR" main
+}
+
+install_preview_package() {
+  python3 -m pip install --user --upgrade pip
+  python3 -m pip install --user "${REPO_DIR}/mcp"
+}
+
+build_validation_image() {
+  native_azure_login
+  install_preview_package
+  (
+    cd "$REPO_DIR"
+    python3 -m ambience_preview.cli build-preview-image --image-tag "$IMAGE_TAG" >"$IMAGE_JSON"
+  )
+  jq -r '.image' "$IMAGE_JSON" >"$IMAGE_FILE"
+}
+
+push_validation_image() {
+  local tag
+  tag="$(
+    az acr repository show-tags \
+      --name romainecr \
+      --repository ambience \
+      --query "[?@=='${IMAGE_TAG}'] | [0]" \
+      --output tsv
+  )"
+  if [ "$tag" != "$IMAGE_TAG" ]; then
+    echo "image tag ${IMAGE_TAG} was not found in romainecr.azurecr.io/ambience" >&2
+    return 1
+  fi
+  echo "verified romainecr.azurecr.io/ambience:${IMAGE_TAG}"
+}
+
+deploy_validation_env() {
+  local image
+  image="$(cat "$IMAGE_FILE")"
+  (
+    cd "$REPO_DIR"
+    python3 -m ambience_preview.cli deploy-validation-preview \
+      --namespace "$NAMESPACE" \
+      --image "$image" \
+      --release "$RELEASE_NAME" \
+      --public-host "$VALIDATION_HOST"
+  )
+}
+
+check_validation_env() {
+  (
+    cd "$REPO_DIR"
+    python3 -m ambience_preview.cli wait-public-preview --url "$VALIDATION_URL"
+  )
+}
+
+emit_env_outputs() {
+  jq -nc \
+    --arg validation_url "$VALIDATION_URL" \
+    --arg namespace "$NAMESPACE" \
+    --arg image_tag "$IMAGE_TAG" \
+    --arg claude_namespace "$CLAUDE_NAMESPACE" \
+    '{
+      validation_url: $validation_url,
+      namespace: $namespace,
+      image_tag: $image_tag,
+      claude_namespace: $claude_namespace
+    }' >/tmp/ambience-env-outputs.json
+  cat /tmp/ambience-env-outputs.json
+}
+
+native_step "clone-repo" clone_repo
+native_step "build-validation-image" build_validation_image
+native_step "push-validation-image" push_validation_image
+native_step "deploy-validation-env" deploy_validation_env
+native_step "check-validation-env" check_validation_env
+native_step "emit-env-outputs" emit_env_outputs
+native_assert_resume_satisfied
+
+native_completed "$(cat /tmp/ambience-env-outputs.json)"

--- a/scripts/glimmung-native/lib.sh
+++ b/scripts/glimmung-native/lib.sh
@@ -1,0 +1,278 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+native_require_env() {
+  local missing=()
+  for name in "$@"; do
+    if [ -z "${!name:-}" ]; then
+      missing+=("$name")
+    fi
+  done
+  if [ "${#missing[@]}" -gt 0 ]; then
+    printf 'missing required env: %s\n' "${missing[*]}" >&2
+    exit 2
+  fi
+}
+
+native_init() {
+  native_require_env \
+    GLIMMUNG_ATTEMPT_TOKEN \
+    GLIMMUNG_EVENTS_URL \
+    GLIMMUNG_COMPLETED_URL \
+    GLIMMUNG_FAILED_URL \
+    GLIMMUNG_GITHUB_TOKEN_URL \
+    GLIMMUNG_JOB_ID \
+    GLIMMUNG_RUN_ID
+
+  NATIVE_SEQ_FILE="${NATIVE_SEQ_FILE:-/tmp/glimmung-native-seq}"
+  if [ ! -f "$NATIVE_SEQ_FILE" ]; then
+    printf '0\n' >"$NATIVE_SEQ_FILE"
+  fi
+  NATIVE_RESUME_FROM_STEP="${GLIMMUNG_RESUME_FROM_STEP:-}"
+  NATIVE_RESUME_SEEN=""
+  if [ -z "$NATIVE_RESUME_FROM_STEP" ]; then
+    NATIVE_RESUME_SEEN="1"
+  fi
+}
+
+native_next_seq() {
+  local current next
+  current="$(cat "$NATIVE_SEQ_FILE" 2>/dev/null || printf '0')"
+  next=$((current + 1))
+  printf '%s\n' "$next" >"$NATIVE_SEQ_FILE"
+  printf '%s' "$next"
+}
+
+native_post_json() {
+  local url="$1"
+  local payload="$2"
+  curl -fsS \
+    --retry 5 \
+    --retry-delay 1 \
+    --retry-all-errors \
+    -H "Content-Type: application/json" \
+    -H "X-Glimmung-Attempt-Token: ${GLIMMUNG_ATTEMPT_TOKEN}" \
+    -d "$payload" \
+    "$url" >/dev/null
+}
+
+native_event() {
+  local event="$1"
+  local step_slug="${2:-}"
+  local message="${3:-}"
+  local exit_code="${4:-}"
+  local metadata_json="${5:-{}}"
+  local seq exit_json payload
+  seq="$(native_next_seq)"
+  if [ -n "$exit_code" ]; then
+    exit_json="$exit_code"
+  else
+    exit_json="null"
+  fi
+  payload="$(
+    jq -nc \
+      --arg job_id "$GLIMMUNG_JOB_ID" \
+      --argjson seq "$seq" \
+      --arg event "$event" \
+      --arg step_slug "$step_slug" \
+      --arg message "$message" \
+      --argjson exit_code "$exit_json" \
+      --argjson metadata "$metadata_json" \
+      '{
+        job_id: $job_id,
+        seq: $seq,
+        event: $event,
+        metadata: $metadata
+      }
+      + (if $step_slug != "" then {step_slug: $step_slug} else {} end)
+      + (if $message != "" then {message: $message} else {} end)
+      + (if $exit_code != null then {exit_code: $exit_code} else {} end)'
+  )"
+  native_post_json "$GLIMMUNG_EVENTS_URL" "$payload"
+}
+
+native_log() {
+  local step_slug="$1"
+  local message="$2"
+  if [ -n "$message" ]; then
+    native_event "log" "$step_slug" "$message"
+  fi
+}
+
+native_log_file() {
+  local step_slug="$1"
+  local file="$2"
+  local chunk_dir part
+  if [ ! -s "$file" ]; then
+    return 0
+  fi
+  chunk_dir="$(mktemp -d)"
+  split -b 12000 "$file" "${chunk_dir}/chunk-"
+  for part in "${chunk_dir}"/chunk-*; do
+    [ -f "$part" ] || continue
+    native_log "$step_slug" "$(cat "$part")"
+  done
+  rm -rf "$chunk_dir"
+}
+
+native_should_skip_step() {
+  local step_slug="$1"
+  if [ -n "$NATIVE_RESUME_SEEN" ]; then
+    return 1
+  fi
+  if [ "$step_slug" = "$NATIVE_RESUME_FROM_STEP" ]; then
+    NATIVE_RESUME_SEEN="1"
+    return 1
+  fi
+  return 0
+}
+
+native_step() {
+  local step_slug="$1"
+  shift
+  native_step_run "$step_slug" "fatal" "$@"
+}
+
+native_step_allow_failure() {
+  local step_slug="$1"
+  shift
+  native_step_run "$step_slug" "allow" "$@"
+}
+
+native_step_run() {
+  local step_slug="$1"
+  local failure_mode="$2"
+  shift 2
+  local log_file rc metadata
+
+  if native_should_skip_step "$step_slug"; then
+    metadata="$(jq -nc --arg resume_from_step "$NATIVE_RESUME_FROM_STEP" '{resume_from_step: $resume_from_step}')"
+    native_event "step_skipped" "$step_slug" "skipped before resume target ${NATIVE_RESUME_FROM_STEP}" "" "$metadata"
+    return 0
+  fi
+
+  native_event "step_started" "$step_slug"
+  log_file="$(mktemp)"
+  set +e
+  "$@" >"$log_file" 2>&1
+  rc=$?
+  set -e
+  cat "$log_file"
+  native_log_file "$step_slug" "$log_file"
+  rm -f "$log_file"
+
+  if [ "$rc" -eq 0 ]; then
+    native_event "step_completed" "$step_slug" "" "0"
+    return 0
+  fi
+
+  native_event "step_failed" "$step_slug" "step exited ${rc}" "$rc"
+  if [ "$failure_mode" = "fatal" ]; then
+    native_failed "step ${step_slug} exited ${rc}"
+    exit "$rc"
+  fi
+  return "$rc"
+}
+
+native_assert_resume_satisfied() {
+  if [ -n "$NATIVE_RESUME_FROM_STEP" ] && [ -z "$NATIVE_RESUME_SEEN" ]; then
+    native_failed "unknown GLIMMUNG_RESUME_FROM_STEP=${NATIVE_RESUME_FROM_STEP}"
+    exit 2
+  fi
+}
+
+native_completed() {
+  local outputs_json="${1:-null}"
+  local verification_json="${2:-null}"
+  local screenshots_markdown="${3:-}"
+  local payload
+  payload="$(
+    jq -nc \
+      --arg conclusion "success" \
+      --argjson outputs "$outputs_json" \
+      --argjson verification "$verification_json" \
+      --arg screenshots "$screenshots_markdown" \
+      '{
+        conclusion: $conclusion
+      }
+      + (if $outputs != null then {outputs: $outputs} else {} end)
+      + (if $verification != null then {verification: $verification} else {} end)
+      + (if $screenshots != "" then {screenshots_markdown: $screenshots} else {} end)'
+  )"
+  native_post_json "$GLIMMUNG_COMPLETED_URL" "$payload"
+}
+
+native_failed() {
+  local reason="$1"
+  local payload
+  payload="$(jq -nc --arg reason "$reason" '{reason: $reason}')"
+  native_post_json "$GLIMMUNG_FAILED_URL" "$payload" || true
+}
+
+native_azure_login() {
+  if [ -z "${AZURE_CLIENT_ID:-}" ] || [ -z "${AZURE_TENANT_ID:-}" ] || [ -z "${AZURE_FEDERATED_TOKEN_FILE:-}" ]; then
+    echo "Azure workload identity env is missing; cannot login" >&2
+    return 1
+  fi
+  az login \
+    --service-principal \
+    --username "$AZURE_CLIENT_ID" \
+    --tenant "$AZURE_TENANT_ID" \
+    --federated-token "$(cat "$AZURE_FEDERATED_TOKEN_FILE")" \
+    --allow-no-subscriptions >/dev/null
+  if [ -n "${AZURE_SUBSCRIPTION_ID:-${ARM_SUBSCRIPTION_ID:-}}" ]; then
+    az account set --subscription "${AZURE_SUBSCRIPTION_ID:-${ARM_SUBSCRIPTION_ID}}"
+  fi
+}
+
+native_github_token() {
+  curl -fsS \
+    --retry 5 \
+    --retry-delay 1 \
+    --retry-all-errors \
+    -X POST \
+    -H "X-Glimmung-Attempt-Token: ${GLIMMUNG_ATTEMPT_TOKEN}" \
+    "$GLIMMUNG_GITHUB_TOKEN_URL" \
+    | jq -r '.token'
+}
+
+native_clone_repo() {
+  local repo_slug="$1"
+  local repo_dir="$2"
+  local base_ref="${3:-main}"
+  local branch_name="${4:-}"
+  local token
+
+  token="$(native_github_token)"
+  mkdir -p "$(dirname "$repo_dir")"
+  if [ ! -d "${repo_dir}/.git" ]; then
+    git init "$repo_dir" >/dev/null
+    git -C "$repo_dir" remote add origin "https://github.com/${repo_slug}.git"
+  fi
+
+  git -C "$repo_dir" remote set-url origin "https://github.com/${repo_slug}.git"
+  git -C "$repo_dir" \
+    -c "http.extraHeader=Authorization: Bearer ${token}" \
+    fetch --force origin "+refs/heads/*:refs/remotes/origin/*"
+  git -C "$repo_dir" config user.name "ambience-agent[bot]"
+  git -C "$repo_dir" config user.email "ambience-agent@romaine.life"
+
+  if [ -n "$branch_name" ]; then
+    git -C "$repo_dir" checkout -B "$branch_name" "origin/${base_ref}"
+  else
+    git -C "$repo_dir" checkout --detach "origin/${base_ref}"
+  fi
+}
+
+native_push_branch() {
+  local repo_slug="$1"
+  local repo_dir="$2"
+  local branch_name="$3"
+  local token
+  token="$(native_github_token)"
+  git -C "$repo_dir" remote set-url origin "https://github.com/${repo_slug}.git"
+  git -C "$repo_dir" \
+    -c "http.extraHeader=Authorization: Bearer ${token}" \
+    push origin "HEAD:${branch_name}"
+}

--- a/scripts/glimmung-native/register-workflow.sh
+++ b/scripts/glimmung-native/register-workflow.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+GLIMMUNG_BASE="${GLIMMUNG_BASE:-https://glimmung.romaine.life}"
+GLIMMUNG_PROJECT="${GLIMMUNG_PROJECT:-ambience}"
+GLIMMUNG_WORKFLOW="${GLIMMUNG_WORKFLOW:-agent-run}"
+AMBIENCE_NATIVE_RUNNER_IMAGE="${AMBIENCE_NATIVE_RUNNER_IMAGE:?set AMBIENCE_NATIVE_RUNNER_IMAGE to the pushed native runner image}"
+AZURE_SUBSCRIPTION_ID="${AZURE_SUBSCRIPTION_ID:-aee0cbd2-8074-4001-b610-0f8edb4eaa3c}"
+AGENT_CONTAINER_TAG="${AGENT_CONTAINER_TAG:-latest}"
+AGENT_SCREENSHOT_STORAGE_ACCOUNT="${AGENT_SCREENSHOT_STORAGE_ACCOUNT:-infraagentscreens}"
+AGENT_SCREENSHOT_CONTAINER="${AGENT_SCREENSHOT_CONTAINER:-ambience}"
+AGENT_SCREENSHOT_CONTAINER_URL="${AGENT_SCREENSHOT_CONTAINER_URL:-https://infraagentscreens.blob.core.windows.net/ambience}"
+
+admin_token() {
+  if [ -n "${GLIMMUNG_ADMIN_TOKEN:-}" ]; then
+    printf '%s' "$GLIMMUNG_ADMIN_TOKEN"
+    return 0
+  fi
+  if [ -n "${GLIMMUNG_ADMIN_TOKEN_FILE:-}" ]; then
+    tr -d '\n' <"$GLIMMUNG_ADMIN_TOKEN_FILE"
+    return 0
+  fi
+  tr -d '\n' </var/run/secrets/kubernetes.io/serviceaccount/token
+}
+
+admin_curl() {
+  local method="$1"
+  local path="$2"
+  local body="$3"
+  local token
+  token="$(admin_token)"
+  curl -fsS \
+    -X "$method" \
+    -H "Authorization: Bearer ${token}" \
+    -H "Content-Type: application/json" \
+    -d "$body" \
+    "${GLIMMUNG_BASE}${path}"
+}
+
+workflow_payload="$(
+  jq -nc \
+    --arg project "$GLIMMUNG_PROJECT" \
+    --arg workflow "$GLIMMUNG_WORKFLOW" \
+    --arg image "$AMBIENCE_NATIVE_RUNNER_IMAGE" \
+    --arg subscription "$AZURE_SUBSCRIPTION_ID" \
+    --arg agent_container_tag "$AGENT_CONTAINER_TAG" \
+    --arg screenshot_account "$AGENT_SCREENSHOT_STORAGE_ACCOUNT" \
+    --arg screenshot_container "$AGENT_SCREENSHOT_CONTAINER" \
+    --arg screenshot_url "$AGENT_SCREENSHOT_CONTAINER_URL" \
+    '{
+      project: $project,
+      name: $workflow,
+      trigger_label: "issue-agent",
+      budget: {total: 25.0},
+      default_requirements: {},
+      phases: [
+        {
+          name: "env-prep",
+          kind: "k8s_job",
+          outputs: ["validation_url", "namespace", "image_tag", "claude_namespace"],
+          jobs: [
+            {
+              id: "env-prep",
+              name: "Build and deploy validation environment",
+              image: $image,
+              command: ["/bin/bash", "/opt/ambience-native/scripts/env-prep.sh"],
+              env: {
+                AZURE_SUBSCRIPTION_ID: $subscription
+              },
+              timeout_seconds: 2400,
+              steps: [
+                {slug: "clone-repo", title: "Clone repository"},
+                {slug: "build-validation-image", title: "Build validation image"},
+                {slug: "push-validation-image", title: "Verify validation image"},
+                {slug: "deploy-validation-env", title: "Deploy validation environment"},
+                {slug: "check-validation-env", title: "Check validation environment"},
+                {slug: "emit-env-outputs", title: "Emit phase outputs"}
+              ]
+            }
+          ]
+        },
+        {
+          name: "agent-execute",
+          kind: "k8s_job",
+          inputs: {
+            validation_url: "${{ phases.env-prep.outputs.validation_url }}",
+            namespace: "${{ phases.env-prep.outputs.namespace }}",
+            image_tag: "${{ phases.env-prep.outputs.image_tag }}",
+            claude_namespace: "${{ phases.env-prep.outputs.claude_namespace }}"
+          },
+          verify: true,
+          recycle_policy: {
+            max_attempts: 3,
+            on: ["verify_fail", "verify_malformed"],
+            lands_at: "self"
+          },
+          jobs: [
+            {
+              id: "agent-execute",
+              name: "Run agent and verify result",
+              image: $image,
+              command: ["/bin/bash", "/opt/ambience-native/scripts/agent-execute.sh"],
+              env: {
+                AZURE_SUBSCRIPTION_ID: $subscription,
+                AGENT_CONTAINER_TAG: $agent_container_tag,
+                AGENT_SCREENSHOT_STORAGE_ACCOUNT: $screenshot_account,
+                AGENT_SCREENSHOT_CONTAINER: $screenshot_container,
+                AGENT_SCREENSHOT_CONTAINER_URL: $screenshot_url
+              },
+              timeout_seconds: 5400,
+              steps: [
+                {slug: "clone-repo", title: "Clone repository"},
+                {slug: "prepare-agent-context", title: "Prepare agent context"},
+                {slug: "run-agent", title: "Run agent job"},
+                {slug: "collect-evidence", title: "Collect evidence"},
+                {slug: "verify-result", title: "Verify result"},
+                {slug: "push-branch", title: "Confirm pushed branch"},
+                {slug: "emit-agent-outputs", title: "Emit verification"}
+              ]
+            }
+          ]
+        }
+      ],
+      pr: {
+        enabled: true,
+        recycle_policy: {
+          max_attempts: 3,
+          on: ["pr_review_changes_requested"],
+          lands_at: "agent-execute"
+        }
+      }
+    }'
+)"
+
+if [ "${GLIMMUNG_REGISTER_DRY_RUN:-}" = "1" ]; then
+  printf '%s\n' "$workflow_payload"
+  exit 0
+fi
+
+if ! curl -fsS "${GLIMMUNG_BASE}/v1/projects" \
+    | jq -e --arg project "$GLIMMUNG_PROJECT" '.[] | select(.name == $project)' >/dev/null; then
+  project_payload="$(
+    jq -nc \
+      --arg name "$GLIMMUNG_PROJECT" \
+      --arg repo "nelsong6/ambience" \
+      '{name: $name, github_repo: $repo, metadata: {runner: "native-k8s"}}'
+  )"
+  admin_curl POST /v1/projects "$project_payload" >/dev/null
+  echo "registered project ${GLIMMUNG_PROJECT}"
+fi
+
+admin_curl POST /v1/workflows "$workflow_payload"
+echo
+echo "registered ${GLIMMUNG_PROJECT}/${GLIMMUNG_WORKFLOW} -> ${AMBIENCE_NATIVE_RUNNER_IMAGE}"


### PR DESCRIPTION
## Summary

- add repo-owned native Glimmung scripts for Ambience `env-prep` and `agent-execute` phases
- add a native runner image build workflow and extend the runner image with Python, kubectl, Helm, and native scripts
- add workflow registration for the native `agent-run` pipeline, including first-class steps and recycle policy
- update the agentic issue-flow docs to state GitHub Actions is no longer the Ambience issue-runner source

## Checks

- `bash -n scripts/glimmung-native/*.sh`
- `PYTHONPATH=mcp python3 -m ambience_preview.cli apply-agent-job --help`
- `AMBIENCE_NATIVE_RUNNER_IMAGE=romainecr.azurecr.io/ambience-agent-runner:native-test GLIMMUNG_REGISTER_DRY_RUN=1 scripts/glimmung-native/register-workflow.sh`
- `uv run python` in `glimmung` validating the generated workflow payload with `WorkflowRegister`
- `git diff --cached --check`