### PR TITLE
Make native Glimmung runner workspace writable

### DIFF
--- a/.github/runner/Dockerfile
+++ b/.github/runner/Dockerfile
@@ -46,6 +46,8 @@ RUN npm install -g @openai/codex \
     && rm -rf /root/.npm /opt/ambience-agent/.cache
 
 COPY scripts/glimmung-native /opt/ambience-native/scripts
-RUN chmod +x /opt/ambience-native/scripts/*.sh
+RUN chmod +x /opt/ambience-native/scripts/*.sh \
+    && mkdir -p /workspace \
+    && chown runner:runner /workspace
 
 USER runner


### PR DESCRIPTION
## Summary
- create and chown `/workspace` in the native runner image so the non-root `runner` user can clone Ambience during native jobs

## Checks
- `git diff --check`

Smoke context: fixes native run `01KQQT3DEC8E59JQ9601K7DBYG`, whose `env-prep` phase failed before clone with `/workspace` permission errors.