### PR TITLE
fix: hand slot fed-cred management to Glimmung's reconciler

### DIFF
--- a/tofu/identity.tf
+++ b/tofu/identity.tf
@@ -44,17 +44,6 @@ resource "azurerm_federated_identity_credential" "ambience" {
   subject             = "system:serviceaccount:ambience:default"
 }
 
-# The slot fed creds (aks-ambience-slot-1..5) were briefly managed here
-# before ambience's project metadata declared native_standby_workload_identity
-# in Glimmung. Glimmung's reconciler now owns them. Hand state ownership
-# over without destroying the Azure resources — Glimmung's next reconcile
-# adopts them by template match (same identity, name, subject, audiences).
-removed {
-  from = azurerm_federated_identity_credential.ambience_slot
-  lifecycle {
-    destroy = false
-  }
-}
 
 output "ambience_identity_client_id" {
   value       = azurerm_user_assigned_identity.ambience.client_id

--- a/tofu/identity.tf
+++ b/tofu/identity.tf
@@ -30,10 +30,11 @@ resource "azurerm_cosmosdb_sql_role_assignment" "ambience_cosmos" {
 }
 
 # Federated to the default ServiceAccount in the prod ambience namespace.
-# The authority StatefulSet runs under `default` today; the chart will add
-# the workload-identity annotations + pod labels in stage 1. Preview slots
-# in ambience-slot-* namespaces do not get persistence, so their default
-# SAs are intentionally NOT federated here.
+# Per-slot fed creds (system:serviceaccount:ambience-slot-N:default) are
+# NOT declared here — Glimmung's NativeWorkloadIdentityService reconciles
+# them dynamically from the ambience project's `native_standby_workload_identity`
+# metadata, matched to slot count and slot prefix. See
+# glimmung/internal/server/native_workload_identities.go.
 resource "azurerm_federated_identity_credential" "ambience" {
   name                = "aks-ambience"
   resource_group_name = azurerm_resource_group.ambience.name
@@ -43,21 +44,16 @@ resource "azurerm_federated_identity_credential" "ambience" {
   subject             = "system:serviceaccount:ambience:default"
 }
 
-# Per-slot federated credentials so any preview slot can opt into Cosmos
-# persistence by setting authority.cosmos.endpoint + serviceAccountClientId
-# at deploy time. All slots share the same ambience-identity UAI and the
-# same dbs/ambience role assignment; isolation between slot writes and the
-# prod `shared` document is via per-slot documentId (e.g. "slot-1"), not
-# via per-slot identity. Bump preview_slot_count when Glimmung grows the
-# pool and re-apply.
-resource "azurerm_federated_identity_credential" "ambience_slot" {
-  for_each            = toset([for i in range(1, var.preview_slot_count + 1) : tostring(i)])
-  name                = "aks-ambience-slot-${each.key}"
-  resource_group_name = azurerm_resource_group.ambience.name
-  parent_id           = azurerm_user_assigned_identity.ambience.id
-  audience            = ["api://AzureADTokenExchange"]
-  issuer              = local.aks_oidc_issuer_url
-  subject             = "system:serviceaccount:ambience-slot-${each.key}:default"
+# The slot fed creds (aks-ambience-slot-1..5) were briefly managed here
+# before ambience's project metadata declared native_standby_workload_identity
+# in Glimmung. Glimmung's reconciler now owns them. Hand state ownership
+# over without destroying the Azure resources — Glimmung's next reconcile
+# adopts them by template match (same identity, name, subject, audiences).
+removed {
+  from = azurerm_federated_identity_credential.ambience_slot
+  lifecycle {
+    destroy = false
+  }
 }
 
 output "ambience_identity_client_id" {

--- a/tofu/variables.tf
+++ b/tofu/variables.tf
@@ -12,9 +12,3 @@ variable "key_vault_name" {
   type    = string
   default = "romaine-kv"
 }
-
-variable "preview_slot_count" {
-  description = "Number of Glimmung-managed ambience preview slot namespaces (ambience-slot-1..N) to federate to ambience-identity. Match Glimmung's slot pool size for this project; raise this and re-apply when the pool grows."
-  type        = number
-  default     = 5
-}


### PR DESCRIPTION
## Summary

[apps#244](https://github.com/nelsong6/ambience/pull/244) hardcoded preview-slot federated identity credentials in \`ambience/tofu/identity.tf\` via \`for_each\`. That worked, but landed in the **wrong layer** — Glimmung's \`NativeWorkloadIdentityService\` is the established pattern for per-slot workload-identity reconciliation (tank-operator uses it; reconciler at [glimmung/internal/server/native_workload_identities.go](https://github.com/nelsong6/glimmung/blob/main/internal/server/native_workload_identities.go)). This PR moves ownership over without disturbing the credentials in Azure.

## What I did out-of-band

Before opening this PR, I:

1. **POSTed updated ambience project metadata to Glimmung** adding \`native_standby_workload_identity\` with a credential template:

   \`\`\`yaml
   identity_name: ambience-identity
   credential_name: aks-{slot_name}
   subject: system:serviceaccount:{slot_name}:default
   resource_group: ambience
   subscription: aee0cbd2-8074-4001-b610-0f8edb4eaa3c
   \`\`\`

2. **PATCHed \`/v1/projects/ambience/test-environments/count\`** with count=5 (unchanged) to trigger \`ReconcileNativeWorkloadIdentities\`. Result:

   \`\`\`json
   "native_standby_workload_identity_status": {
     "state": "ok",
     "desired_count": 5,
     "managed_credentials": [ /* aks-ambience-slot-1..5, same identity/subject/audiences as tofu */ ]
   }
   \`\`\`

   Glimmung adopted the 5 existing fed creds by template match — zero creations, zero deletions in Azure.

3. **Verified Azure** via \`az identity federated-credential list --identity-name ambience-identity\`: all 6 creds present (prod + 5 slots).

## What this PR does

- \`tofu/identity.tf\`: delete the \`azurerm_federated_identity_credential.ambience_slot\` \`for_each\` block; add a \`removed { ... lifecycle { destroy = false } }\` block so tofu drops state ownership without destroying. Glimmung continues to own the creds going forward.
- \`tofu/variables.tf\`: delete \`preview_slot_count\`. Slot count now comes from \`native_standby_dns.count\` in Glimmung project metadata; bumping the pool is a Glimmung config change, not a tofu commit.

The prod fed cred (\`aks-ambience\` → \`system:serviceaccount:ambience:default\`) stays in tofu — it's not a slot cred and isn't matched by Glimmung's template.

## Test plan

- [ ] \`tofu plan\` shows \`Plan: 0 to add, 0 to change, 0 to destroy.\` along with 5 forget-from-state entries (one per slot index).
- [ ] After apply: \`az identity federated-credential list --identity-name ambience-identity -g ambience\` still returns 6 creds.
- [ ] If slot pool ever grows, only the Glimmung project metadata changes (count or via PATCH endpoint); tofu stays inert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)