### PR TITLE
Self-manage Ambience Microsoft auth

### DIFF
--- a/.github/workflows/tofu.yaml
+++ b/.github/workflows/tofu.yaml
@@ -23,6 +23,6 @@ jobs:
     uses: nelsong6/pipeline-templates/.github/workflows/tofu-plan-apply-template.yml@main
     with:
       working_directory: tofu
-      backend_storage_account: ${{ vars.TFSTATE_STORAGE_ACCOUNT }}
+      backend_storage_account: ${{ vars.TFSTATE_STORAGE_ACCOUNT || 'nelsontofu' }}
       backend_key: ambience.tfstate
     secrets: inherit

--- a/.github/workflows/tofu.yaml
+++ b/.github/workflows/tofu.yaml
@@ -1,0 +1,28 @@
+name: Infrastructure
+
+on:
+  pull_request:
+    branches: [main]
+    paths: ['tofu/**']
+  push:
+    branches: [main]
+    paths: ['tofu/**']
+  workflow_dispatch:
+
+concurrency:
+  group: tofu-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  id-token: write
+  contents: read
+  pull-requests: write
+
+jobs:
+  tofu:
+    uses: nelsong6/pipeline-templates/.github/workflows/tofu-plan-apply-template.yml@main
+    with:
+      working_directory: tofu
+      backend_storage_account: ${{ vars.TFSTATE_STORAGE_ACCOUNT }}
+      backend_key: ambience.tfstate
+    secrets: inherit

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@
 .env
 /.claude/settings.local.json
 node_modules/
+.terraform/
+**/.terraform/
 /.github/codex/output/
 /.github/codex/tmp/
 mcp/.venv/

--- a/chart/ambience/templates/authority-statefulset.yaml
+++ b/chart/ambience/templates/authority-statefulset.yaml
@@ -52,6 +52,17 @@ spec:
                   name: {{ .existingSecret | quote }}
                   key: {{ .passwordKey | quote }}
             {{- end }}
+            {{- with .microsoft }}
+            {{- if .enabled }}
+            - name: AMBIENCE_MICROSOFT_TENANT
+              value: {{ $.Values.oauth.microsoft.tenant | quote }}
+            - name: AMBIENCE_MICROSOFT_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .existingSecret | quote }}
+                  key: {{ .clientIdKey | quote }}
+            {{- end }}
+            {{- end }}
             {{- end }}
           ports:
             - containerPort: 8080

--- a/chart/ambience/templates/oauth-externalsecret.yaml
+++ b/chart/ambience/templates/oauth-externalsecret.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.oauth.externalSecret.enabled }}
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: {{ .Values.oauth.externalSecret.name | quote }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "ambience.labels" . | nindent 4 }}
+spec:
+  refreshInterval: {{ .Values.oauth.externalSecret.refreshInterval | quote }}
+  secretStoreRef:
+    name: {{ .Values.oauth.externalSecret.storeName | quote }}
+    kind: {{ .Values.oauth.externalSecret.storeKind | quote }}
+  target:
+    name: {{ .Values.oauth.externalSecret.name | quote }}
+    creationPolicy: Owner
+    deletionPolicy: Retain
+  data:
+    - secretKey: client-id
+      remoteRef:
+        key: {{ .Values.oauth.externalSecret.clientIdKey | quote }}
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None
+        nullBytePolicy: Ignore
+{{- end }}

--- a/chart/ambience/values-prod.yaml
+++ b/chart/ambience/values-prod.yaml
@@ -10,8 +10,12 @@ edge:
 
 authority:
   controlAuth:
-    existingSecret: ambience-control-auth
-    passwordKey: password
+    microsoft:
+      enabled: true
+
+oauth:
+  externalSecret:
+    enabled: true
 
 pdb:
   enabled: true

--- a/chart/ambience/values.yaml
+++ b/chart/ambience/values.yaml
@@ -44,6 +44,17 @@ service:
   port: 80
   targetPort: http
 
+oauth:
+  microsoft:
+    tenant: common
+  externalSecret:
+    enabled: false
+    name: ambience-oauth
+    storeName: romaine-kv
+    storeKind: ClusterSecretStore
+    refreshInterval: 1h
+    clientIdKey: ambience-oauth-client-id
+
 edge:
   enabled: true
   image:
