### PR TITLE
Restore agent state for native step resume

### DIFF
--- a/scripts/glimmung-native/agent-execute.sh
+++ b/scripts/glimmung-native/agent-execute.sh
@@ -119,7 +119,31 @@ prepare_agent_context() {
     --dry-run=client -o yaml | kubectl apply -f -
 }
 
+ensure_repo_for_resume() {
+  if [ ! -d "${REPO_DIR}/.git" ]; then
+    clone_repo
+  fi
+}
+
+ensure_agent_context_for_resume() {
+  if [ -z "${PROXY_IP:-}" ]; then
+    PROXY_IP="$(kubectl -n "$CLAUDE_NAMESPACE" get svc claude-api-proxy -o jsonpath='{.spec.clusterIP}')"
+    if [ -z "$PROXY_IP" ]; then
+      echo "claude-api-proxy Service not found in ${CLAUDE_NAMESPACE}" >&2
+      return 1
+    fi
+    export PROXY_IP
+  fi
+  if ! kubectl -n "$NAMESPACE" get configmap agent-config >/dev/null 2>&1 \
+      || ! kubectl -n "$NAMESPACE" get secret agent-github-token >/dev/null 2>&1; then
+    ensure_repo_for_resume
+    prepare_agent_context
+  fi
+}
+
 run_agent() {
+  ensure_repo_for_resume
+  ensure_agent_context_for_resume
   (
     cd "$REPO_DIR"
     args=(


### PR DESCRIPTION
## Summary
- make `run-agent` restore the repo checkout when resuming past `clone-repo`
- restore `PROXY_IP` and agent config/token when resuming past `prepare-agent-context`
- keep normal full-run behavior unchanged

## Verification
- `bash -n scripts/glimmung-native/agent-execute.sh scripts/glimmung-native/lib.sh scripts/glimmung-native/env-prep.sh`
- live run `01KQRKNNV32NES7XZEFRYAGBED` showed the prior failure mode after step resume: skipped setup left `/workspace/ambience` and `PROXY_IP` unavailable before `run-agent`.