### PR TITLE
Import existing Ambience OAuth resources

### DIFF
--- a/tofu/imports.tf
+++ b/tofu/imports.tf
@@ -1,0 +1,23 @@
+# Adopt the existing user-facing OAuth resources that were originally
+# provisioned by infra-bootstrap, preserving the published client id.
+
+import {
+  to = azuread_application.oauth_registration
+  id = "/applications/0f8417f4-9ba1-4116-94bd-ae1a18b8f356"
+}
+
+import {
+  to = azuread_service_principal.oauth_service_principal
+  id = "/servicePrincipals/8a400255-bb60-4320-bfa1-b949c3257b08"
+}
+
+import {
+  to = azurerm_key_vault_secret.oauth_client_id
+  id = "https://romaine-kv.vault.azure.net/secrets/ambience-oauth-client-id/dd2ea8c6150748eaadda53389fac360b"
+}
+
+# The first Ambience-owned apply ran before these imports existed and created
+# duplicate app/SP objects at the old azuread_application.oauth and
+# azuread_service_principal.oauth addresses. Those addresses are intentionally
+# absent from configuration now, so the next apply destroys only that partial
+# duplicate while importing the original registration above.

--- a/tofu/oauth.tf
+++ b/tofu/oauth.tf
@@ -4,7 +4,7 @@
 # browser control sign-in, while the public client id is published to Key Vault
 # for the chart to project into the authority pod.
 
-resource "azuread_application" "oauth" {
+resource "azuread_application" "oauth_registration" {
   display_name     = "ambience-oauth"
   sign_in_audience = "AzureADMyOrg"
 
@@ -38,12 +38,12 @@ resource "azuread_application" "oauth" {
   }
 }
 
-resource "azuread_service_principal" "oauth" {
-  client_id = azuread_application.oauth.client_id
+resource "azuread_service_principal" "oauth_service_principal" {
+  client_id = azuread_application.oauth_registration.client_id
 }
 
 resource "azurerm_key_vault_secret" "oauth_client_id" {
   name         = "ambience-oauth-client-id"
-  value        = azuread_application.oauth.client_id
+  value        = azuread_application.oauth_registration.client_id
   key_vault_id = data.azurerm_key_vault.main.id
 }


### PR DESCRIPTION
## Summary
- import the existing infra-bootstrap-created `ambience-oauth` app, service principal, and Key Vault client-id secret into Ambience tofu state
- move the managed OAuth resource addresses so the partial duplicate app/SP from the failed first apply can be destroyed normally
- preserve the currently published Microsoft client id

## Checks
- `tofu fmt -check -recursive`
- `tofu init -backend=false`
- `tofu validate`
- `git diff --check`