### PR TITLE
Pass Claude CA namespace through native runner

### DIFF
--- a/scripts/glimmung-native/agent-execute.sh
+++ b/scripts/glimmung-native/agent-execute.sh
@@ -17,6 +17,7 @@ REPO_SLUG="${AMBIENCE_REPO_SLUG:-nelsong6/ambience}"
 REPO_DIR="${AMBIENCE_REPO_DIR:-/workspace/ambience}"
 AGENT_CONTAINER_TAG="${AGENT_CONTAINER_TAG:-latest}"
 CLAUDE_NAMESPACE="${GLIMMUNG_INPUT_CLAUDE_NAMESPACE:-tank-operator}"
+CLAUDE_CA_NAMESPACE="${GLIMMUNG_INPUT_CLAUDE_CA_NAMESPACE:-${CLAUDE_CA_NAMESPACE:-tank-operator-sessions}}"
 
 VALIDATION_URL="${GLIMMUNG_INPUT_VALIDATION_URL}"
 NAMESPACE="${GLIMMUNG_INPUT_NAMESPACE}"
@@ -53,9 +54,10 @@ install_preview_package() {
 }
 
 copy_claude_ca() {
-  kubectl -n "$CLAUDE_NAMESPACE" get configmap claude-oauth-ca -o json \
+  kubectl -n "$CLAUDE_CA_NAMESPACE" get configmap claude-oauth-ca -o json \
     | NAMESPACE="$NAMESPACE" jq '
         del(
+          .metadata.annotations,
           .metadata.uid,
           .metadata.resourceVersion,
           .metadata.generation,

--- a/scripts/glimmung-native/env-prep.sh
+++ b/scripts/glimmung-native/env-prep.sh
@@ -13,6 +13,7 @@ REPO_SLUG="${AMBIENCE_REPO_SLUG:-nelsong6/ambience}"
 REPO_DIR="${AMBIENCE_REPO_DIR:-/workspace/ambience}"
 RELEASE_NAME="${AMBIENCE_VALIDATION_RELEASE:-ambience-agent}"
 CLAUDE_NAMESPACE="${CLAUDE_NAMESPACE:-tank-operator}"
+CLAUDE_CA_NAMESPACE="${CLAUDE_CA_NAMESPACE:-tank-operator-sessions}"
 
 NAMESPACE="${GLIMMUNG_VALIDATION_NAMESPACE}"
 VALIDATION_HOST="${NAMESPACE}.ambience.dev.romaine.life"
@@ -83,11 +84,13 @@ emit_env_outputs() {
     --arg namespace "$NAMESPACE" \
     --arg image_tag "$IMAGE_TAG" \
     --arg claude_namespace "$CLAUDE_NAMESPACE" \
+    --arg claude_ca_namespace "$CLAUDE_CA_NAMESPACE" \
     '{
       validation_url: $validation_url,
       namespace: $namespace,
       image_tag: $image_tag,
-      claude_namespace: $claude_namespace
+      claude_namespace: $claude_namespace,
+      claude_ca_namespace: $claude_ca_namespace
     }' >/tmp/ambience-env-outputs.json
   cat /tmp/ambience-env-outputs.json
 }

--- a/scripts/glimmung-native/register-workflow.sh
+++ b/scripts/glimmung-native/register-workflow.sh
@@ -58,7 +58,13 @@ workflow_payload="$(
         {
           name: "env-prep",
           kind: "k8s_job",
-          outputs: ["validation_url", "namespace", "image_tag", "claude_namespace"],
+          outputs: [
+            "validation_url",
+            "namespace",
+            "image_tag",
+            "claude_namespace",
+            "claude_ca_namespace"
+          ],
           jobs: [
             {
               id: "env-prep",
@@ -87,7 +93,8 @@ workflow_payload="$(
             validation_url: "${{ phases.env-prep.outputs.validation_url }}",
             namespace: "${{ phases.env-prep.outputs.namespace }}",
             image_tag: "${{ phases.env-prep.outputs.image_tag }}",
-            claude_namespace: "${{ phases.env-prep.outputs.claude_namespace }}"
+            claude_namespace: "${{ phases.env-prep.outputs.claude_namespace }}",
+            claude_ca_namespace: "${{ phases.env-prep.outputs.claude_ca_namespace }}"
           },
           verify: true,
           recycle_policy: {


### PR DESCRIPTION
## Summary
- Emit `claude_ca_namespace` from native env-prep alongside the Claude proxy namespace
- Pass that namespace into agent-execute so Glimmung grants RBAC for the CA ConfigMap source namespace
- Copy `claude-oauth-ca` from the CA namespace while still reading the proxy Service from `tank-operator`

## Tests
- `bash -n scripts/glimmung-native/*.sh`
- `AMBIENCE_NATIVE_RUNNER_IMAGE=example GLIMMUNG_REGISTER_DRY_RUN=1 scripts/glimmung-native/register-workflow.sh | jq -e '.phases[0].outputs | index("claude_ca_namespace")'`
- `git diff --check`