### PR TITLE
feat: provision ambience-identity + Cosmos database (stage 0 of PVC→Cosmos)

### DIFF
--- a/tofu/db.tf
+++ b/tofu/db.tf
@@ -1,0 +1,33 @@
+# Cosmos DB NoSQL database (per-app; the account itself is provisioned by
+# infra-bootstrap as a shared resource). Mirrors glimmung/tofu/db.tf and the
+# convention noted in infra-bootstrap/tofu/cosmos-serverless.tf — narrow
+# per-app database scope, not shared account scope.
+#
+# Single container holding the shared atmosphere snapshot. Partition key is
+# `/id`; the runtime writes one document with id="shared". A single doc per
+# partition keeps point-reads at 1 RU and point-writes at the document size's
+# RU cost (~10 for the current persistedAtmosphere shape).
+
+resource "azurerm_cosmosdb_sql_database" "ambience" {
+  name                = "ambience"
+  resource_group_name = local.infra.resource_group_name
+  account_name        = data.azurerm_cosmosdb_account.infra.name
+  lifecycle {
+    ignore_changes = [throughput]
+  }
+}
+
+resource "azurerm_cosmosdb_sql_container" "atmosphere" {
+  name                = "atmosphere"
+  resource_group_name = local.infra.resource_group_name
+  account_name        = data.azurerm_cosmosdb_account.infra.name
+  database_name       = azurerm_cosmosdb_sql_database.ambience.name
+  partition_key_paths = ["/id"]
+
+  indexing_policy {
+    indexing_mode = "consistent"
+    included_path {
+      path = "/*"
+    }
+  }
+}

--- a/tofu/identity.tf
+++ b/tofu/identity.tf
@@ -1,0 +1,49 @@
+# Workload identity for ambience.
+#
+# Mirrors the per-app convention established by glimmung/tofu/identity.tf and
+# documented in infra-bootstrap/tofu/cosmos-serverless.tf: each app owns a
+# user-assigned identity with Cosmos data-plane scope narrowed to its own
+# database, not the account. A pod compromise in this app cannot reach any
+# other app's data on the shared infra-cosmos-serverless account.
+
+resource "azurerm_resource_group" "ambience" {
+  name     = "ambience"
+  location = data.azurerm_resource_group.infra.location
+}
+
+resource "azurerm_user_assigned_identity" "ambience" {
+  name                = "ambience-identity"
+  resource_group_name = azurerm_resource_group.ambience.name
+  location            = azurerm_resource_group.ambience.location
+}
+
+# Cosmos DB Built-in Data Contributor (00000000-0000-0000-0000-000000000002)
+# scoped to the ambience database, not the account. `scope` uses the Cosmos
+# data-plane path scheme (`/dbs/<name>`) — the ARM resource ID's
+# `/sqlDatabases/<name>` form is rejected by the Cosmos service.
+resource "azurerm_cosmosdb_sql_role_assignment" "ambience_cosmos" {
+  resource_group_name = local.infra.resource_group_name
+  account_name        = data.azurerm_cosmosdb_account.infra.name
+  role_definition_id  = "${data.azurerm_cosmosdb_account.infra.id}/sqlRoleDefinitions/00000000-0000-0000-0000-000000000002"
+  principal_id        = azurerm_user_assigned_identity.ambience.principal_id
+  scope               = "${data.azurerm_cosmosdb_account.infra.id}/dbs/${azurerm_cosmosdb_sql_database.ambience.name}"
+}
+
+# Federated to the default ServiceAccount in the prod ambience namespace.
+# The authority StatefulSet runs under `default` today; the chart will add
+# the workload-identity annotations + pod labels in stage 1. Preview slots
+# in ambience-slot-* namespaces do not get persistence, so their default
+# SAs are intentionally NOT federated here.
+resource "azurerm_federated_identity_credential" "ambience" {
+  name                = "aks-ambience"
+  resource_group_name = azurerm_resource_group.ambience.name
+  parent_id           = azurerm_user_assigned_identity.ambience.id
+  audience            = ["api://AzureADTokenExchange"]
+  issuer              = local.aks_oidc_issuer_url
+  subject             = "system:serviceaccount:ambience:default"
+}
+
+output "ambience_identity_client_id" {
+  value       = azurerm_user_assigned_identity.ambience.client_id
+  description = "client_id of ambience-identity. Pin into chart/ambience/values.yaml as authority.cosmos.serviceAccountClientId."
+}

