### PR TITLE
Disable ambience-authority PDB; gate per-component

### DIFF
--- a/chart/ambience/templates/poddisruptionbudgets.yaml
+++ b/chart/ambience/templates/poddisruptionbudgets.yaml
@@ -1,4 +1,18 @@
-{{- if and .Values.pdb.enabled (not .Values.testEnv.enabled) }}
+{{- /*
+PDBs are split per-component so each can be toggled independently.
+A PDB on a single-replica StatefulSet (authority) makes voluntary
+disruption impossible — the eviction API refuses to evict the only
+pod under a minAvailable:1 constraint, which blocks every AKS node
+drain until someone manually intervenes. The right semantic for a
+1-replica workload is either no PDB (accept brief disruption during
+maintenance) or maxUnavailable:1; pdb.authority.enabled defaults to
+false until authority is HA.
+
+testEnv mode skips both PDBs (test slots don't need disruption
+protection and the singleton replicas would cause the same eviction
+deadlock during cluster maintenance).
+*/}}
+{{- if and .Values.pdb.enabled .Values.pdb.authority.enabled (not .Values.testEnv.enabled) }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
@@ -12,6 +26,8 @@ spec:
     matchLabels:
       {{- include "ambience.authoritySelectorLabels" . | nindent 6 }}
 ---
+{{- end }}
+{{- if and .Values.pdb.enabled .Values.pdb.edge.enabled (not .Values.testEnv.enabled) }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:

--- a/chart/ambience/values.yaml
+++ b/chart/ambience/values.yaml
@@ -177,9 +177,16 @@ authority:
 
 pdb:
   enabled: true
+  # authority is a single-replica StatefulSet; a PDB on it blocks every
+  # AKS node drain (the eviction API can't satisfy minAvailable:1 with
+  # only one pod total, so kubelet eviction returns 429 forever). Until
+  # authority is HA, keep this off and accept the brief unavailability
+  # during planned cluster maintenance.
   authority:
+    enabled: false
     minAvailable: 1
   edge:
+    enabled: true
     minAvailable: 1
 
 certificate:


### PR DESCRIPTION
## Summary

- Splits the PDB template into per-component blocks (`pdb.authority.enabled`, `pdb.edge.enabled`)
- Defaults `pdb.authority.enabled=false` — `authority` is a single-replica StatefulSet, so `minAvailable: 1` on it is unsatisfiable during eviction
- `edge` is unchanged (2 replicas, PDB still renders)

## Why

The authority PDB was blocking AKS node drains. Sequence:
1. AKS auto-upgrade kicked off (the cluster has `automatic_upgrade_channel = "patch"`)
2. Surge node joined the `system` pool
3. AKS tried to drain the existing nodes
4. Eviction deadlocked on `ambience-authority` PDB (1 pod, `minAvailable: 1`, can't be evicted without violating budget)
5. Agent pool marked `Failed`
6. Surge node cordoned and abandoned in the cluster

Same problem exists for any single-replica workload with a PDB. Long-term answer is HA for authority; this is the short-term unblock.

## Test plan

- [x] `helm template ambience chart/ambience` — only `ambience-edge` PDB renders
- [x] `helm template ambience chart/ambience --set pdb.authority.enabled=true` — both render (escape hatch works)
- [x] `helm template ambience chart/ambience --set testEnv.enabled=true` — neither renders (existing behavior preserved)
- [ ] ArgoCD reconciles and prunes `ambience-authority` PDB from cluster after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)