### PR TITLE
Clean up Ambience OAuth tofu state handoff

### DIFF
--- a/tofu/imports.tf
+++ b/tofu/imports.tf
@@ -19,5 +19,13 @@ import {
 # The first Ambience-owned apply ran before these imports existed and created
 # duplicate app/SP objects at the old azuread_application.oauth and
 # azuread_service_principal.oauth addresses. Those addresses are intentionally
-# absent from configuration now, so the next apply destroys only that partial
-# duplicate while importing the original registration above.
+# forgotten rather than destroyed because Ambience's app-owned CI identity
+# should not need directory-wide privileges to clean up bootstrap fallout.
+
+removed {
+  from = azuread_application.oauth
+}
+
+removed {
+  from = azuread_service_principal.oauth
+}

--- a/tofu/oauth.tf
+++ b/tofu/oauth.tf
@@ -8,8 +8,6 @@ resource "azuread_application" "oauth_registration" {
   display_name     = "ambience-oauth"
   sign_in_audience = "AzureADMyOrg"
 
-  owners = [data.azuread_client_config.current.object_id]
-
   api {
     requested_access_token_version = 2
   }

--- a/tofu/oauth.tf
+++ b/tofu/oauth.tf
@@ -8,6 +8,10 @@ resource "azuread_application" "oauth_registration" {
   display_name     = "ambience-oauth"
   sign_in_audience = "AzureADMyOrg"
 
+  lifecycle {
+    ignore_changes = [owners]
+  }
+
   api {
     requested_access_token_version = 2
   }


### PR DESCRIPTION
## Summary
- stop Ambience tofu from trying to mutate the existing OAuth app owner during the state handoff
- forget the duplicate OAuth app/SP state addresses created by the failed first Ambience apply instead of destroying the live duplicate objects

## Validation
- `tofu fmt -check -recursive`
- `tofu init -backend=false`
- `tofu validate`
- `git diff --check`