### PR TITLE
Use Basic auth for native runner git operations

### DIFF
--- a/mcp/ambience_preview/ops.py
+++ b/mcp/ambience_preview/ops.py
@@ -486,8 +486,9 @@ EOF
 
 git config --global user.name "ambience-agent[bot]"
 git config --global user.email "ambience-agent@romaine.life"
+GIT_AUTH_HEADER="Authorization: Basic $(printf 'x-access-token:%s' "${GH_TOKEN}" | base64 | tr -d '\n')"
 
-git -c "http.extraHeader=Authorization: Bearer ${GH_TOKEN}" \
+git -c "http.extraHeader=${GIT_AUTH_HEADER}" \
   clone "https://github.com/${REPO_SLUG}.git" /workspace/repo
 cd /workspace/repo
 git checkout -B "${BRANCH_NAME}"
@@ -546,10 +547,10 @@ ${close_line}"
 # commit didn't touch those files. Rebase replays the agent's single
 # commit on top of current main; if there's a real conflict we fail loudly
 # rather than ship a stale-base branch.
-git -c "http.extraHeader=Authorization: Bearer ${GH_TOKEN}" fetch origin main
+git -c "http.extraHeader=${GIT_AUTH_HEADER}" fetch origin main
 git rebase origin/main
 
-git -c "http.extraHeader=Authorization: Bearer ${GH_TOKEN}" push origin "HEAD:${BRANCH_NAME}"
+git -c "http.extraHeader=${GIT_AUTH_HEADER}" push origin "HEAD:${BRANCH_NAME}"
 
 # Stream the evidence dir as a base64-encoded tarball to stdout between
 # clear markers the workflow extracts via sed. We can't kubectl cp from

--- a/scripts/glimmung-native/agent-execute.sh
+++ b/scripts/glimmung-native/agent-execute.sh
@@ -209,10 +209,11 @@ write_verification() {
 }
 
 fetch_agent_branch() {
-  local token
+  local token auth_header
   token="$(native_github_token)"
+  auth_header="$(native_git_auth_header "$token")"
   git -C "$REPO_DIR" \
-    -c "http.extraHeader=Authorization: Bearer ${token}" \
+    -c "http.extraHeader=${auth_header}" \
     fetch origin "refs/heads/${BRANCH_NAME}:refs/remotes/origin/${BRANCH_NAME}"
   git -C "$REPO_DIR" checkout -B "$BRANCH_NAME" "origin/${BRANCH_NAME}"
 }
@@ -348,9 +349,10 @@ verify_result() {
 }
 
 push_branch() {
-  local token
+  local token auth_header
   token="$(native_github_token)"
-  if git -c "http.extraHeader=Authorization: Bearer ${token}" \
+  auth_header="$(native_git_auth_header "$token")"
+  if git -c "http.extraHeader=${auth_header}" \
       ls-remote --exit-code "https://github.com/${REPO_SLUG}.git" "refs/heads/${BRANCH_NAME}" >/dev/null; then
     kubectl label namespace "$NAMESPACE" "ambience.io/branch=${BRANCH_NAME//\//-}" --overwrite || true
     echo "branch ${BRANCH_NAME} is present"

--- a/scripts/glimmung-native/lib.sh
+++ b/scripts/glimmung-native/lib.sh
@@ -237,14 +237,22 @@ native_github_token() {
     | jq -r '.token'
 }
 
+native_git_auth_header() {
+  local token="$1"
+  local encoded
+  encoded="$(printf 'x-access-token:%s' "$token" | base64 | tr -d '\n')"
+  printf 'Authorization: Basic %s' "$encoded"
+}
+
 native_clone_repo() {
   local repo_slug="$1"
   local repo_dir="$2"
   local base_ref="${3:-main}"
   local branch_name="${4:-}"
-  local token
+  local token auth_header
 
   token="$(native_github_token)"
+  auth_header="$(native_git_auth_header "$token")"
   mkdir -p "$(dirname "$repo_dir")"
   if [ ! -d "${repo_dir}/.git" ]; then
     git init "$repo_dir" >/dev/null
@@ -253,7 +261,7 @@ native_clone_repo() {
 
   git -C "$repo_dir" remote set-url origin "https://github.com/${repo_slug}.git"
   git -C "$repo_dir" \
-    -c "http.extraHeader=Authorization: Bearer ${token}" \
+    -c "http.extraHeader=${auth_header}" \
     fetch --force origin "+refs/heads/*:refs/remotes/origin/*"
   git -C "$repo_dir" config user.name "ambience-agent[bot]"
   git -C "$repo_dir" config user.email "ambience-agent@romaine.life"
@@ -269,10 +277,11 @@ native_push_branch() {
   local repo_slug="$1"
   local repo_dir="$2"
   local branch_name="$3"
-  local token
+  local token auth_header
   token="$(native_github_token)"
+  auth_header="$(native_git_auth_header "$token")"
   git -C "$repo_dir" remote set-url origin "https://github.com/${repo_slug}.git"
   git -C "$repo_dir" \
-    -c "http.extraHeader=Authorization: Bearer ${token}" \
+    -c "http.extraHeader=${auth_header}" \
     push origin "HEAD:${branch_name}"
 }


### PR DESCRIPTION
## Summary
- switch native runner Git operations from Bearer headers to GitHub-compatible Basic auth headers
- apply the same auth header to the in-cluster agent job template for clone/fetch/push
- keep credentials out of Git remote URLs

## Checks
- `bash -n scripts/glimmung-native/*.sh`
- `PYTHONPATH=mcp python3 -m py_compile mcp/ambience_preview/ops.py`
- `git diff --check`
- verified `git ls-remote` succeeds with the Basic auth header

Smoke context: fixes native run `01KQQTT21NZ63GCVA1J14S49E5`, whose `env-prep` phase got past image startup but failed on GitHub auth during clone.