### PR TITLE
Use precreated namespace for native validation deploys

### DIFF
--- a/mcp/ambience_preview/cli.py
+++ b/mcp/ambience_preview/cli.py
@@ -24,6 +24,13 @@ def build_parser() -> argparse.ArgumentParser:
         default="",
         help="Optional public hostname for the validation env (attached to the wildcard listener).",
     )
+    deploy_validation.add_argument(
+        "--no-create-namespace",
+        action="store_false",
+        default=True,
+        dest="create_namespace",
+        help="Do not pass Helm --create-namespace; use when the namespace is pre-created.",
+    )
 
     screenshot = subparsers.add_parser("capture-validation-screenshot")
     screenshot.add_argument("--page-path", required=True)
@@ -106,6 +113,7 @@ def main() -> int:
                     image=args.image,
                     release=release,
                     public_host=public_host,
+                    create_namespace=args.create_namespace,
                 )
             )
         elif args.command == "capture-validation-screenshot":

--- a/mcp/ambience_preview/ops.py
+++ b/mcp/ambience_preview/ops.py
@@ -147,6 +147,7 @@ def deploy_preview(
     image: str,
     release: str = DEFAULT_RELEASE_NAME,
     public_host: str | None = None,
+    create_namespace: bool = True,
     tls_secret_name: str | None = None,
     timeout: str = "10m",
     rollout_timeout: str = "180s",
@@ -160,11 +161,12 @@ def deploy_preview(
         str(chart_path()),
         "--namespace",
         namespace,
-        "--create-namespace",
         "--wait",
         "--timeout",
         timeout,
     ]
+    if create_namespace:
+        command.append("--create-namespace")
 
     string_values = {
         "image.repository": image_repository,

--- a/scripts/glimmung-native/env-prep.sh
+++ b/scripts/glimmung-native/env-prep.sh
@@ -65,7 +65,8 @@ deploy_validation_env() {
       --namespace "$NAMESPACE" \
       --image "$image" \
       --release "$RELEASE_NAME" \
-      --public-host "$VALIDATION_HOST"
+      --public-host "$VALIDATION_HOST" \
+      --no-create-namespace
   )
 }
 


### PR DESCRIPTION
## Summary
- make `deploy-validation-preview` namespace creation optional while preserving the default behavior
- have the Glimmung native env-prep script skip Helm `--create-namespace` because Glimmung already scaffolds the validation namespace

## Checks
- `bash -n scripts/glimmung-native/*.sh`
- `PYTHONPATH=mcp python3 -m py_compile mcp/ambience_preview/cli.py mcp/ambience_preview/ops.py`
- `PYTHONPATH=mcp python3 -m ambience_preview.cli deploy-validation-preview --help`
- `git diff --check`

Smoke context: fixes native run `01KQQW5SRJ60239W7WBP26RAK9`, whose validation image built and verified but Helm failed because the runner cannot and should not create namespaces at cluster scope.