--- a/tofu/remote-state.tf
+++ b/tofu/remote-state.tf
@@ -10,7 +10,32 @@ locals {
 
 data "azuread_client_config" "current" {}
 
+data "azurerm_resource_group" "infra" {
+  name = local.infra.resource_group_name
+}
+
 data "azurerm_key_vault" "main" {
   name                = var.key_vault_name
   resource_group_name = local.infra.resource_group_name
+}
+
+data "azurerm_cosmosdb_account" "infra" {
+  name                = "infra-cosmos-serverless"
+  resource_group_name = local.infra.resource_group_name
+}
+
+data "terraform_remote_state" "infra_bootstrap" {
+  backend = "azurerm"
+
+  config = {
+    resource_group_name  = "infra"
+    storage_account_name = "nelsontofu"
+    container_name       = "tfstate"
+    key                  = "infra-bootstrap.tfstate"
+    use_oidc             = true
+  }
+}
+
+locals {
+  aks_oidc_issuer_url = data.terraform_remote_state.infra_bootstrap.outputs.aks_oidc_issuer_url
 }


### PR DESCRIPTION
## Summary

Stage 0 of migrating ambience's authority persistence off the 1Gi PVC onto a per-app Cosmos DB database. This PR provisions infrastructure only — no chart or code changes. The PVC keeps working unchanged until stage 1.

- Adds `ambience-identity` (user-assigned managed identity) federated to `system:serviceaccount:ambience:default`.
- Cosmos data-plane role assignment is **scoped to `dbs/ambience`**, not the account — pod compromise cannot reach any other app's data on `infra-cosmos-serverless`.
- New `ambience` Cosmos DB + `atmosphere` container, partition key `/id`. Authority will write one doc with `id="shared"` once stage 1 lands.

Mirrors the per-app convention from [glimmung/tofu/identity.tf](https://github.com/nelsong6/glimmung) and the comment in `infra-bootstrap/tofu/cosmos-serverless.tf`.

## What's NOT in this PR (and why)

Per `migration-policy.md`, the file-based `fileStore` and PVC stay live until stage 1 deletes them end-to-end. No compatibility shim, no dual-write transition. The cutover will be cold — old PVC data is dropped; ambience regenerates scenes on first boot under stage-1 code.

## Stage sequence

- **Stage 0 (this PR):** tofu only. Safe alone — identity has no consumers, DB has no clients.
- **Stage 1 (next PR):** atomic swap. Go code adds `cosmosStore`, deletes `fileStore` + `AMBIENCE_PERSIST_PATH`. Chart deletes `pvc.yaml` + storage values, adds workload-identity annotations + Cosmos env vars. Single PR because old/new chart can't coexist.
- **Stage 2 (post-rollout):** `kubectl delete pvc ambience-state -n ambience` (Helm leaves orphan when a template is removed from the chart).

## Apply-time risk to watch

The OIDC SP that runs this repo's tofu workflow needs `Microsoft.DocumentDB/databaseAccounts/sqlRoleAssignments/write` on the `infra-cosmos-serverless` account for the role-assignment step. If apply fails on `azurerm_cosmosdb_sql_role_assignment.ambience_cosmos`, the fix is upstream (grant Cosmos DB Operator at the account scope in infra-bootstrap).

## After merge

Grab the value of the `ambience_identity_client_id` output (visible in the Infrastructure workflow log after apply) and pass it into the stage 1 PR.

## Test plan

- [ ] `tofu plan` on the PR shows the expected adds: 1 RG, 1 user-assigned identity, 1 federated cred, 1 Cosmos role assignment, 1 SQL database, 1 SQL container.
- [ ] `tofu apply` on merge to main succeeds end-to-end.
- [ ] `az cosmosdb sql database list --account-name infra-cosmos-serverless -g infra` includes `ambience`.
- [ ] Existing prod ambience pod keeps writing to the PVC unaffected (no chart change in this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)