### PR TITLE
Create fresh Ambience-owned OAuth app

### DIFF
--- a/tofu/imports.tf
+++ b/tofu/imports.tf
@@ -1,31 +1,12 @@
-# Adopt the existing user-facing OAuth resources that were originally
-# provisioned by infra-bootstrap, preserving the published client id.
-
-import {
-  to = azuread_application.oauth_registration
-  id = "/applications/0f8417f4-9ba1-4116-94bd-ae1a18b8f356"
-}
-
-import {
-  to = azuread_service_principal.oauth_service_principal
-  id = "/servicePrincipals/8a400255-bb60-4320-bfa1-b949c3257b08"
-}
-
-import {
-  to = azurerm_key_vault_secret.oauth_client_id
-  id = "https://romaine-kv.vault.azure.net/secrets/ambience-oauth-client-id/dd2ea8c6150748eaadda53389fac360b"
-}
-
-# The first Ambience-owned apply ran before these imports existed and created
-# duplicate app/SP objects at the old azuread_application.oauth and
-# azuread_service_principal.oauth addresses. Those addresses are intentionally
-# forgotten rather than destroyed because Ambience's app-owned CI identity
-# should not need directory-wide privileges to clean up bootstrap fallout.
+# The previous migration imported the pre-existing bootstrap-created
+# ambience-oauth app/SP. Ambience now creates a fresh app-owned registration
+# instead, so forget the adopted Entra objects without requiring Ambience CI to
+# mutate or delete bootstrap-created app objects.
 
 removed {
-  from = azuread_application.oauth
+  from = azuread_application.oauth_registration
 }
 
 removed {
-  from = azuread_service_principal.oauth
+  from = azuread_service_principal.oauth_service_principal
 }

--- a/tofu/oauth.tf
+++ b/tofu/oauth.tf
@@ -4,13 +4,11 @@
 # browser control sign-in, while the public client id is published to Key Vault
 # for the chart to project into the authority pod.
 
-resource "azuread_application" "oauth_registration" {
+resource "azuread_application" "oauth" {
   display_name     = "ambience-oauth"
   sign_in_audience = "AzureADMyOrg"
 
-  lifecycle {
-    ignore_changes = [owners]
-  }
+  owners = [data.azuread_client_config.current.object_id]
 
   api {
     requested_access_token_version = 2
@@ -40,12 +38,12 @@ resource "azuread_application" "oauth_registration" {
   }
 }
 
-resource "azuread_service_principal" "oauth_service_principal" {
-  client_id = azuread_application.oauth_registration.client_id
+resource "azuread_service_principal" "oauth" {
+  client_id = azuread_application.oauth.client_id
 }
 
 resource "azurerm_key_vault_secret" "oauth_client_id" {
   name         = "ambience-oauth-client-id"
-  value        = azuread_application.oauth_registration.client_id
+  value        = azuread_application.oauth.client_id
   key_vault_id = data.azurerm_key_vault.main.id
 }


### PR DESCRIPTION
## Summary
- stop adopting the old bootstrap-created `ambience-oauth` app/SP
- create a fresh Ambience-owned OAuth app registration from Ambience tofu
- update the existing Key Vault client-id secret to point Ambience at the new app

## Validation
- `tofu fmt -check -recursive`
- `tofu init -backend=false`
- `tofu validate`
- `git diff --check`