@@ -119,6 +130,10 @@ authority:
   controlAuth:
     existingSecret: ""
     passwordKey: password
+    microsoft:
+      enabled: false
+      existingSecret: ambience-oauth
+      clientIdKey: client-id
   resources:
     requests:
       cpu: 10m

--- a/cmd/ambience/control_auth.go
+++ b/cmd/ambience/control_auth.go
@@ -17,17 +17,20 @@ const controlAuthCookie = "ambience_control"
 type controlAuthenticator struct {
 	passwordHash [sha256.Size]byte
 	required     bool
+	microsoft    *microsoftControlAuth
 	mu           sync.Mutex
 	sessions     map[string]time.Time
 }
 
-func newControlAuthenticator(password string) *controlAuthenticator {
+func newControlAuthenticator(password string, microsoftCfg microsoftControlAuthConfig) *controlAuthenticator {
 	password = strings.TrimSpace(password)
+	microsoftAuth := newMicrosoftControlAuth(microsoftCfg)
 	a := &controlAuthenticator{
-		required: password != "",
-		sessions: make(map[string]time.Time),
+		required:  password != "" || microsoftAuth != nil,
+		microsoft: microsoftAuth,
+		sessions:  make(map[string]time.Time),
 	}
-	if a.required {
+	if password != "" {
 		a.passwordHash = sha256.Sum256([]byte(password))
 	}
 	return a
@@ -81,10 +84,16 @@ func (a *controlAuthenticator) serve(w http.ResponseWriter, req *http.Request) {
 
 func (a *controlAuthenticator) writeStatus(w http.ResponseWriter, req *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
-	_ = json.NewEncoder(w).Encode(map[string]bool{
+	status := map[string]any{
 		"required":      a.required,
 		"authenticated": a.authenticated(req),
-	})
+	}
+	if a.microsoft != nil {
+		status["provider"] = "microsoft"
+		status["microsoftTenant"] = a.microsoft.tenant
+		status["microsoftClientId"] = a.microsoft.clientID
+	}
+	_ = json.NewEncoder(w).Encode(status)
 }
 
 func (a *controlAuthenticator) login(w http.ResponseWriter, req *http.Request) {
@@ -94,15 +103,24 @@ func (a *controlAuthenticator) login(w http.ResponseWriter, req *http.Request) {
 	}
 	var body struct {
 		Password string `json:"password"`
+		IDToken  string `json:"idToken"`
+		Nonce    string `json:"nonce"`
 	}
 	if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
 		http.Error(w, "bad auth payload", http.StatusBadRequest)
 		return
 	}
-	got := sha256.Sum256([]byte(body.Password))
-	if subtle.ConstantTimeCompare(got[:], a.passwordHash[:]) != 1 {
-		http.Error(w, "bad password", http.StatusUnauthorized)
-		return
+	if a.microsoft != nil {
+		if err := a.microsoft.verifyIDToken(req.Context(), body.IDToken, body.Nonce); err != nil {
+			http.Error(w, "bad microsoft token", http.StatusUnauthorized)
+			return
+		}
+	} else {
+		got := sha256.Sum256([]byte(body.Password))
+		if subtle.ConstantTimeCompare(got[:], a.passwordHash[:]) != 1 {
+			http.Error(w, "bad password", http.StatusUnauthorized)
+			return
+		}
 	}
 	token, err := randomToken()
 	if err != nil {

--- a/cmd/ambience/main.go
+++ b/cmd/ambience/main.go
@@ -12,7 +12,7 @@
 //	GET  /snapshot              — shared atmosphere init payload (JSON)
 //	GET  /events                — shared atmosphere SSE command stream
 //	GET  /control-auth          — live-control auth status
-//	POST /control-auth          — live-control password login
+//	POST /control-auth          — live-control login
 //	POST /config?effect=&...    — mutate the shared atmosphere config
 //	POST /trigger/:event        — fire a discrete event on the shared atmosphere
 //	GET  /dev                   — dev page with knob controls (defaults to rain)
@@ -63,12 +63,13 @@ const (
 )
 
 type appConfig struct {
-	role            appRole
-	addr            string
-	authorityURL    string
-	controlPassword string
-	shutdownDrain   time.Duration
-	webOverrideDir  string
+	role             appRole
+	addr             string
+	authorityURL     string
+	controlPassword  string
+	controlMicrosoft microsoftControlAuthConfig
+	shutdownDrain    time.Duration
+	webOverrideDir   string
 }
 
 type lifecycleState struct {
@@ -96,7 +97,7 @@ func main() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	lifecycle := &lifecycleState{}
-	controlAuth = newControlAuthenticator(cfg.controlPassword)
+	controlAuth = newControlAuthenticator(cfg.controlPassword, cfg.controlMicrosoft)
 
 	mux := http.NewServeMux()
 	baseReady := func() bool { return true }
@@ -186,6 +187,10 @@ func loadAppConfigFromEnv() (appConfig, error) {
 		return appConfig{}, fmt.Errorf("AMBIENCE_AUTHORITY_URL is required when AMBIENCE_ROLE=%q", roleEdge)
 	}
 	cfg.controlPassword = os.Getenv("AMBIENCE_CONTROL_PASSWORD")
+	cfg.controlMicrosoft = microsoftControlAuthConfig{
+		Tenant:   strings.TrimSpace(os.Getenv("AMBIENCE_MICROSOFT_TENANT")),
+		ClientID: strings.TrimSpace(os.Getenv("AMBIENCE_MICROSOFT_CLIENT_ID")),
+	}
 	if rawDrain := strings.TrimSpace(os.Getenv("AMBIENCE_SHUTDOWN_DRAIN")); rawDrain != "" {
 		d, err := time.ParseDuration(rawDrain)
 		if err != nil {
@@ -244,6 +249,7 @@ func registerStaticRoutes(mux *http.ServeMux, static staticAssets, lookup effect
 	// it as a platform route, kept out of product-route space. Contract:
 	// nelsong6/glimmung/docs/styleguide-contract.md.
 	mux.HandleFunc("/_styleguide", serveExactStaticFile(static, "/_styleguide", "styleguide.html"))
+	mux.HandleFunc("/auth/callback", serveExactStaticFile(static, "/auth/callback", "index.html"))
 	mux.HandleFunc("/", serveExactStaticFile(static, "/", "index.html"))
 }
 

--- a/cmd/ambience/microsoft_auth.go
+++ b/cmd/ambience/microsoft_auth.go
@@ -1,0 +1,218 @@
+package main
+
+import (
+	"context"
+	"crypto"
+	"crypto/rsa"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"math/big"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+type microsoftControlAuthConfig struct {
+	Tenant   string
+	ClientID string
+}
+
+type microsoftControlAuth struct {
+	tenant   string
+	clientID string
+	jwksURL  string
+	client   *http.Client
+	mu       sync.Mutex
+	keys     map[string]*rsa.PublicKey
+	fetched  time.Time
+}
+
+func newMicrosoftControlAuth(cfg microsoftControlAuthConfig) *microsoftControlAuth {
+	tenant := strings.TrimSpace(cfg.Tenant)
+	clientID := strings.TrimSpace(cfg.ClientID)
+	if tenant == "" || clientID == "" {
+		return nil
+	}
+	return &microsoftControlAuth{
+		tenant:   tenant,
+		clientID: clientID,
+		jwksURL:  fmt.Sprintf("https://login.microsoftonline.com/%s/discovery/v2.0/keys", tenant),
+		client:   &http.Client{Timeout: 5 * time.Second},
+	}
+}
+
+func (m *microsoftControlAuth) verifyIDToken(ctx context.Context, raw, nonce string) error {
+	parts := strings.Split(raw, ".")
+	if len(parts) != 3 {
+		return errors.New("token must be jwt")
+	}
+	var header struct {
+		Alg string `json:"alg"`
+		Kid string `json:"kid"`
+	}
+	var claims struct {
+		Aud   any    `json:"aud"`
+		Iss   string `json:"iss"`
+		Tid   string `json:"tid"`
+		Exp   int64  `json:"exp"`
+		Nbf   int64  `json:"nbf"`
+		Nonce string `json:"nonce"`
+	}
+	if err := decodeJWTJSON(parts[0], &header); err != nil {
+		return err
+	}
+	if header.Alg != "RS256" || header.Kid == "" {
+		return errors.New("unsupported token header")
+	}
+	if err := decodeJWTJSON(parts[1], &claims); err != nil {
+		return err
+	}
+	now := time.Now().Unix()
+	if claims.Exp <= now || (claims.Nbf != 0 && claims.Nbf > now+60) {
+		return errors.New("token time invalid")
+	}
+	if !jwtAudienceMatches(claims.Aud, m.clientID) {
+		return errors.New("token audience invalid")
+	}
+	if !m.issuerAllowed(claims.Iss, claims.Tid) {
+		return errors.New("token issuer invalid")
+	}
+	if nonce == "" || claims.Nonce != nonce {
+		return errors.New("token nonce invalid")
+	}
+	key, err := m.key(ctx, header.Kid)
+	if err != nil {
+		return err
+	}
+	sig, err := base64.RawURLEncoding.DecodeString(parts[2])
+	if err != nil {
+		return err
+	}
+	sum := sha256.Sum256([]byte(parts[0] + "." + parts[1]))
+	return rsa.VerifyPKCS1v15(key, crypto.SHA256, sum[:], sig)
+}
+
+func (m *microsoftControlAuth) issuerAllowed(issuer, tenantID string) bool {
+	tenant := strings.ToLower(m.tenant)
+	if tenant == "common" || tenant == "organizations" {
+		return tenantID != "" && strings.HasPrefix(issuer, "https://login.microsoftonline.com/"+tenantID+"/")
+	}
+	return issuer == "https://login.microsoftonline.com/"+m.tenant+"/v2.0"
+}
+
+func (m *microsoftControlAuth) key(ctx context.Context, kid string) (*rsa.PublicKey, error) {
+	m.mu.Lock()
+	if key := m.keys[kid]; key != nil && time.Since(m.fetched) < time.Hour {
+		m.mu.Unlock()
+		return key, nil
+	}
+	m.mu.Unlock()
+	if err := m.refreshKeys(ctx); err != nil {
+		return nil, err
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	key := m.keys[kid]
+	if key == nil {
+		return nil, errors.New("microsoft key not found")
+	}
+	return key, nil
+}
+
+func (m *microsoftControlAuth) refreshKeys(ctx context.Context) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, m.jwksURL, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := m.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("microsoft jwks returned %s", resp.Status)
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return err
+	}
+	var jwks struct {
+		Keys []struct {
+			Kid string `json:"kid"`
+			Kty string `json:"kty"`
+			N   string `json:"n"`
+			E   string `json:"e"`
+		} `json:"keys"`
+	}
+	if err := json.Unmarshal(body, &jwks); err != nil {
+		return err
+	}
+	keys := make(map[string]*rsa.PublicKey, len(jwks.Keys))
+	for _, jwk := range jwks.Keys {
+		if jwk.Kty != "RSA" || jwk.Kid == "" {
+			continue
+		}
+		key, err := rsaPublicKeyFromJWK(jwk.N, jwk.E)
+		if err != nil {
+			continue
+		}
+		keys[jwk.Kid] = key
+	}
+	if len(keys) == 0 {
+		return errors.New("microsoft jwks had no rsa keys")
+	}
+	m.mu.Lock()
+	m.keys = keys
+	m.fetched = time.Now()
+	m.mu.Unlock()
+	return nil
+}
+
+func decodeJWTJSON(segment string, target any) error {
+	raw, err := base64.RawURLEncoding.DecodeString(segment)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(raw, target)
+}
+
+func jwtAudienceMatches(aud any, clientID string) bool {
+	switch value := aud.(type) {
+	case string:
+		return value == clientID
+	case []any:
+		for _, item := range value {
+			if s, ok := item.(string); ok && s == clientID {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func rsaPublicKeyFromJWK(nRaw, eRaw string) (*rsa.PublicKey, error) {
+	nBytes, err := base64.RawURLEncoding.DecodeString(nRaw)
+	if err != nil {
+		return nil, err
+	}
+	eBytes, err := base64.RawURLEncoding.DecodeString(eRaw)
+	if err != nil {
+		return nil, err
+	}
+	e := 0
+	for _, b := range eBytes {
+		e = e<<8 + int(b)
+	}
+	if e == 0 {
+		return nil, errors.New("invalid rsa exponent")
+	}
+	return &rsa.PublicKey{
+		N: new(big.Int).SetBytes(nBytes),
+		E: e,
+	}, nil
+}

--- a/cmd/ambience/web/index.html
+++ b/cmd/ambience/web/index.html
@@ -486,6 +486,9 @@
   let initialFadeCover = null;
   let controlAuthenticated = false;
   let controlAuthRequired = true;
+  let controlAuthProvider = '';
+  let microsoftTenant = '';
+  let microsoftClientId = '';
 
   const el = {
     panel: document.getElementById('panel'),
@@ -551,6 +554,9 @@
       const status = await resp.json();
       controlAuthRequired = !!status.required;
       controlAuthenticated = !controlAuthRequired || !!status.authenticated;
+      controlAuthProvider = status.provider || '';
+      microsoftTenant = status.microsoftTenant || '';
+      microsoftClientId = status.microsoftClientId || '';
     } catch (err) {
       console.error('control auth', err);
       controlAuthRequired = true;
@@ -559,7 +565,69 @@
     setControlsLocked(controls.isLocked());
   }
 
+  function microsoftAuthURL() {
+    const state = crypto.randomUUID ? crypto.randomUUID() : String(Date.now()) + Math.random();
+    const nonce = crypto.randomUUID ? crypto.randomUUID() : String(Date.now()) + Math.random();
+    sessionStorage.setItem('ambience.microsoft.state', state);
+    sessionStorage.setItem('ambience.microsoft.nonce', nonce);
+    const q = new URLSearchParams({
+      client_id: microsoftClientId,
+      response_type: 'id_token',
+      redirect_uri: window.location.origin + '/auth/callback',
+      response_mode: 'fragment',
+      scope: 'openid profile email',
+      state,
+      nonce,
+    });
+    return 'https://login.microsoftonline.com/' + encodeURIComponent(microsoftTenant) + '/oauth2/v2.0/authorize?' + q.toString();
+  }
+
+  async function completeMicrosoftSignIn(idToken, nonce) {
+    const resp = await fetch('/control-auth', {
+      method: 'POST',
+      credentials: 'same-origin',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ idToken, nonce }),
+    });
+    if (!resp.ok) throw new Error('auth returned ' + resp.status);
+    const status = await resp.json();
+    controlAuthRequired = !!status.required;
+    controlAuthenticated = !controlAuthRequired || !!status.authenticated;
+    controlAuthProvider = status.provider || controlAuthProvider;
+    microsoftTenant = status.microsoftTenant || microsoftTenant;
+    microsoftClientId = status.microsoftClientId || microsoftClientId;
+    log('live controls signed in', 'system');
+    return controlAuthenticated;
+  }
+
+  async function handleMicrosoftCallback() {
+    if (!window.location.hash || !window.location.hash.includes('id_token=')) return;
+    const params = new URLSearchParams(window.location.hash.slice(1));
+    const expectedState = sessionStorage.getItem('ambience.microsoft.state');
+    const expectedNonce = sessionStorage.getItem('ambience.microsoft.nonce');
+    sessionStorage.removeItem('ambience.microsoft.state');
+    sessionStorage.removeItem('ambience.microsoft.nonce');
+    history.replaceState(null, '', '/');
+    if (!params.get('id_token') || !expectedState || !expectedNonce || params.get('state') !== expectedState) {
+      log('live control sign-in failed', 'system');
+      return;
+    }
+    try {
+      const signedIn = await completeMicrosoftSignIn(params.get('id_token'), expectedNonce);
+      setControlsLocked(!signedIn);
+    } catch (err) {
+      console.error('control auth', err);
+      controlAuthenticated = false;
+      log('live control sign-in failed', 'system');
+      setControlsLocked(true);
+    }
+  }
+
   async function signInControls() {
+    if (controlAuthProvider === 'microsoft' && microsoftTenant && microsoftClientId) {
+      window.location.assign(microsoftAuthURL());
+      return;
+    }
     const password = window.prompt('live control password');
     if (!password) return;
     el.lockButton.disabled = true;
@@ -637,6 +705,7 @@
     }
     setControlsLocked(!controls.isLocked());
   });
+  handleMicrosoftCallback();
   refreshControlAuth();
 
   function setPanelCollapsed(on) {

--- a/tofu/.terraform.lock.hcl
+++ b/tofu/.terraform.lock.hcl
@@ -1,0 +1,40 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/azuread" {
+  version = "3.8.0"
+  hashes = [
+    "h1:rqAjqkA5dloKFuETW2+/jaFrnUFIPKJkTAkpQFUFh6k=",
+    "zh:0cb139a86c05254ad19d6fe7e287758121300d85f6093e5da2fc4e5bc3905b1e",
+    "zh:28a656a84534c5f954a0c77133737890a1923ff077cdde38a5c99073bffb5ec8",
+    "zh:2944340622ec29f64e2a6425ef6ef954bba7ece30f1a0aa3782a5725cd6a6b72",
+    "zh:4317d439cb32edd7f493dfab4b7b4cec55023564ed0bad7a41ee2fccc8cc42e7",
+    "zh:4446aedb4f31c84051f7868e14abf278d4a8d604fb8f1946f58624c2976797fa",
+    "zh:45fc14856de8baaafb1954298b6f6e68510e3225d8d794e07f3e2c295f7be6d7",
+    "zh:6996bf92d8a1ba346323659b631489849c971f8caac711cecb518409e35a3eed",
+    "zh:6f5a31e6e1aac4b2f84001cdb73f1f02833986141d0019b257d1a2e4a8598864",
+    "zh:a05b0790926f02bf0a80b4dd3595a3cdf1d22e175cbe1de0dccf04d66f827aee",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/azurerm" {
+  version = "4.71.0"
+  hashes = [
+    "h1:jZ0P6nxFKT4hfN8+fM3vIALecddVsLwfg3arz5iPCRA=",
+    "zh:1a4c5352c62d5baf77f11c3c6db911b54bd59c42397d87bd41efe0e0c0db6804",
+    "zh:2b7a324b1a131bad5e426e65cbb64230f6c8a1d64ee85850e56116b6503e1c71",
+    "zh:2ed38f89ac5176c6cc519d4e05d66621fb2e6650f9d071a91bc4b855960d4464",
+    "zh:3d5ac7037209ef36f29be18c0b673fa776bffac0b2cc04c41c32eeb9f608cee7",
+    "zh:3f02e61c4b420fe47f1918fe53f630eaf6e63722f329f3f5a199c907dec830c0",
+    "zh:4398eeaada4f676bb603697e4e5f3429fa309dd99cba63581957f431dfa7977e",
+    "zh:6478d34cbfa7e37e880a3f64f0be79a4eebf2d2cef8e68cdea4d4401e861f3d7",
+    "zh:6c373e810a473a369fb22f77d19dcec8bf7f8b92a9a068078d030544812508bb",
+    "zh:6e3c182bc68fb2cad1d700c5371334c0c307c28a3d56daa74cf87c199fb81f99",
+    "zh:7718b65d9d55470f1181c8ab7ca9713dc74d0a85935ccbbaba07cfeddbb09ab4",
+    "zh:b3fd7ac2e39535d091c9abbfdf44b952d89295634b6d28b84aa54d88cbe0dbdd",
+    "zh:b5af2f6e8412acd28c687fd34623fd310abea76f850a94774749147532e7c675",
+    "zh:d5ea340d08e5112cdb84f38b3d22f4e48ece6620b4de753e0bca27e5e8274a0a",
+    "zh:e8f585779b280e92b1b4beb9b5e79386023f8fe25e92580cb069d741af0f7f62",
+    "zh:f5c219704df8481b2a55046956e681aa9b0e16ffeba01bb3429be3e2d0b500db",
+  ]
+}

--- a/tofu/README.md
+++ b/tofu/README.md
@@ -1,0 +1,19 @@
+# Ambience Infrastructure
+
+This directory owns Ambience-specific Azure resources. Shared cluster
+infrastructure still lives in `nelsong6/infra-bootstrap`.
+
+## Existing OAuth Registration Migration
+
+`ambience-oauth` was originally declared in `infra-bootstrap`. Apply the
+matching `infra-bootstrap` change first so that state forgets the old resources
+without deleting them. Then import the live objects here before the first
+Ambience tofu apply:
+
+```sh
+tofu import azuread_application.oauth <ambience-oauth application object id>
+tofu import azuread_service_principal.oauth <ambience-oauth service principal object id>
+tofu import azurerm_key_vault_secret.oauth_client_id https://romaine-kv.vault.azure.net/secrets/ambience-oauth-client-id/<version>
+```
+
+After import, `tofu plan` should show no replacement for the Entra application.

--- a/tofu/oauth.tf
+++ b/tofu/oauth.tf
@@ -1,0 +1,49 @@
+# Ambience user-auth Entra app.
+#
+# This is app-owned infrastructure: the registration exists for Ambience's
+# browser control sign-in, while the public client id is published to Key Vault
+# for the chart to project into the authority pod.
+
+resource "azuread_application" "oauth" {
+  display_name     = "ambience-oauth"
+  sign_in_audience = "AzureADMyOrg"
+
+  owners = [data.azuread_client_config.current.object_id]
+
+  api {
+    requested_access_token_version = 2
+  }
+
+  # The web platform permits the wildcard callback used by per-issue preview
+  # hosts. Ambience consumes an id_token from the browser and validates it
+  # server-side before minting the live-control session cookie.
+  web {
+    redirect_uris = [
+      for hostname in var.hostnames : "https://${hostname}/auth/callback"
+    ]
+
+    implicit_grant {
+      access_token_issuance_enabled = false
+      id_token_issuance_enabled     = true
+    }
+  }
+
+  required_resource_access {
+    resource_app_id = "00000003-0000-0000-c000-000000000000" # Microsoft Graph
+
+    resource_access {
+      id   = "e1fe6dd8-ba31-4d61-89e7-88639da4683d" # User.Read
+      type = "Scope"
+    }
+  }
+}
+
+resource "azuread_service_principal" "oauth" {
+  client_id = azuread_application.oauth.client_id
+}
+
+resource "azurerm_key_vault_secret" "oauth_client_id" {
+  name         = "ambience-oauth-client-id"
+  value        = azuread_application.oauth.client_id
+  key_vault_id = data.azurerm_key_vault.main.id
+}

--- a/tofu/provider.tf
+++ b/tofu/provider.tf
@@ -2,7 +2,10 @@
 # uses GitHub OIDC through this repo's app service principal.
 
 terraform {
-  backend "azurerm" {}
+  backend "azurerm" {
+    use_oidc         = true
+    use_azuread_auth = true
+  }
 }
 
 provider "azurerm" {

--- a/tofu/provider.tf
+++ b/tofu/provider.tf
@@ -1,0 +1,11 @@
+# Remote state in Azure Storage (backend config passed by CI). Authentication
+# uses GitHub OIDC through this repo's app service principal.
+
+terraform {
+  backend "azurerm" {}
+}
+
+provider "azurerm" {
+  features {}
+  use_oidc = true
+}

--- a/tofu/remote-state.tf
+++ b/tofu/remote-state.tf
@@ -1,0 +1,16 @@
+# References to shared infrastructure provisioned by infra-bootstrap. This app
+# owns its Entra registration, but writes public runtime config into the shared
+# Key Vault so External Secrets can project it into Kubernetes.
+
+locals {
+  infra = {
+    resource_group_name = "infra"
+  }
+}
+
+data "azuread_client_config" "current" {}
+
+data "azurerm_key_vault" "main" {
+  name                = var.key_vault_name
+  resource_group_name = local.infra.resource_group_name
+}

--- a/tofu/variables.tf
+++ b/tofu/variables.tf
@@ -1,0 +1,14 @@
+variable "hostnames" {
+  description = "Ambience hostnames that can complete the Microsoft login callback."
+  type        = list(string)
+  default = [
+    "ambience.romaine.life",
+    "ambience.dev.romaine.life",
+    "*.ambience.dev.romaine.life",
+  ]
+}
+
+variable "key_vault_name" {
+  type    = string
+  default = "romaine-kv"
+}


### PR DESCRIPTION
## Summary
- add Ambience-owned OpenTofu for the `ambience-oauth` Entra app and Key Vault client-id secret
- wire the Helm chart to sync `ambience-oauth-client-id` from Key Vault and enable Microsoft auth in prod
- replace the prod password prompt path with a Microsoft ID token flow that validates the token server-side before minting the existing control cookie

## Checks
- `/tmp/go/bin/go test ./cmd/ambience`
- `/tmp/go/bin/go test ./...`
- `tofu init -backend=false && tofu validate` from `tofu/`
- `tofu fmt -check -recursive`
- `helm lint chart/ambience -f chart/ambience/values-prod.yaml`
- `helm template ambience chart/ambience -f chart/ambience/values-prod.yaml`
- `git diff --check`

## Rollout note
Land nelsong6/infra-bootstrap#55 first so shared infra forgets the old OAuth resources before Ambience imports/owns them.